### PR TITLE
fix(docker): prevent creation of new files via touch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ include/
 /server/.project
 /server/.pydevproject
 /server/.settings/org.eclipse.core.resources.prefs
+/results/

--- a/docker/container_build.sh
+++ b/docker/container_build.sh
@@ -38,9 +38,7 @@ mkdir -p $CLIENT_RESULTS_DIR/unit &&
 mkdir -p $SCREENSHOTS_DIR
 
 # reset repo files' dates:
-cd $BAMBOO_DIR/server/
-find -print0 ./ | grep -vzZ .git/ | xargs -0 touch -t 200001010000.00
-cd $BAMBOO_DIR/client/
+cd $BAMBOO_DIR
 find -print0 ./ | grep -vzZ .git/ | xargs -0 touch -t 200001010000.00
 
 # build container:

--- a/docker/container_build.sh
+++ b/docker/container_build.sh
@@ -39,9 +39,9 @@ mkdir -p $SCREENSHOTS_DIR
 
 # reset repo files' dates:
 cd $BAMBOO_DIR/server/
-find ./ | grep -v .git/ | xargs touch -t 200001010000.00
+find -print0 ./ | grep -vzZ .git/ | xargs -0 touch -t 200001010000.00
 cd $BAMBOO_DIR/client/
-find ./ | grep -v .git/ | xargs touch -t 200001010000.00
+find -print0 ./ | grep -vzZ .git/ | xargs -0 touch -t 200001010000.00
 
 # build container:
 cd $SCRIPT_DIR &&

--- a/server/Procfile
+++ b/server/Procfile
@@ -1,4 +1,4 @@
-rest: python3 -u app.py
+rest: gunicorn -c gunicorn_config.py wsgi
 wamp: python3 -u ws.py
 work: celery -A worker worker
 beat: celery -A worker beat --pid=

--- a/server/gunicorn_config.py
+++ b/server/gunicorn_config.py
@@ -1,0 +1,11 @@
+
+import os
+import multiprocessing
+
+workers = multiprocessing.cpu_count() * 2 + 1
+bind = '0.0.0.0:%s' % os.environ.get('PORT', 5000)
+
+accesslog = '-'
+access_log_format = '%(r)s\nstatus=%(s)s time=%(T)ss bytes=%(b)s pid=%(p)s remote=%(h)s referer=%(f)s'
+
+pidfile = 'gunicorn.pid'

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -18,6 +18,7 @@ celery[redis]==3.1.17
 elasticsearch==1.4.0
 feedparser==5.1.3
 flake8==2.3.0
+gunicorn==19.2.1
 honcho==0.5.0
 itsdangerous==0.24
 mccabe==0.3

--- a/server/settings.py
+++ b/server/settings.py
@@ -84,6 +84,8 @@ CELERY_ACCEPT_CONTENT = ['pickle', 'json']  # it's using pickle when in eager mo
 CELERY_IGNORE_RESULT = True
 CELERY_DISABLE_RATE_LIMITS = True
 CELERYD_TASK_SOFT_TIME_LIMIT = 300
+CELERYD_LOG_FORMAT = '%(message)s level=%(levelname)s process=%(processName)s'
+CELERYD_TASK_LOG_FORMAT = ' '.join([CELERYD_LOG_FORMAT, 'task=%(task_name)s task_id=%(task_id)s'])
 
 CELERYBEAT_SCHEDULE_FILENAME = env('CELERYBEAT_SCHEDULE_FILENAME', './celerybeatschedule.db')
 CELERYBEAT_SCHEDULE = {

--- a/server/ws.py
+++ b/server/ws.py
@@ -15,14 +15,17 @@ import json
 import logging
 import asyncio
 import signal
+
 from autobahn.asyncio.websocket import WebSocketServerProtocol
 from autobahn.asyncio.websocket import WebSocketServerFactory
+from app import get_app
 
 
 host = '0.0.0.0'
 beat_delay = 30
 port = int(os.environ.get('WSPORT', '5100'))
 logger = logging.getLogger(__name__)
+app = get_app()
 
 
 def log(msg):


### PR DESCRIPTION
if there was a file with space in name it would split it
for xargs and touch every part of that filename, creating new files,
and not touching the original file at all

but not sure why it's there @actionless ?