### PR TITLE
fix(desks): avoid updating preferences when fetching desks

### DIFF
--- a/client/app/scripts/superdesk-desks/desks.js
+++ b/client/app/scripts/superdesk-desks/desks.js
@@ -399,10 +399,10 @@
                                 userDesks = desks;
                                 if (desks._items.length) {
                                     if (!this.activeDeskId || !_.find(desks._items, {_id: this.activeDeskId})) {
-                                        this.setCurrentDesk(desks._items[0]);
+                                        this.activeDeskId = desks._items[0]._id;
                                     }
                                 } else if (this.activeDeskId) {
-                                    this.setCurrentDesk(null);
+                                    this.activeDeskId = null;
                                 }
                                 setActive(this);
                                 return desks;

--- a/client/app/scripts/superdesk-desks/tests/desks-spec.js
+++ b/client/app/scripts/superdesk-desks/tests/desks-spec.js
@@ -31,6 +31,7 @@ describe('desks service', function() {
 			desks.fetchCurrentUserDesks();
 			$rootScope.$digest();
 			expect(desks.activeDeskId).toBe('foo');
+			expect(preferencesService.update).not.toHaveBeenCalled();
 		})
 	);
 
@@ -42,6 +43,7 @@ describe('desks service', function() {
 			desks.fetchCurrentUserDesks();
 			$rootScope.$digest();
 			expect(desks.activeDeskId).toBe(null);
+			expect(preferencesService.update).not.toHaveBeenCalled();
 		})
 	);
 


### PR DESCRIPTION
there is no need for this, and also it was a side effect doing updates
in fetch current user desks.