### PR TITLE
[SD-1682] - Display the expiry field in metadata tab for ingest items

### DIFF
--- a/server/features/steps/steps.py
+++ b/server/features/steps/steps.py
@@ -269,6 +269,7 @@ def step_impl_fetch_from_provider_ingest(context, provider_name, guid):
 
         for item in items:
             item['versioncreated'] = utcnow()
+            item['expiry'] = utcnow() + timedelta(minutes=20)
         context.ingest_items(items, provider)
 
 

--- a/server/superdesk/io/commands/remove_expired_content.py
+++ b/server/superdesk/io/commands/remove_expired_content.py
@@ -73,8 +73,16 @@ def get_expired_items(provider_id, expiration_date):
 
 
 def get_query_for_expired_items(provider_id, expiration_date):
+    """Find all ingest items with given provider id and
+    (expiry is past or
+    (no expiry assigned and versioncreated is less then calculated expiry date))"""
     query = {'and': [
         {'term': {'ingest.ingest_provider': provider_id}},
-        {'range': {'ingest.versioncreated': {'lte': date_to_str(expiration_date)}}},
+        {'or': [
+            {'range': {'ingest.expiry': {'lte': date_to_str(utcnow())}}},
+            {'and': [{'missing': {'field': 'ingest.expiry'}},
+                     {'range': {'ingest.versioncreated': {'lte': date_to_str(expiration_date)}}}]},
+        ]},
     ]}
+
     return superdesk.json.dumps(query)

--- a/server/superdesk/io/commands/update_ingest.py
+++ b/server/superdesk/io/commands/update_ingest.py
@@ -20,7 +20,7 @@ from werkzeug.exceptions import HTTPException
 from superdesk.notification import push_notification
 from superdesk.io import providers
 from superdesk.celery_app import celery
-from superdesk.utc import utcnow
+from superdesk.utc import utcnow, get_expiry_date
 from superdesk.workflow import set_default_state
 from superdesk.errors import ProviderError
 from superdesk.stats import stats
@@ -233,6 +233,7 @@ def ingest_item(item, provider, rule_set=None):
         item['ingest_provider'] = str(provider['_id'])
         item.setdefault('source', provider.get('source', ''))
         set_default_state(item, STATE_INGESTED)
+        item['expiry'] = get_expiry_date(provider.get('content_expiry', INGEST_EXPIRY_MINUTES), item['versioncreated'])
 
         if 'anpa-category' in item:
             process_anpa_category(item, provider)

--- a/server/superdesk/io/commands/update_ingest_tests.py
+++ b/server/superdesk/io/commands/update_ingest_tests.py
@@ -58,6 +58,19 @@ class UpdateIngestTest(TestCase):
             self.assertEquals(12, len(items))
             self.ingest_items(items, provider)
 
+    def test_ingest_item_expiry(self):
+        provider_name = 'reuters'
+        guid = 'tag_reuters.com_2014_newsml_KBN0FL0NM'
+        with self.app.app_context():
+            provider = self._get_provider(provider_name)
+            provider_service = self._get_provider_service(provider)
+            provider_service.provider = provider
+            items = provider_service.fetch_ingest(guid)
+            self.assertIsNone(items[1].get('expiry'))
+            items[1]['versioncreated'] = utcnow()
+            self.ingest_items([items[1]], provider)
+            self.assertIsNotNone(items[1].get('expiry'))
+
     def test_ingest_item_sync_if_missing_from_elastic(self):
         provider_name = 'reuters'
         guid = 'tag_reuters.com_2014_newsml_KBN0FL0NM'


### PR DESCRIPTION
Changes:
- Started using the 'expiry' field in ingested items
- Elastic filter in remove_expired_content has changed to use 'expiry' field (it should also be backward compatible)