### PR TITLE
[SD-1853] WENN/FTP Ingest errors

### DIFF
--- a/server/superdesk/io/ftp.py
+++ b/server/superdesk/io/ftp.py
@@ -84,7 +84,11 @@ class FTPService(IngestService):
                     if not parser:
                         raise IngestFtpError.ftpUnknownParserError(Exception('Parser not found'),
                                                                    provider, filename)
-                    items.append([parser.parse_message(xml, provider)])
+                    parsed = parser.parse_message(xml, provider)
+                    if isinstance(parsed, dict):
+                        parsed = [parsed]
+
+                    items.append(parsed)
             return items
         except IngestFtpError:
             raise

--- a/server/superdesk/io/wenn_parser.py
+++ b/server/superdesk/io/wenn_parser.py
@@ -49,7 +49,7 @@ class WENNParser(Parser):
         item['urgency'] = '5'
         item['pubstatus'] = 'Usable'
         item['anpa-category'] = {'qcode': 'e'}
-        item['subject'] = {'qcode': '01000000', 'name': 'arts, culture and entertainment'}
+        item['subject'] = [{'qcode': '01000000', 'name': 'arts, culture and entertainment'}]
 
     def parse_news_management(self, item, entry):
         news_mgmt_el = entry.find(self.qname('NewsManagement', self.WENN_NM_NS))

--- a/server/superdesk/io/wenn_parser_test.py
+++ b/server/superdesk/io/wenn_parser_test.py
@@ -49,8 +49,8 @@ class WENNTestCase(unittest.TestCase):
         self.assertEqual(self.items[1].get('anpa-category')['qcode'], 'e')
 
     def test_subject(self):
-        self.assertEqual(self.items[0].get('subject')['qcode'], '01000000')
-        self.assertEqual(self.items[1].get('subject')['qcode'], '01000000')
+        self.assertEqual(self.items[0].get('subject')[0]['qcode'], '01000000')
+        self.assertEqual(self.items[1].get('subject')[0]['qcode'], '01000000')
 
     def test_firstcreated(self):
         self.assertEqual(self.items[0].get('firstcreated'), datetime.datetime(year=2015, month=1, day=30, hour=0,


### PR DESCRIPTION
Two problems, the subject codes parsed by the WENN parser where not in a list. Also the NITF parser can be used either by a File Ingestor or FTP, it returns a dictionary not a list.