### PR TITLE
(fix) SD-1723

### DIFF
--- a/client/app/scripts/superdesk-authoring/authoring.js
+++ b/client/app/scripts/superdesk-authoring/authoring.js
@@ -180,10 +180,23 @@
         /**
          * Save the item
          *
+         * @param {Object} origItem
          * @param {Object} item
          */
-        this.save = function saveAuthoring(item) {
+        this.save = function saveAuthoring(origItem, item) {
             var diff = extendItem({}, item);
+
+            // Finding if all the keys are dirty for real
+            if (angular.isDefined(origItem)) {
+                var keysInDiff = _.keys(diff);
+                for (var i = 0; i < keysInDiff.length; i++) {
+                    var keyName = keysInDiff[i];
+                    if (_.isEqual(diff[keyName], origItem[keyName])) {
+                        delete diff[keyName];
+                    }
+                }
+            }
+
             autosave.stop(item);
             var endpoint = item.type === 'composite' ? 'packages' : 'archive';
             return api.save(endpoint, item, diff).then(function(_item) {
@@ -431,7 +444,7 @@
                  * Create a new version
                  */
             	$scope.save = function() {
-            		return authoring.save($scope.item).then(function(res) {
+            		return authoring.save($scope.origItem, $scope.item).then(function(res) {
                         $scope.origItem = res;
                         $scope.dirty = false;
                         $scope.item = _.create($scope.origItem);

--- a/server/features/packages.feature
+++ b/server/features/packages.feature
@@ -584,7 +584,7 @@ Feature: Packages
         """
         Then we get error 400
         """
-        {"_status": "ERR", "_issues": {"validator exception": "403"}}
+        {"_status": "ERR", "_issues": {"validator exception": "403: The number of groups and of referenced groups in the root group do not match."}}
         """
 
     @auth

--- a/server/features/user.feature
+++ b/server/features/user.feature
@@ -192,7 +192,7 @@ Feature: User Resource
         Then we get error 403
 
     @auth
-    Scenario: A logged-in user can't change roleROLES_ID
+    Scenario: A logged-in user can't change role
         Given "roles"
         """
         [{"name": "A", "is_default": true}, {"name": "B"}]
@@ -212,7 +212,7 @@ Feature: User Resource
         """
         Then we get error 400
         """
-        {"_status": "ERR", "_issues": {"validator exception": "403"}}
+        {"_status": "ERR", "_issues": {"validator exception": "403: Insufficient privileges to change the role"}}
         """
 
     @auth

--- a/server/superdesk/errors.py
+++ b/server/superdesk/errors.py
@@ -81,7 +81,7 @@ class SuperdeskApiError(SuperdeskError):
         return rv
 
     def __str__(self):
-        return repr(self.status_code)
+        return "{}: {}".format(repr(self.status_code), self.message)
 
     @classmethod
     def badRequestError(cls, message=None, payload=None):


### PR DESCRIPTION
[SD-1723] A combination of privileges gives unclear error.
Modified SuperdeskAPIError.__str__() in errors.py module to return error code and message, which is sometimes sent to client as part of response. This will enhance the user experience to see what exactly went wrong. To put it in simple words the error message is changed from "Error:403" to "Error: 403: Unauthorized to modify unique name".