### PR TITLE
auth.js: use regex instead of comparing location path and route path

### DIFF
--- a/client/app/scripts/superdesk/auth/auth.js
+++ b/client/app/scripts/superdesk/auth/auth.js
@@ -131,7 +131,7 @@ define([
 
             // prevent routing when there is no token
             $rootScope.$on('$locationChangeStart', function (e) {
-                $rootScope.requiredLogin = requiresLogin($route.routes[$location.path()]);
+                $rootScope.requiredLogin = requiresLogin($location.path());
                 if (!session.token && $rootScope.requiredLogin) {
                     session.getIdentity().then(function() {
                         $http.defaults.headers.common.Authorization = session.token;
@@ -140,8 +140,15 @@ define([
                 }
             });
 
-            function requiresLogin(route) {
-                return route ? route.auth : false;
+            function requiresLogin(url) {
+                var routes = _.values($route.routes);
+                for (var i = routes.length - 1; i >= 0; i--) {
+                    if (routes[i].regexp.test(url)) {
+                        return routes[i].auth;
+                    }
+                }
+                return false;
             }
+
         }]);
 });


### PR DESCRIPTION
When `$location.path` contains variables (id or parameters),
requiresLogin() can't return the `auth` status.
So here I am using the regex provided by `$route` to test if a route match the `$location.path`.
Then we retrieve the `auth` status or `false` if not found.