### PR TITLE
fix(ingest) - always generated an _id, guid is going to point to the ID in the provider system

### DIFF
--- a/server/apps/archive/common.py
+++ b/server/apps/archive/common.py
@@ -28,6 +28,7 @@ from superdesk.errors import SuperdeskApiError, IdentifierGenerationError
 
 
 GUID_TAG = 'tag'
+GUID_FIELD = 'guid'
 GUID_NEWSML = 'newsml'
 FAMILY_ID = 'family_id'
 INGEST_ID = 'ingest_id'
@@ -39,27 +40,27 @@ def on_create_item(docs):
         update_dates_for(doc)
         set_original_creator(doc)
 
-        if not doc.get('guid'):
-            doc['guid'] = generate_guid(type=GUID_NEWSML)
+        if not doc.get(GUID_FIELD):
+            doc[GUID_FIELD] = generate_guid(type=GUID_NEWSML)
 
         if 'unique_id' not in doc:
             generate_unique_id_and_name(doc)
 
         if 'family_id' not in doc:
-            doc['family_id'] = doc['guid']
+            doc['family_id'] = doc[GUID_FIELD]
 
         set_default_state(doc, 'draft')
-        doc.setdefault('_id', doc['guid'])
+        doc.setdefault('_id', doc[GUID_FIELD])
 
 
 def on_duplicate_item(doc):
     """Make sure duplicated item has basic fields populated."""
-    doc['guid'] = generate_guid(type=GUID_NEWSML)
+    doc[GUID_FIELD] = generate_guid(type=GUID_NEWSML)
 
     if 'unique_id' not in doc:
         generate_unique_id_and_name(doc)
 
-    doc.setdefault('_id', doc['guid'])
+    doc.setdefault('_id', doc[GUID_FIELD])
 
 
 def update_dates_for(doc):
@@ -109,7 +110,7 @@ def set_original_creator(doc):
 
 item_url = 'regex("[\w,.:_-]+")'
 
-extra_response_fields = ['guid', 'headline', 'firstcreated', 'versioncreated', 'archived']
+extra_response_fields = [GUID_FIELD, 'headline', 'firstcreated', 'versioncreated', 'archived']
 
 aggregations = {
     'type': {'terms': {'field': 'type'}},

--- a/server/apps/duplication/archive_fetch.py
+++ b/server/apps/duplication/archive_fetch.py
@@ -52,9 +52,9 @@ class FetchResource(Resource):
 class FetchService(BaseService):
 
     def create(self, docs, **kwargs):
-        return self.__fetch(docs, id=request.view_args.get('id'), **kwargs)
+        return self.fetch(docs, id=request.view_args.get('id'), **kwargs)
 
-    def __fetch(self, docs, id=None, **kwargs):
+    def fetch(self, docs, id=None, **kwargs):
         id_of_fetched_items = []
 
         for doc in docs:
@@ -113,7 +113,7 @@ class FetchService(BaseService):
                 for ref in group.get('refs', []) if 'residRef' in ref]
 
         if refs:
-            new_ref_guids = self.__fetch(refs, id=None, notify=False)
+            new_ref_guids = self.fetch(refs, id=None, notify=False)
             count = 0
             for ref in [ref for group in dest_doc.get('groups', [])
                         for ref in group.get('refs', []) if 'residRef' in ref]:

--- a/server/apps/rules/routing_rules.py
+++ b/server/apps/rules/routing_rules.py
@@ -267,12 +267,11 @@ class RoutingRuleSchemeService(BaseService):
         archive_items = []
         for destination in destinations:
             try:
-                item_id = get_resource_service('fetch') \
-                    .post([{'_id': ingest_item['_id'],
-                            'desk': str(destination.get('desk')),
-                            'stage': str(destination.get('stage')),
-                            'state': STATE_ROUTED,
-                            'macro': destination.get('macro', None)}])[0]
+                item_id = get_resource_service('fetch').fetch([{'_id': ingest_item['_id'],
+                                                                'desk': str(destination.get('desk')),
+                                                                'stage': str(destination.get('stage')),
+                                                                'state': STATE_ROUTED,
+                                                                'macro': destination.get('macro', None)}])[0]
                 archive_items.append(item_id)
             except:
                 logger.exception("Failed to fetch item %s to desk %s" % (ingest_item['guid'], destination))

--- a/server/apps/rules/routing_rules.py
+++ b/server/apps/rules/routing_rules.py
@@ -268,7 +268,7 @@ class RoutingRuleSchemeService(BaseService):
         for destination in destinations:
             try:
                 item_id = get_resource_service('fetch') \
-                    .post([{'guid': ingest_item['guid'],
+                    .post([{'_id': ingest_item['_id'],
                             'desk': str(destination.get('desk')),
                             'stage': str(destination.get('stage')),
                             'state': STATE_ROUTED,

--- a/server/features/auto_routing.feature
+++ b/server/features/auto_routing.feature
@@ -60,14 +60,14 @@ Feature: Auto Routing
         """
         {
           "routing_scheme": "#routing_schemes._id#",
-          "ingest": "AFP.121974877.6504909"
+          "ingest": "#AAP.AFP.121974877.6504909#"
         }
         """
         Then the ingest item is not routed based on routing scheme and rule "Sports Rule"
         """
         {
           "routing_scheme": "#routing_schemes._id#",
-          "ingest": "AFP.121974877.6504909"
+          "ingest": "#AAP.AFP.121974877.6504909#"
         }
         """
         When we fetch from "AAP" ingest "aap-sports.xml" using routing_scheme
@@ -78,14 +78,14 @@ Feature: Auto Routing
         """
         {
           "routing_scheme": "#routing_schemes._id#",
-          "ingest": "AAP.123253116.6697929"
+          "ingest": "#AAP.AAP.123253116.6697929#"
         }
         """
         Then the ingest item is not routed based on routing scheme and rule "Finance Rule"
         """
         {
           "routing_scheme": "#routing_schemes._id#",
-          "ingest": "AAP.123253116.6697929"
+          "ingest": "#AAP.AAP.123253116.6697929#"
         }
         """
 
@@ -128,7 +128,7 @@ Feature: Auto Routing
         """
         {
           "routing_scheme": "#routing_schemes._id#",
-          "ingest": "tag_reuters.com_2014_newsml_KBN0FL0NM"
+          "ingest": "#reuters.tag_reuters.com_2014_newsml_KBN0FL0NM#"
         }
         """
 
@@ -209,14 +209,14 @@ Feature: Auto Routing
         """
         {
           "routing_scheme": "#routing_schemes._id#",
-          "ingest": "AFP.121974877.6504909"
+          "ingest": "#AAP.AFP.121974877.6504909#"
         }
         """
         Then the ingest item is routed based on routing scheme and rule "Finance Rule 2"
         """
         {
           "routing_scheme": "#routing_schemes._id#",
-          "ingest": "AFP.121974877.6504909"
+          "ingest": "#AAP.AFP.121974877.6504909#"
         }
         """
         When we fetch from "AAP" ingest "aap-finance1.xml" using routing_scheme
@@ -227,14 +227,14 @@ Feature: Auto Routing
         """
         {
           "routing_scheme": "#routing_schemes._id#",
-          "ingest": "AAP.0.6703189"
+          "ingest": "#AAP.AAP.0.6703189#"
         }
         """
         Then the ingest item is routed based on routing scheme and rule "Finance Rule 1"
         """
         {
           "routing_scheme": "#routing_schemes._id#",
-          "ingest": "AAP.0.6703189"
+          "ingest": "#AAP.AAP.0.6703189#"
         }
         """
 
@@ -303,14 +303,14 @@ Feature: Auto Routing
         """
         {
           "routing_scheme": "#routing_schemes._id#",
-          "ingest": "AFP.121974877.6504909"
+          "ingest": "#AAP.AFP.121974877.6504909#"
         }
         """
         Then the ingest item is routed based on routing scheme and rule "Finance Rule 2"
         """
         {
           "routing_scheme": "#routing_schemes._id#",
-          "ingest": "AFP.121974877.6504909"
+          "ingest": "#AAP.AFP.121974877.6504909#"
         }
         """
 
@@ -380,13 +380,13 @@ Feature: Auto Routing
         """
         {
           "routing_scheme": "#routing_schemes._id#",
-          "ingest": "AFP.121974877.6504909"
+          "ingest": "#AAP.AFP.121974877.6504909#"
         }
         """
         Then the ingest item is routed and transformed based on routing scheme and rule "Politics Rule 2"
         """
         {
           "routing_scheme": "#routing_schemes._id#",
-          "ingest": "AFP.121974877.6504909"
+          "ingest": "#AAP.AFP.121974877.6504909#"
         }
         """

--- a/server/features/content_duplication.feature
+++ b/server/features/content_duplication.feature
@@ -46,7 +46,7 @@ Feature: Duplication of Content within Desk
       """
       And empty "archive"
       When we fetch from "reuters" ingest "tag_reuters.com_2014_newsml_KBN0FL0NM"
-      And we post to "/ingest/tag_reuters.com_2014_newsml_KBN0FL0NM/fetch"
+      And we post to "/ingest/#reuters.tag_reuters.com_2014_newsml_KBN0FL0NM#/fetch" with success
       """
       {
       "desk": "#desks._id#"

--- a/server/features/content_fetch.feature
+++ b/server/features/content_fetch.feature
@@ -32,7 +32,7 @@ Feature: Fetch Items from Ingest
       [{"name": "Sports"}]
       """
       When we fetch from "reuters" ingest "tag_reuters.com_0000_newsml_GM1EA7M13RP01"
-      And we post to "/ingest/tag_reuters.com_0000_newsml_GM1EA7M13RP01/fetch" with success
+      And we post to "/ingest/#reuters.tag_reuters.com_0000_newsml_GM1EA7M13RP01#/fetch" with success
       """
       {
       "desk": "#desks._id#"
@@ -62,7 +62,7 @@ Feature: Fetch Items from Ingest
       [{"name": "Sports"}]
       """
       When we fetch from "reuters" ingest "tag_reuters.com_2014_newsml_KBN0FL0NM"
-      And we post to "/ingest/tag_reuters.com_2014_newsml_KBN0FL0NM/fetch"
+      And we post to "/ingest/#reuters.tag_reuters.com_2014_newsml_KBN0FL0NM#/fetch"
       """
       {
       "desk": "#desks._id#"
@@ -169,7 +169,7 @@ Feature: Fetch Items from Ingest
       """
       Then we get error 404
       """
-      {"_message": "Fail to found ingest item with guid: invalid_id", "_status": "ERR"}
+      {"_message": "Fail to found ingest item with _id: invalid_id", "_status": "ERR"}
       """
 
     @auth

--- a/server/features/content_publish.feature
+++ b/server/features/content_publish.feature
@@ -58,7 +58,7 @@ Feature: Content Publishing
         [{"name": "Sports"}]
         """
     	When we fetch from "reuters" ingest "tag_reuters.com_2014_newsml_KBN0FL0NM"
-        And we post to "/ingest/tag_reuters.com_2014_newsml_KBN0FL0NM/fetch"
+        And we post to "/ingest/#reuters.tag_reuters.com_2014_newsml_KBN0FL0NM#/fetch"
         """
         {
         "desk": "#desks._id#"

--- a/server/features/ingest.feature
+++ b/server/features/ingest.feature
@@ -45,13 +45,13 @@ Feature: Fetch From Ingest
                     "groups": [
                         {
                             "refs": [
-                                {"itemClass": "icls:text", "residRef": "tag_reuters.com_2014_newsml_KBN0FL0NN"},
-                                {"itemClass": "icls:picture", "residRef": "tag_reuters.com_2014_newsml_LYNXMPEA6F13M"},
-                                {"itemClass": "icls:picture", "residRef": "tag_reuters.com_2014_newsml_LYNXMPEA6F0MS"},
-                                {"itemClass": "icls:picture", "residRef": "tag_reuters.com_2014_newsml_LYNXMPEA6F0MT"}
+                                {"itemClass": "icls:text", "guid": "tag_reuters.com_2014_newsml_KBN0FL0NN"},
+                                {"itemClass": "icls:picture", "guid": "tag_reuters.com_2014_newsml_LYNXMPEA6F13M"},
+                                {"itemClass": "icls:picture", "guid": "tag_reuters.com_2014_newsml_LYNXMPEA6F0MS"},
+                                {"itemClass": "icls:picture", "guid": "tag_reuters.com_2014_newsml_LYNXMPEA6F0MT"}
                             ]
                         },
-                        {"refs": [{"itemClass": "icls:text", "residRef": "tag_reuters.com_2014_newsml_KBN0FL0ZP"}]}
+                        {"refs": [{"itemClass": "icls:text", "guid": "tag_reuters.com_2014_newsml_KBN0FL0ZP"}]}
                     ],
                     "guid": "tag_reuters.com_2014_newsml_KBN0FL0NM",
                     "ingest_provider_sequence": "6",
@@ -93,7 +93,7 @@ Feature: Fetch From Ingest
     	Given empty "ingest"
     	When we fetch from "reuters" ingest "tag_reuters.com_2014_newsml_LYNXMPEA6F0MS"
         And we fetch from "AAP" ingest "aap.xml"
-        And we get "/ingest/tag_reuters.com_2014_newsml_LYNXMPEA6F0MS"
+        And we get "/ingest/#reuters.tag_reuters.com_2014_newsml_LYNXMPEA6F0MS#"
         Then we get existing resource
 		"""
 		{
@@ -103,7 +103,7 @@ Feature: Fetch From Ingest
           "ingest_provider_sequence" : "1"
 		}
   		"""
-        When we get "/ingest/AAP.115314987.5417374"
+        When we get "/ingest/#AAP.AAP.115314987.5417374#"
         Then we get existing resource
 		"""
 		{

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -31,7 +31,7 @@ python-dateutil==2.2
 python-magic==0.4.6
 pytz==2014.4
 raven[flask]==5.0.0
-requests==2.3.0
+requests==2.6.0
 simplejson==3.6.5
 six==1.7.3
 statsd==3.0.1

--- a/server/superdesk/io/commands/update_ingest.py
+++ b/server/superdesk/io/commands/update_ingest.py
@@ -29,6 +29,7 @@ from superdesk.upload import url_for_media
 from superdesk.media.media_operations import download_file_from_url, process_file
 from superdesk.media.renditions import generate_renditions
 from superdesk.io.iptc import subject_codes
+from apps.archive.common import generate_guid, GUID_NEWSML, GUID_FIELD
 
 UPDATE_SCHEDULE_DEFAULT = {'minutes': 5}
 LAST_UPDATED = 'last_updated'
@@ -129,7 +130,7 @@ def get_is_idle(providor):
 
 
 def get_task_id(provider):
-    return 'update-ingest-{0}-{1}'.format(provider.get('name'), provider.get('_id'))
+    return 'update-ingest-{0}-{1}'.format(provider.get('name'), provider.get(superdesk.config.ID_FIELD))
 
 
 class UpdateIngest(superdesk.Command):
@@ -167,20 +168,20 @@ def update_provider(provider, rule_set=None, routing_scheme=None):
         stats.incr('ingest.ingested_items', len(items))
         if items:
             update[LAST_ITEM_UPDATE] = utcnow()
-
-    superdesk.get_resource_service('ingest_providers').system_update(provider['_id'], update, provider)
+    ingest_service = superdesk.get_resource_service('ingest_providers')
+    ingest_service.system_update(provider[superdesk.config.ID_FIELD], update, provider)
 
     if LAST_ITEM_UPDATE not in update and get_is_idle(provider):
         notify_and_add_activity(
             ACTIVITY_EVENT,
             'Provider {{name}} has gone strangely quiet. Last activity was on {{last}}',
             resource='ingest_providers',
-            user_list=superdesk.get_resource_service('ingest_providers')._get_administrators(),
+            user_list=ingest_service._get_administrators(),
             name=provider.get('name'),
             last=provider[LAST_ITEM_UPDATE].replace(tzinfo=timezone.utc).astimezone(tz=None).strftime("%c"))
 
-    logger.info('Provider {0} updated'.format(provider['_id']))
-    push_notification('ingest:update', provider_id=str(provider['_id']))
+    logger.info('Provider {0} updated'.format(provider[superdesk.config.ID_FIELD]))
+    push_notification('ingest:update', provider_id=str(provider[superdesk.config.ID_FIELD]))
 
 
 def process_anpa_category(item, provider):
@@ -252,9 +253,9 @@ def apply_rule_set(item, provider, rule_set=None):
 
 def ingest_items(items, provider, rule_set=None, routing_scheme=None):
     all_items = filter_expired_items(provider, items)
-    items_dict = {doc['guid']: doc for doc in all_items}
+    items_dict = {doc[GUID_FIELD]: doc for doc in all_items}
     items_in_package = []
-    failed_items = []
+    failed_items = set()
 
     for item in [doc for doc in all_items if doc.get('type') == 'composite']:
         items_in_package = [ref['residRef'] for group in item.get('groups', [])
@@ -262,37 +263,41 @@ def ingest_items(items, provider, rule_set=None, routing_scheme=None):
 
     for item in [doc for doc in all_items if doc.get('type') != 'composite']:
         ingested = ingest_item(item, provider, rule_set,
-                               routing_scheme=routing_scheme if not item['guid'] in items_in_package else None)
+                               routing_scheme=routing_scheme if not item[GUID_FIELD] in items_in_package else None)
         if not ingested:
-            failed_items.append(item['guid'])
+            failed_items.add(item[GUID_FIELD])
 
     for item in [doc for doc in all_items if doc.get('type') == 'composite']:
         for ref in [ref for group in item.get('groups', [])
                     for ref in group.get('refs', []) if 'residRef' in ref]:
             if ref['residRef'] in failed_items:
-                failed_items.append(item['guid'])
+                failed_items.add(item[GUID_FIELD])
                 continue
 
             ref.setdefault('location', 'ingest')
             itemRendition = items_dict.get(ref['residRef'], {}).get('renditions')
             if itemRendition:
                 ref.setdefault('renditions', itemRendition)
-        if item['guid'] in failed_items:
+            ref[GUID_FIELD] = ref['residRef']
+            if items_dict.get(ref['residRef']):
+                ref['residRef'] = items_dict.get(ref['residRef'], {}).get(superdesk.config.ID_FIELD)
+        if item[GUID_FIELD] in failed_items:
             continue
 
         ingested = ingest_item(item, provider, rule_set, routing_scheme)
         if not ingested:
-            failed_items.append(item['guid'])
+            failed_items.add(item[GUID_FIELD])
     if failed_items:
         logger.error('Failed to ingest the following items: %s', failed_items)
+    return failed_items
 
 
 def ingest_item(item, provider, rule_set=None, routing_scheme=None):
     try:
-        item.setdefault('_id', item['guid'])
+        item.setdefault(superdesk.config.ID_FIELD, generate_guid(type=GUID_NEWSML))
         providers[provider.get('type')].provider = provider
 
-        item['ingest_provider'] = str(provider['_id'])
+        item['ingest_provider'] = str(provider[superdesk.config.ID_FIELD])
         item.setdefault('source', provider.get('source', ''))
         set_default_state(item, STATE_INGESTED)
         item['expiry'] = get_expiry_date(provider.get('content_expiry', INGEST_EXPIRY_MINUTES),
@@ -318,10 +323,12 @@ def ingest_item(item, provider, rule_set=None, routing_scheme=None):
                 href = providers[provider.get('type')].prepare_href(baseImageRend['href'])
                 update_renditions(item, href)
 
-        old_item = ingest_service.find_one(_id=item['guid'], req=None)
+        old_item = ingest_service.find_one(guid=item[GUID_FIELD], req=None)
 
         if old_item:
-            ingest_service.put(item['guid'], item)
+            # In case we already have the item, preserve the _id
+            item[superdesk.config.ID_FIELD] = old_item[superdesk.config.ID_FIELD]
+            ingest_service.put(item[superdesk.config.ID_FIELD], item)
         else:
             try:
                 ingest_service.post([item])
@@ -329,8 +336,8 @@ def ingest_item(item, provider, rule_set=None, routing_scheme=None):
                 logger.error("Exception while persisting item in ingest collection", e)
 
         if routing_scheme:
-            superdesk.get_resource_service('routing_schemes')\
-                .apply_routing_scheme(ingest_service.find_one(_id=item['guid'], req=None), provider, routing_scheme)
+            routed = ingest_service.find_one(_id=item[superdesk.config.ID_FIELD], req=None)
+            superdesk.get_resource_service('routing_schemes').apply_routing_scheme(routed, provider, routing_scheme)
     except Exception as ex:
         logger.exception(ex)
         try:


### PR DESCRIPTION
SD-1946 Fetching operation fails on recently ingested items with Post 404 not found code

This is a big change in how the system works, summary of changes:
- all the items will have an `_id` generated that is going to be different from `guid`, this is because `guid` is not always suited to be used inside URL's
- we won't be able to use `_id` and `guid` interchangeably which is a good thing IMO, we shouldn't rely on this at all, I've updated the obvious situations, hopefully I fixed all of them

@petrjasek @superdesk/developers @sivakuna-aap @akintolga @marwoodandrew @mdhaman 