### PR TITLE
fix(ingest expiry) Email and Teletype parsers to include version created in all items

### DIFF
--- a/server/superdesk/io/rfc822.py
+++ b/server/superdesk/io/rfc822.py
@@ -103,6 +103,7 @@ class rfc822Parser(Parser):
 
                         media_item = dict()
                         media_item['guid'] = generate_guid(type=GUID_TAG)
+                        media_item['versioncreated'] = utcnow()
                         media_item['type'] = 'picture'
                         media_item['renditions'] = renditions
                         media_item['mimetype'] = content_type

--- a/server/superdesk/io/rfc822_parser_test.py
+++ b/server/superdesk/io/rfc822_parser_test.py
@@ -50,3 +50,5 @@ class rfc822ComplexTestCase(TestCase):
 
     def test_composite(self):
         self.assertEqual(len(self.items), 3)
+        for item in self.items:
+            self.assertIn('versioncreated', item)

--- a/server/superdesk/io/zczc.py
+++ b/server/superdesk/io/zczc.py
@@ -11,6 +11,7 @@
 from superdesk.io import Parser
 from superdesk.errors import ParserError
 from .iptc import subject_codes
+from superdesk.utc import utcnow
 import uuid
 
 
@@ -95,3 +96,4 @@ class ZCZCParser(Parser):
         item['type'] = 'text'
         item['urgency'] = '5'
         item['pubstatus'] = 'Usable'
+        item['versioncreated'] = utcnow()

--- a/server/superdesk/io/zczc_parser_test.py
+++ b/server/superdesk/io/zczc_parser_test.py
@@ -30,3 +30,6 @@ class ZCZCTestCase(unittest.TestCase):
 
     def test_subject(self):
         self.assertEqual(self.items.get('subject')[0]['qcode'], '15039001')
+
+    def test_version_created(self):
+        self.assertIn('versioncreated', self.items)


### PR DESCRIPTION
The changes to the ingest expiry requires that all items are created with the versioncreated key in the item dictionary.