### PR TITLE
fix(desks): check if user current desk exists

### DIFF
--- a/client/app/scripts/superdesk-desks/desks.js
+++ b/client/app/scripts/superdesk-desks/desks.js
@@ -383,6 +383,9 @@
                     return api.get(user._links.self.href + '/desks');
                 },
 
+                /**
+                 * Fetch current user desks and make sure active desk is present in there
+                 */
                 fetchCurrentUserDesks: function() {
                     if (userDesks) {
                         return $q.when(userDesks);
@@ -394,8 +397,12 @@
                             .then(angular.bind(this, this.fetchUserDesks))
                             .then(angular.bind(this, function(desks) {
                                 userDesks = desks;
-                                if (!this.activeDeskId && desks._items.length) {
-                                    this.setCurrentDesk(desks._items[0]);
+                                if (desks._items.length) {
+                                    if (!this.activeDeskId || !_.find(desks._items, {_id: this.activeDeskId})) {
+                                        this.setCurrentDesk(desks._items[0]);
+                                    }
+                                } else if (this.activeDeskId) {
+                                    this.setCurrentDesk(null);
                                 }
                                 setActive(this);
                                 return desks;

--- a/client/app/scripts/superdesk-desks/tests/desks-spec.js
+++ b/client/app/scripts/superdesk-desks/tests/desks-spec.js
@@ -11,6 +11,7 @@ describe('desks service', function() {
 		spyOn(session, 'getIdentity').and.returnValue($q.when({_links: {self: {href: USER_URL}}}));
 		spyOn(api, 'get').and.returnValue($q.when({_items: [{name: 'sport'}, {name: 'news'}]}));
 		spyOn(preferencesService, 'get').and.returnValue($q.when([]));
+		spyOn(preferencesService, 'update');
 
 		var userDesks;
 		desks.fetchCurrentUserDesks().then(function(_userDesks) {
@@ -24,12 +25,23 @@ describe('desks service', function() {
 
 	it('can pick a first desk if user has no current desk selected',
 		inject(function(desks, session, api, preferencesService, $q, $rootScope) {
-			spyOn(preferencesService, 'get').and.returnValue($q.when(null));
+			spyOn(preferencesService, 'get').and.returnValue($q.when('missing'));
 			spyOn(preferencesService, 'update');
-			spyOn(desks, 'fetchUserDesks').and.returnValue($q.when({_items: [{_id: 1, desk: 'foo'}]}));
+			spyOn(desks, 'fetchUserDesks').and.returnValue($q.when({_items: [{_id: 'foo'}]}));
 			desks.fetchCurrentUserDesks();
 			$rootScope.$digest();
-			expect(desks.activeDeskId).not.toBe(null);
+			expect(desks.activeDeskId).toBe('foo');
+		})
+	);
+
+	it('can checks if current desk is part of user desks',
+		inject(function(desks, session, api, preferencesService, $q, $rootScope) {
+			spyOn(preferencesService, 'get').and.returnValue($q.when('missing'));
+			spyOn(preferencesService, 'update');
+			spyOn(desks, 'fetchUserDesks').and.returnValue($q.when({_items: []}));
+			desks.fetchCurrentUserDesks();
+			$rootScope.$digest();
+			expect(desks.activeDeskId).toBe(null);
 		})
 	);
 


### PR DESCRIPTION
we get user default desk via preferences, but this desk might not
exist anymore when using it, so it will check if that desk is there
when fetching user desks and if not it will set 1st desk as current.