### PR TITLE
chore(travis, client): install patched protractor for travis on-demand

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,9 @@ install:
     - if [ "${TARGET}" = "client" ] || [ "${TARGET}" = "e2e" ]; then
         cd client && bower install && cd .. ;
       fi
+    - if [ "${TARGET}" = "e2e" ]; then
+        (cd client && npm install "actionless/protractor#1.6.1-old" );
+      fi
 
 before_script:
     - if [ "${TARGET}" = "e2e" ]; then

--- a/client/package.json
+++ b/client/package.json
@@ -38,7 +38,7 @@
     "karma-ng-html2js-preprocessor": "^0.1.0",
     "lodash": "^2.4.1",
     "karma-coverage": "^0.2.0",
-    "protractor": "actionless/protractor#1.6.1-old",
+    "protractor": "~1.6.1",
     "protractor-screenshot-reporter": "^0.0.5",
     "karma-junit-reporter": "^0.2.2",
     "grunt-contrib-cssmin": "^0.11.0",

--- a/docker/container_build.sh
+++ b/docker/container_build.sh
@@ -35,7 +35,7 @@ mkdir -p $BAMBOO_DIR/data/db
 rm -r $BAMBOO_DIR/results/
 mkdir -p $SERVER_RESULTS_DIR/{unit,behave} &&
 mkdir -p $CLIENT_RESULTS_DIR/unit &&
-mkdir $SCREENSHOTS_DIR
+mkdir -p $SCREENSHOTS_DIR
 
 # copy files for client+nginx container
 cp $SCRIPT_DIR/Dockerfile_client $BAMBOO_DIR/client/Dockerfile

--- a/docker/container_build.sh
+++ b/docker/container_build.sh
@@ -69,7 +69,6 @@ echo "+++ new user has been created" &&
 (
 	cd $BAMBOO_DIR/client &&
 	sh $SCRIPT_DIR/run_e2e_tests.sh ;
-	ls -la $BAMBOO_DIR/client/
 	mv $BAMBOO_DIR/client/e2e-test-results $CLIENT_RESULTS_DIR/e2e
 	mv $BAMBOO_DIR/client/screenshots $SCREENSHOTS_DIR &&
 		echo "!!! Screenshots were saved to $SCREENSHOTS_DIR"

--- a/docker/container_build.sh
+++ b/docker/container_build.sh
@@ -69,6 +69,7 @@ echo "+++ new user has been created" &&
 (
 	cd $BAMBOO_DIR/client &&
 	sh $SCRIPT_DIR/run_e2e_tests.sh ;
+	ls -la $BAMBOO_DIR/client/
 	mv $BAMBOO_DIR/client/e2e-test-results $CLIENT_RESULTS_DIR/e2e
 	mv $BAMBOO_DIR/client/screenshots $SCREENSHOTS_DIR
 	true

--- a/docker/container_build.sh
+++ b/docker/container_build.sh
@@ -11,6 +11,7 @@ SCRIPT_DIR=$(readlink -e $(dirname "$0"))
 BAMBOO_DIR=$(readlink -e $SCRIPT_DIR/..)
 SERVER_RESULTS_DIR=$BAMBOO_DIR/results/server
 CLIENT_RESULTS_DIR=$BAMBOO_DIR/results/client
+SCREENSHOTS_DIR=/opt/screenshots/$(date +%Y%m%d-%H%M%S)/
 
 # install script requirements
 virtualenv -p python2 $SCRIPT_DIR/env &&
@@ -34,6 +35,7 @@ mkdir -p $BAMBOO_DIR/data/db
 rm -r $BAMBOO_DIR/results/
 mkdir -p $SERVER_RESULTS_DIR/{unit,behave} &&
 mkdir -p $CLIENT_RESULTS_DIR/unit &&
+mkdir $SCREENSHOTS_DIR
 
 # copy files for client+nginx container
 cp $SCRIPT_DIR/Dockerfile_client $BAMBOO_DIR/client/Dockerfile
@@ -68,6 +70,7 @@ echo "+++ new user has been created" &&
 	cd $BAMBOO_DIR/client &&
 	sh $SCRIPT_DIR/run_e2e_tests.sh ;
 	mv $BAMBOO_DIR/client/e2e-test-results $CLIENT_RESULTS_DIR/e2e
+	mv $BAMBOO_DIR/client/screenshots $SCREENSHOTS_DIR
 	true
 );
 CODE="$?"

--- a/docker/container_build.sh
+++ b/docker/container_build.sh
@@ -71,7 +71,8 @@ echo "+++ new user has been created" &&
 	sh $SCRIPT_DIR/run_e2e_tests.sh ;
 	ls -la $BAMBOO_DIR/client/
 	mv $BAMBOO_DIR/client/e2e-test-results $CLIENT_RESULTS_DIR/e2e
-	mv $BAMBOO_DIR/client/screenshots $SCREENSHOTS_DIR
+	mv $BAMBOO_DIR/client/screenshots $SCREENSHOTS_DIR &&
+		echo "!!! Screenshots were saved to $SCREENSHOTS_DIR"
 	true
 );
 CODE="$?"


### PR DESCRIPTION
should speed-up client build (not installing protractor from git) and hopefully should fix e2e on bamboo (it seems chromedriver 2.13 works there better than 2.12 on bamboo)