### PR TITLE
fix(workspace): prevent preferences update errors

### DIFF
--- a/client/app/scripts/superdesk-archive/controllers/list.js
+++ b/client/app/scripts/superdesk-archive/controllers/list.js
@@ -28,13 +28,12 @@ define([
 
         $scope.toggleSpike = function toggleSpike() {
             $scope.spike = !$scope.spike;
-            $scope.stages.select(null);
             $location.search('spike', $scope.spike ? 1 : null);
             $location.search('_id', null);
+            $scope.stages.select(null);
         };
 
         $scope.stageSelect = function(stage) {
-            initpage();
             if ($scope.spike) {
                 $scope.toggleSpike();
             }
@@ -59,9 +58,8 @@ define([
         };
 
         var refreshItems = _.debounce(_refresh, 100);
-
         function _refresh() {
-            if ($scope.selected.desk && $scope.selected.desk.name) {
+            if (desks.activeDeskId) {
                 resource = api('archive');
             } else {
                 resource = api('user_content', session.identity);
@@ -79,9 +77,9 @@ define([
         }
 
         $scope.$on('task:stage', function(_e, data) {
-        	if ($scope.stages.selected &&
-        	    ($scope.stages.selected._id === data.new_stage ||
-        	     $scope.stages.selected._id === data.old_stage)) {
+        	if ($scope.stages.selected && (
+                $scope.stages.selected._id === data.new_stage ||
+                $scope.stages.selected._id === data.old_stage)) {
         		refreshItems();
         	}
         });
@@ -95,22 +93,19 @@ define([
         $scope.$on('item:spike', refreshItems);
         $scope.$on('item:unspike', reset);
 
-        $scope.$watchGroup(['stages.selected', 'selected.desk'], refreshOnDeskAndStages);
-        function refreshOnDeskAndStages() {
-        	if ($scope.selected.desk && desks.activeDeskId) {
-        		refreshItems();
-        	} else if (!$scope.selected.desk && desks.activeDeskId) {
-        		desks.fetchCurrentUserDesks()
-                .then(function(userDesks) {
-                	$scope.selected.desk = desks.getCurrentDesk();
-                });
-        	}
-        }
+        desks.fetchCurrentUserDesks().then(function() {
+            // only watch desk/stage after we get current user desk
+            $scope.$watch(function() {
+                return desks.active;
+            }, function(active) {
+                if ($location.search().page) {
+                    $location.search('page', null);
+                    return; // will reload via $routeUpdate
+                }
 
-        $scope.$watch('selected.desk', initpage);
-        function initpage() {
-            $location.search('page', null);
-        }
+                refreshItems();
+            });
+        });
 
         // reload on route change if there is still the same _id
         var oldQuery = _.omit($location.search(), '_id');

--- a/client/app/scripts/superdesk-dashboard/module.js
+++ b/client/app/scripts/superdesk-dashboard/module.js
@@ -18,12 +18,7 @@ define([
 
                 scope.select = function selectDesk(desk) {
                     scope.selected = desk;
-
-                    if (desk._id === 'personal' && $location.path() === '/workspace/ingest') {
-                        desks.setCurrentDesk();
-                    } else {
-                        desks.setCurrentDesk(desk);
-                    }
+                    desks.setCurrentDesk(desk._id === 'personal' ? null : desk);
 
                     if (desk._id === 'personal') {
                        $location.path('/workspace/content') ;

--- a/client/app/scripts/superdesk-dashboard/module.js
+++ b/client/app/scripts/superdesk-dashboard/module.js
@@ -16,34 +16,25 @@ define([
             templateUrl: 'scripts/superdesk-dashboard/views/desk-dropdown.html',
             link: function(scope) {
 
-                scope.select = function selectDesk(desk, reloadRoute) {
-                    if (angular.isUndefined(reloadRoute)) {
-                        reloadRoute = true;
-                    }
-
-                    desks.setCurrentDesk(desk);
+                scope.select = function selectDesk(desk) {
                     scope.selected = desk;
 
                     if (desk._id === 'personal' && $location.path() === '/workspace/ingest') {
-                       $location.path('/workspace/content') ;
+                        desks.setCurrentDesk();
+                    } else {
+                        desks.setCurrentDesk(desk);
                     }
 
-                    if (reloadRoute) {
-                        $route.reload();
+                    if (desk._id === 'personal') {
+                       $location.path('/workspace/content') ;
                     }
                 };
 
-                desks.initialize()
-                .then(function() {
-                    desks.fetchCurrentUserDesks().then(function (userDesks) {
-                    	scope.userDesks = userDesks._items;
-                    	if (!desks.activeDeskId && scope.userDesks.length) {
-                    		scope.select(scope.userDesks[0], false);
-                    	} else if (desks.getCurrentDesk() != null) {
-                    		scope.select(desks.getCurrentDesk(), false);
-                    	}
+                desks.fetchCurrentUserDesks()
+                    .then(function(userDesks) {
+                        scope.userDesks = userDesks._items;
+                        scope.selected = _.find(scope.userDesks, {_id: desks.activeDeskId}) || null;
                     });
-                });
             }
         };
     }

--- a/client/app/scripts/superdesk-dashboard/views/desk-dropdown.html
+++ b/client/app/scripts/superdesk-dashboard/views/desk-dropdown.html
@@ -8,5 +8,5 @@
     <li ng-repeat="desk in userDesks track by desk._id" ng-if="desk !== selected">
         <button option="{{ desk.name | uppercase }}" ng-click="select(desk)">{{ desk.name }}</button>
     </li>
-    <li ng-if="selected.name"><button option="PERSONAL" ng-click="select({'_id': 'personal'})" translate>Personal</button></li>
+    <li ng-if="selected.name"><button option="PERSONAL" ng-click="select({_id: 'personal'})" translate>Personal</button></li>
 </ul>

--- a/client/app/scripts/superdesk-dashboard/views/desk-dropdown.html
+++ b/client/app/scripts/superdesk-dashboard/views/desk-dropdown.html
@@ -1,6 +1,6 @@
 <button id="selected-desk" data-toggle="dropdown" class="dropdown-toggle pull-left">
     <span class="name" ng-if="selected.name">{{ selected.name }}</span>
-    <span class="name" ng-if="!selected.name" translate>Personal</span>
+    <span class="name" ng-if="selected !== undefined && !selected.name" translate>Personal</span>
     <span class="caret"></span>
 </button>
 

--- a/client/app/scripts/superdesk-dashboard/workspace-tasks/tasks.js
+++ b/client/app/scripts/superdesk-dashboard/workspace-tasks/tasks.js
@@ -229,9 +229,9 @@ function AssigneeViewDirective(desks) {
     };
 }
 
+// todo(petr): move to desks module
 StagesCtrlFactory.$inject = ['api', 'desks'];
 function StagesCtrlFactory(api, desks) {
-
     var promise = desks.initialize();
     return function StagesCtrl($scope) {
         var self = this;
@@ -242,27 +242,22 @@ function StagesCtrlFactory(api, desks) {
 
             // select a stage as active
             self.select = function(stage) {
-                self.selected = stage || null;
                 var stageId = stage ? stage._id : null;
+                self.selected = stage || null;
                 desks.setCurrentStageId(stageId);
             };
 
             // reload list of stages
             self.reload = function(deskId) {
-                if (deskId) {
-                    self.stages = desks.deskStages[deskId];
-                } else {
-                    self.stages = null;
-                }
-                self.select(_.find(self.stages, {_id: desks.getCurrentStageId()}));
+                self.stages = deskId ? desks.deskStages[deskId] : null;
+                self.select(_.find(self.stages, {_id: desks.activeStageId}));
             };
 
             $scope.$watch(function() {
-                return desks.getCurrentDeskId();
-            }, function(_deskId) {
-                self.reload(_deskId || null);
+                return desks.activeDeskId;
+            }, function() {
+                self.reload(desks.activeDeskId);
             });
-
         });
     };
 }

--- a/client/app/scripts/superdesk/api/url-resolver-service.js
+++ b/client/app/scripts/superdesk/api/url-resolver-service.js
@@ -55,7 +55,8 @@ define([], function() {
 
             return $http({
                 method: 'GET',
-                url: baseUrl
+                url: baseUrl,
+                cache: true
             }).then(function(response) {
                 _links = {};
 

--- a/client/app/scripts/superdesk/services/preferencesService.js
+++ b/client/app/scripts/superdesk/services/preferencesService.js
@@ -27,7 +27,7 @@ define(['angular', 'lodash'], function(angular, _) {
 
             function saveLocally(preferences, type) {
                 if (type && original_preferences) {
-                    angular.extend(original_preferences[type], preferences[type]);
+                    angular.extend(original_preferences[type], preferences[type][session.sessionId] || preferences[type]);
                 } else {
                     original_preferences = preferences;
                 }
@@ -128,7 +128,7 @@ define(['angular', 'lodash'], function(angular, _) {
 
                 if (type) {
                     // make changes available right away
-                    angular.extend(original_preferences[type], user_updates);
+                    angular.extend(original_preferences[type], updates);
                 }
 
                 return api.save('preferences', original_prefs, user_updates)

--- a/client/app/scripts/superdesk/services/preferencesService.js
+++ b/client/app/scripts/superdesk/services/preferencesService.js
@@ -17,7 +17,6 @@ define(['angular', 'lodash'], function(angular, _) {
                     'email:notification': 1,
                     'workqueue:items': 1
                 },
-                api,
                 original_preferences = null,
                 defaultPreferences = {};
 
@@ -26,24 +25,19 @@ define(['angular', 'lodash'], function(angular, _) {
             defaultPreferences[ACTIVE_PRIVILEGES] = {};
             defaultPreferences[ACTIONS] = {};
 
-            function saveLocally(preferences, type, key) {
-
-                if (type && key && original_preferences)
-                {
-                    original_preferences[type][key] = preferences[type][key];
-                    original_preferences._etag = preferences._etag;
-                } else
-                {
+            function saveLocally(preferences, type) {
+                if (type && original_preferences) {
+                    angular.extend(original_preferences[type], preferences[type]);
+                } else {
                     original_preferences = preferences;
                 }
 
+                original_preferences._etag = preferences._etag;
                 storage.setItem(PREFERENCES, original_preferences);
             }
 
-            function loadLocally()
-            {
-                if (!original_preferences)
-                {
+            function loadLocally() {
+                if (!original_preferences) {
                     original_preferences = storage.getItem(PREFERENCES);
                 }
 
@@ -70,7 +64,7 @@ define(['angular', 'lodash'], function(angular, _) {
             };
 
             function getPreferences(sessionId, key) {
-                if (!api) { api = $injector.get('api'); }
+                var api = $injector.get('api');
 
                 if (!sessionId) {
                     return $q.reject();
@@ -127,12 +121,15 @@ define(['angular', 'lodash'], function(angular, _) {
             };
 
             function updatePreferences(type, updates, key) {
-
+                var api = $injector.get('api');
                 var original_prefs = _.cloneDeep(loadLocally());
                 var user_updates = {};
                 user_updates[type] = updates;
 
-                if (!api) { api = $injector.get('api'); }
+                if (type) {
+                    // make changes available right away
+                    angular.extend(original_preferences[type], user_updates);
+                }
 
                 return api.save('preferences', original_prefs, user_updates)
                 .then(function(result) {
@@ -148,5 +145,4 @@ define(['angular', 'lodash'], function(angular, _) {
                 return session.sessionId;
             }, getPreferences);
     }]);
-
 });

--- a/client/app/scripts/superdesk/services/preferences_spec.js
+++ b/client/app/scripts/superdesk/services/preferences_spec.js
@@ -120,7 +120,7 @@ define([
 			preferencesService.get();
             $rootScope.$digest();
 
-            preferencesService.update(update, 'feature:preview').then(function() {}, function(response) { });
+            preferencesService.update(update, 'feature:preview');
             $rootScope.$digest();
 
             var preferences;

--- a/server/apps/preferences.py
+++ b/server/apps/preferences.py
@@ -159,7 +159,8 @@ class PreferencesService(BaseService):
 
             existing = existing_session_preferences.get(session_id, {})
             existing.update(session_prefs)
-            updates[_session_preferences_key] = existing
+            existing_session_preferences[session_id] = existing
+            updates[_session_preferences_key] = existing_session_preferences
 
     def update_user_prefs(self, updates, existing_user_preferences):
         user_prefs = updates.get(_user_preferences_key)

--- a/server/apps/preferences.py
+++ b/server/apps/preferences.py
@@ -154,13 +154,12 @@ class PreferencesService(BaseService):
     def update_session_prefs(self, updates, existing_session_preferences, session_id):
         session_prefs = updates.get(_session_preferences_key)
         if session_prefs is not None:
-            for k in ((k for k, v in session_prefs.items() if k not in superdesk.default_session_preferences)):
+            for k in (k for k, v in session_prefs.items() if k not in superdesk.default_session_preferences):
                 raise ValidationError('Invalid preference: %s' % k)
 
             existing = existing_session_preferences.get(session_id, {})
             existing.update(session_prefs)
-            existing_session_preferences[session_id] = existing
-            updates[_session_preferences_key] = existing_session_preferences
+            updates[_session_preferences_key] = existing
 
     def update_user_prefs(self, updates, existing_user_preferences):
         user_prefs = updates.get(_user_preferences_key)


### PR DESCRIPTION
there were multiple calls to update preferences at the same time,
both using same etag, so the later had to fail. that was happening
on desk/stage change which are 2 settings. now those 2 should be
updated together, and also there is no update if the new value
matches the old one.

SD-1867