### PR TITLE
(Fix)[Ingest] Added FTP passive switch for connection to the server.

### DIFF
--- a/client/app/scripts/superdesk-ingest/views/settings/ftp-config.html
+++ b/client/app/scripts/superdesk-ingest/views/settings/ftp-config.html
@@ -18,3 +18,7 @@
     <label for="ftp_dest_path" translate>Local Path</label>
     <input type="text" id="ftp_dest_path" placeholder="{{ :: 'Local Path'|translate }}" ng-model="provider.config.dest_path" required ng-change="$parent.setConfig(provider)">
 </div>
+<div class="field">
+    <label translate>Passive</label>
+    <span sd-switch ng-model="provider.config.passive"></span>
+</div>


### PR DESCRIPTION
@petrjasek ftp code change did not work expected. I was getting error as "200 Type is Image (Binary)" on line https://github.com/superdesk/superdesk/blob/2bca01c2999b01da03a9c32a764a90a2e9d73e95/server/superdesk/io/ftp.py#L88.

The ftp.retrbinary command does the following in passive mode:
- send "Type I"
- send PASV 
The response of the PASV command is "200 Type is Image (Binary)" instead of "227 Entering Passive Mode" Hence response validation of PASV fails. FTP download in active mode work fine. 

Moreover, I have modified the client and server so that the FTP connection type is configurable.