### PR TITLE
fix(ingest): set 5m soft time limit for all tasks

### DIFF
--- a/server/Procfile
+++ b/server/Procfile
@@ -1,4 +1,4 @@
 rest: python3 -u app.py
 wamp: python3 -u ws.py
-work: celery -A worker.celery worker
-beat: celery -A worker.celery beat --pid=
+work: celery -A worker worker
+beat: celery -A worker beat --pid=

--- a/server/apps/archive/__init__.py
+++ b/server/apps/archive/__init__.py
@@ -131,6 +131,6 @@ def init_app(app):
     superdesk.intrinsic_privilege(ArchiveUnlockResource.endpoint_name, method=['POST'])
 
 
-@celery.task()
+@celery.task
 def content_purge():
     ArchiveRemoveExpiredContent().run()

--- a/server/apps/auth/__init__.py
+++ b/server/apps/auth/__init__.py
@@ -33,7 +33,7 @@ def init_app(app):
     SessionsResource(endpoint_name, app=app, service=service)
 
 
-@celery.task()
+@celery.task
 def session_purge():
     try:
         RemoveExpiredSessions().run()

--- a/server/settings.py
+++ b/server/settings.py
@@ -77,11 +77,13 @@ REDIS_URL = env('REDIS_URL', 'redis://localhost:6379')
 if env('REDIS_PORT'):
     REDIS_URL = env('REDIS_PORT').replace('tcp:', 'redis:')
 BROKER_URL = env('CELERY_BROKER_URL', REDIS_URL)
+CELERY_RESULT_BACKEND = BROKER_URL
 CELERY_ALWAYS_EAGER = (env('CELERY_ALWAYS_EAGER', False) == 'True')
 CELERY_TASK_SERIALIZER = 'json'
 CELERY_ACCEPT_CONTENT = ['pickle', 'json']  # it's using pickle when in eager mode
 CELERY_IGNORE_RESULT = True
 CELERY_DISABLE_RATE_LIMITS = True
+CELERYD_TASK_SOFT_TIME_LIMIT = 300
 
 CELERYBEAT_SCHEDULE_FILENAME = env('CELERYBEAT_SCHEDULE_FILENAME', './celerybeatschedule.db')
 CELERYBEAT_SCHEDULE = {
@@ -94,7 +96,7 @@ CELERYBEAT_SCHEDULE = {
     },
     'ingest:gc': {
         'task': 'superdesk.io.gc_ingest',
-        'schedule': crontab(minute=10),
+        'schedule': crontab(minute=5),
     },
     'session:gc': {
         'task': 'apps.auth.session_purge',

--- a/server/superdesk/io/__init__.py
+++ b/server/superdesk/io/__init__.py
@@ -38,12 +38,12 @@ def register_provider(type, provider):
     allowed_providers.append(type)
 
 
-@celery.task()
+@celery.task(soft_time_limit=15)
 def update_ingest():
     UpdateIngest().run()
 
 
-@celery.task()
+@celery.task
 def gc_ingest():
     RemoveExpiredContent().run()
 

--- a/server/superdesk/io/commands/update_ingest.py
+++ b/server/superdesk/io/commands/update_ingest.py
@@ -115,12 +115,11 @@ class UpdateIngest(superdesk.Command):
                     'rule_set': get_provider_rule_set(provider)
                 }
                 update_provider.apply_async(
-                    task_id=get_task_id(provider),
                     expires=get_task_ttl(provider),
                     kwargs=kwargs)
 
 
-@celery.task
+@celery.task(soft_time_limit=1800)
 def update_provider(provider, rule_set=None):
     """
     Fetches items from ingest provider as per the configuration, ingests them into Superdesk and

--- a/server/superdesk/io/reuters.py
+++ b/server/superdesk/io/reuters.py
@@ -113,7 +113,7 @@ class ReutersIngestService(IngestService):
         url = self.get_url(endpoint)
 
         try:
-            response = requests.get(url, params=payload, timeout=21.0)
+            response = requests.get(url, params=payload, timeout=30)
         except requests.exceptions.Timeout as ex:
             # Maybe set up for a retry, or continue in a retry loop
             raise IngestApiError.apiTimeoutError(ex, self.provider)

--- a/server/superdesk/io/reuters_token.py
+++ b/server/superdesk/io/reuters_token.py
@@ -54,7 +54,7 @@ def fetch_token_from_api(provider):
         'password': provider.get('config', {}).get('password', ''),
     }
 
-    response = session.get(url, params=payload, stream=False, verify=False)
+    response = session.get(url, params=payload, verify=False, timeout=30)
     # workaround for httmock lib
     # tree = etree.fromstring(response.text)
     tree = etree.fromstring(response.content)

--- a/server/superdesk/media/media_operations.py
+++ b/server/superdesk/media/media_operations.py
@@ -39,7 +39,7 @@ def get_file_name(file):
 
 
 def download_file_from_url(url):
-    rv = requests.get(url)
+    rv = requests.get(url, timeout=300)
     if rv.status_code not in (200, 201):
         raise SuperdeskApiError.internalError('Failed to retrieve file from URL: %s' % url)
 


### PR DESCRIPTION
but keep it 10s for emails, and make it 30m for ingest.update_provider
+ set timeouts for reuters api requests