### PR TITLE
fix(highlights): Disable mark for highlights on Personal, show highlight...

### DIFF
--- a/client/app/scripts/superdesk-highlights/highlights.js
+++ b/client/app/scripts/superdesk-highlights/highlights.js
@@ -33,7 +33,12 @@
             } else {
                 var criteria = {};
                 if (desk) {
-                	criteria = {where: {'desks': desk}};
+                	criteria = {where: {'$or': [
+                	                            {'desks': desk},
+                	                            {'desks': {'$size': 0}}
+                	                           ]
+                	                    }
+                	            };
                 }
 
                 return api('highlights').query(criteria)
@@ -278,7 +283,8 @@
         	templateUrl: 'scripts/superdesk-highlights/views/mark_highlights_dropdown.html',
         	filters: [
                 {action: 'list', type: 'archive'}
-            ]
+            ],
+            condition: function(item) {return item.task && item.task.desk;}
         })
         .activity('/settings/highlights', {
             label: gettext('Highlights'),

--- a/client/spec/content_spec.js
+++ b/client/spec/content_spec.js
@@ -13,7 +13,7 @@ describe('Content', function() {
     beforeEach(function() {
         openUrl('/#/workspace/content')();
         workspace.switchToDesk('PERSONAL');
-        expect(element.all(by.repeater('items._items')).count()).toBe(7);
+        expect(element.all(by.repeater('items._items')).count()).toBe(3);
     });
 
     it('can navigate with keyboard', function() {
@@ -53,7 +53,7 @@ describe('Content', function() {
 
         expect(element.all(by.css('.state-border')).count()).toBe(0);
         body.sendKeys('v');
-        expect(element.all(by.css('.state-border')).count()).toBe(7);
+        expect(element.all(by.css('.state-border')).count()).toBe(3);
         body.sendKeys('v');
         expect(element.all(by.css('.state-border')).count()).toBe(0);
     });

--- a/server/apps/archive/user_content.py
+++ b/server/apps/archive/user_content.py
@@ -23,7 +23,7 @@ class UserContentResource(Resource):
     datasource = {
         'source': 'archive',
         'aggregations': aggregations,
-        'elastic_filter': {'not': {'exists': {'field': 'task.stage'}}}  # eve-elastic specific filter
+        'elastic_filter': {'not': {'exists': {'field': 'task.desk'}}}  # eve-elastic specific filter
     }
     resource_methods = ['GET', 'POST']
     item_methods = ['GET', 'PATCH', 'DELETE']

--- a/server/features/highlights.feature
+++ b/server/features/highlights.feature
@@ -152,21 +152,39 @@ Feature: Highlights
         Given "archive"
         """
         [
-            {"_id": "item1", "type": "text", "headline": "item1", "body_html": "<p>item1 first</p><p>item1 second</p>", "task": {"desk": "#desks._id#"}},
-            {"_id": "item2", "type": "text", "headline": "item2", "body_html": "<p>item2 first</p><p>item2 second</p>", "task": {"desk": "#desks._id#"}},
-            {"_id": "package", "type": "composite", "headline": "highlights", "groups": [
-                {"id": "root", "refs": [{"idRef": "main"}]},
-                {
-                    "id": "main",
-                    "refs": [
-                        {"residRef": "item1"},
-                        {"residRef": "item2"}
-                    ]
-                }
-            ], "task": {"desk": "#desks._id#"}}
+            {"guid": "item1", "type": "text", "headline": "item1", "body_html": "<p>item1 first</p><p>item1 second</p>", "task": {"desk": "#desks._id#"}},
+            {"guid": "item2", "type": "text", "headline": "item2", "body_html": "<p>item2 first</p><p>item2 second</p>", "task": {"desk": "#desks._id#"}}
         ]
         """ 
-
+		When we post to "archive"
+		"""
+		{   "guid": "package",
+		    "type": "composite",
+		    "headline": "highlights",
+		    "groups": [{
+		        "id": "root",
+		        "refs": [{
+		            "idRef": "main"
+		        }]
+		    }, {
+		        "id": "main",
+		        "refs": [{
+		            "residRef": "item1"
+		        }, {
+		            "residRef": "item2"
+		        }]
+		    }],
+		    "task": {
+		        "desk": "#desks._id#"
+		    }
+		}
+		"""
+		
+        Then we get new resource
+        """
+        {"_id": "", "type": "composite", "headline": "highlights"}
+        """
+			
         When we post to "generate_highlights"
         """
         {"package": "package"}


### PR DESCRIPTION
...s with no desk

Disable mark for highlights on Personal
When a highlight has no desk, it will be showed for all desks
Change the filter from Personal in order to show only items not assigned
to a desk