### PR TITLE
fix(generate): ignore content for non-text items

### DIFF
--- a/server/apps/highlights/generate.py
+++ b/server/apps/highlights/generate.py
@@ -3,6 +3,29 @@ import superdesk
 from bs4 import BeautifulSoup
 
 
+def join_html(pieces):
+    """Join given list with line breaks.
+
+    :param pieces: list of str
+    """
+    return '\n'.join(pieces)
+
+
+def item_to_str(item):
+    """Get text representation of a given item.
+
+    :param item: news item
+    """
+
+    pieces = []
+    pieces.append('<h2>%s</h2>' % item.get('headline', ''))
+    html = item.get('body_html')
+    if html:
+        soup = BeautifulSoup(html)
+        pieces.append(str(soup.p))
+    return join_html(pieces)
+
+
 class GenerateHighlightsService(superdesk.Service):
     def create(self, docs, **kwargs):
         """Generate highlights text item for given package.
@@ -29,10 +52,9 @@ class GenerateHighlightsService(superdesk.Service):
                 for ref in group.get('refs', []):
                     if 'residRef' in ref:
                         item = service.find_one(req=None, _id=ref.get('residRef'))
-                        body.append('<h2>%s</h2>' % item.get('headline', ''))
-                        soup = BeautifulSoup(item.get('body_html', ''))
-                        body.append(str(soup.p))
-            doc['body_html'] = '\n'.join(body)
+                        body.append(item_to_str(item))
+                        body.append('<p></p>')
+            doc['body_html'] = join_html(body)
 
         if preview:
             return ['' for doc in docs]

--- a/server/apps/highlights/generate_test.py
+++ b/server/apps/highlights/generate_test.py
@@ -1,0 +1,15 @@
+
+import unittest
+
+from .generate import item_to_str
+
+
+class GenerateTestCase(unittest.TestCase):
+
+    def test_item_to_str_body(self):
+        text = item_to_str({'headline': 'test', 'body_html': '<p>one</p><p>two</p>'})
+        self.assertEquals('<h2>test</h2>\n<p>one</p>', text)
+
+    def test_item_to_str_no_body(self):
+        text = item_to_str({'headline': 'test'})
+        self.assertEquals('<h2>test</h2>', text)

--- a/server/features/highlights.feature
+++ b/server/features/highlights.feature
@@ -192,7 +192,7 @@ Feature: Highlights
 
         Then we get new resource
         """
-        {"_id": "", "type": "text", "headline": "highlights", "body_html": "<h2>item1</h2>\n<p>item1 first</p>\n<h2>item2</h2>\n<p>item2 first</p>"}
+        {"_id": "", "type": "text", "headline": "highlights", "body_html": "<h2>item1</h2>\n<p>item1 first</p>\n<p></p>\n<h2>item2</h2>\n<p>item2 first</p>\n<p></p>"}
         """
 
         When we get "/archive"


### PR DESCRIPTION
in case there is no `body_html` in item it will not output `None`