### PR TITLE
[SD-1328] - Automatically close ingest channel after critical error

### DIFF
--- a/client/app/scripts/superdesk-ingest/module.js
+++ b/client/app/scripts/superdesk-ingest/module.js
@@ -421,7 +421,7 @@ define([
                         }
                     );
 
-                    fetchSourceErrors(provider.source);
+                    fetchSourceErrors(provider.type);
                 };
 
                 $scope.cancel = function() {

--- a/client/app/scripts/superdesk-ingest/module.js
+++ b/client/app/scripts/superdesk-ingest/module.js
@@ -342,6 +342,14 @@ define([
                         });
                 }
 
+                function fetchSourceErrors(source_type) {
+                    return api('ingest_errors').query({'source_type': source_type})
+                        .then(function(result) {
+                            $scope.provider.source_errors = result._items[0].source_errors;
+                            $scope.provider.all_errors = result._items[0].all_errors;
+                        });
+                }
+
                 function openProviderModal() {
                     var provider_id = $location.search()._id;
                     var provider;
@@ -412,6 +420,8 @@ define([
                             return !(fieldName in aliasObj);
                         }
                     );
+
+                    fetchSourceErrors(provider.source);
                 };
 
                 $scope.cancel = function() {
@@ -519,6 +529,8 @@ define([
                     });
 
                     $scope.provider.config.field_aliases = newAliases;
+                    delete $scope.provider.all_errors;
+                    delete $scope.provider.source_errors;
 
                     api.ingestProviders.save($scope.origProvider, $scope.provider)
                     .then(function() {

--- a/client/app/scripts/superdesk-ingest/views/settings/ingest-sources-content.html
+++ b/client/app/scripts/superdesk-ingest/views/settings/ingest-sources-content.html
@@ -127,6 +127,21 @@
                             </label>
                         </div>
                     </tab>
+
+                     <tab heading="Critical Errors" class="TabContent">
+                        <div class="content privileges-settings">
+                            <div class="horizontal">
+                                <div class="roles-list">
+                                    <div ng-repeat="(key, val) in provider.source_errors | orderBy:name" class="field">
+                                        <label>
+                                            {{key}}: {{val}}
+                                            <span sd-switch ng-model="provider.critical_errors[key]"></span>
+                                        </label>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </tab>
                 </tabset>
             </fieldset>
         </form>

--- a/server/features/ingest_errors.feature
+++ b/server/features/ingest_errors.feature
@@ -1,4 +1,4 @@
-Feature: Macros
+Feature: Ingest Errors
 
     @auth
     Scenario: Get list of all errors

--- a/server/features/ingest_errors.feature
+++ b/server/features/ingest_errors.feature
@@ -1,0 +1,25 @@
+Feature: Macros
+
+    @auth
+    Scenario: Get list of all errors
+        When we get "/ingest_errors"
+        Then we get list with 1 items
+            """
+            {"_items":[{"all_errors":{"1001":"Message could not be parsed","1002":"Ingest file could not be parsed","1004":"NewsML1 input could not be processed","1006":"NITF input could not be processed","1008":"ZCZC input could not be processed","1009":"IPTC7901 input could not be processed","2004":"Ingest error","4000":"Unknown API ingest error","4001":"API ingest connection has timed out.","4002":"API ingest has too many redirects","4003":"API ingest has request error","4004":"API ingest Unicode Encode Error","4005":"API ingest xml parse error","4006":"API service not found(404) error","4007":"API authorization error","5000":"FTP ingest error","5001":"FTP parser could not be found","6000":"Email authentication failure","6002":"Email ingest error"}}]}
+            """
+
+    @auth
+    Scenario: Get list of all errors for reuters
+        When we get "/ingest_errors?source_type=reuters"
+        Then we get list with 1 items
+            """
+            {"_items":[{"all_errors":{"1001":"Message could not be parsed","1002":"Ingest file could not be parsed"},"source_errors":{"4000":"Unknown API ingest error","4001":"API ingest connection has timed out.","4002":"API ingest has too many redirects","4003":"API ingest has request error","4004":"API ingest Unicode Encode Error","4005":"API ingest xml parse error"}}]}
+            """
+
+    @auth
+    Scenario: Get list of all errors for email
+        When we get "/ingest_errors?source_type=email"
+        Then we get list with 1 items
+            """
+            {"_items":[{"all_errors":{"1001":"Message could not be parsed","1002":"Ingest file could not be parsed"},"source_errors":{"6000":"Email authentication failure","6002":"Email ingest error"}}]}
+            """

--- a/server/features/ingest_provider.feature
+++ b/server/features/ingest_provider.feature
@@ -121,6 +121,29 @@ Feature: Ingest Provider
 
     @auth
     @notification
+    Scenario: Update critical errors for ingest_provider
+        Given "ingest_providers"
+	    """
+        [{
+        "type": "reuters",
+        "name": "reuters 4",
+        "source": "reuters",
+        "is_closed": false,
+        "config": {"username": "foo", "password": "bar"}
+        }]
+	    """
+        When we patch "/ingest_providers/#ingest_providers._id#"
+        """
+        {"critical_errors":{"6000":true, "6001":true}}
+        """
+        Then we get updated response
+        """
+        {"critical_errors":{"6000":true, "6001":true}}
+        """
+
+
+    @auth
+    @notification
     Scenario: Open/Close ingest_provider
         Given "ingest_providers"
 	    """

--- a/server/superdesk/errors.py
+++ b/server/superdesk/errors.py
@@ -151,10 +151,11 @@ class SuperdeskIngestError(SuperdeskError):
                                  name=self.provider_name,
                                  provider_id=provider.get('_id', ''))
 
-        if provider:
-            logger.error("{}: {} on channel {}".format(self, exception, self.provider_name))
-        else:
-            logger.error("{}: {}".format(self, exception))
+        if exception:
+            if provider:
+                logger.error("{}: {} on channel {}".format(self, exception, self.provider_name))
+            else:
+                logger.error("{}: {}".format(self, exception))
 
     def get_error_description(self):
         return self.code, self._codes[self.code]

--- a/server/superdesk/errors.py
+++ b/server/superdesk/errors.py
@@ -151,7 +151,6 @@ class SuperdeskIngestError(SuperdeskError):
                                  name=self.provider_name,
                                  provider_id=provider.get('_id', ''))
 
-        if exception:
             if provider:
                 logger.error("{}: {} on channel {}".format(self, exception, self.provider_name))
             else:
@@ -173,31 +172,31 @@ class ProviderError(SuperdeskIngestError):
     }
 
     @classmethod
-    def providerAddError(cls, exception, provider):
+    def providerAddError(cls, exception=None, provider=None):
         return ProviderError(2001, exception, provider)
 
     @classmethod
-    def expiredContentError(cls, exception, provider):
+    def expiredContentError(cls, exception=None, provider=None):
         return ProviderError(2002, exception, provider)
 
     @classmethod
-    def ruleError(cls, exception, provider):
+    def ruleError(cls, exception=None, provider=None):
         return ProviderError(2003, exception, provider)
 
     @classmethod
-    def ingestError(cls, exception, provider):
+    def ingestError(cls, exception=None, provider=None):
         return ProviderError(2004, exception, provider)
 
     @classmethod
-    def anpaError(cls, exception, provider):
+    def anpaError(cls, exception=None, provider=None):
         return ProviderError(2005, exception, provider)
 
     @classmethod
-    def providerFilterExpiredContentError(cls, exception, provider):
+    def providerFilterExpiredContentError(cls, exception=None, provider=None):
         return ProviderError(2006, exception, provider)
 
     @classmethod
-    def iptcError(cls, exception, provider):
+    def iptcError(cls, exception=None, provider=None):
         return ProviderError(2007, exception, provider)
 
 
@@ -215,43 +214,43 @@ class ParserError(SuperdeskIngestError):
     }
 
     @classmethod
-    def parseMessageError(cls, exception, provider):
+    def parseMessageError(cls, exception=None, provider=None):
         return ParserError(1001, exception, provider)
 
     @classmethod
-    def parseFileError(cls, source, filename, exception, provider):
+    def parseFileError(cls, source=None, filename=None, exception=None, provider=None):
         if source and filename:
             logger.exception("Source Type: {} - File: {} could not be processed".format(source, filename))
         return ParserError(1002, exception, provider)
 
     @classmethod
-    def anpaParseFileError(cls, filename, exception):
+    def anpaParseFileError(cls, filename=None, exception=None):
         if filename:
             logger.exception("File: {} could not be processed".format(filename))
         return ParserError(1003, exception)
 
     @classmethod
-    def newsmlOneParserError(cls, exception, provider):
+    def newsmlOneParserError(cls, exception=None, provider=None):
         return ParserError(1004, exception, provider)
 
     @classmethod
-    def newsmlTwoParserError(cls, exception, provider):
+    def newsmlTwoParserError(cls, exception=None, provider=None):
         return ParserError(1005, exception, provider)
 
     @classmethod
-    def nitfParserError(cls, exception, provider):
+    def nitfParserError(cls, exception=None, provider=None):
         return ParserError(1006, exception, provider)
 
     @classmethod
-    def wennParserError(cls, exception, provider):
+    def wennParserError(cls, exception=None, provider=None):
         return ParserError(1007, exception, provider)
 
     @classmethod
-    def ZCZCParserError(cls, exception, provider):
+    def ZCZCParserError(cls, exception=None, provider=None):
         return ParserError(1008, exception, provider)
 
     @classmethod
-    def IPTC7901ParserError(cls, exception, provider):
+    def IPTC7901ParserError(cls, exception=None, provider=None):
         return ParserError(1009, exception, provider)
 
 
@@ -262,11 +261,11 @@ class IngestFileError(SuperdeskIngestError):
     }
 
     @classmethod
-    def folderCreateError(cls, exception, provider):
+    def folderCreateError(cls, exception=None, provider=None):
         return IngestFileError(3001, exception, provider)
 
     @classmethod
-    def fileMoveError(cls, exception, provider):
+    def fileMoveError(cls, exception=None, provider=None):
         return IngestFileError(3002, exception, provider)
 
 
@@ -283,35 +282,35 @@ class IngestApiError(SuperdeskIngestError):
     }
 
     @classmethod
-    def apiGeneralError(cls, exception, provider):
+    def apiGeneralError(cls, exception=None, provider=None):
         return cls(4000, exception, provider)
 
     @classmethod
-    def apiTimeoutError(cls, exception, provider):
+    def apiTimeoutError(cls, exception=None, provider=None):
         return cls(4001, exception, provider)
 
     @classmethod
-    def apiRedirectError(cls, exception, provider):
+    def apiRedirectError(cls, exception=None, provider=None):
         return cls(4002, exception, provider)
 
     @classmethod
-    def apiRequestError(cls, exception, provider):
+    def apiRequestError(cls, exception=None, provider=None):
         return cls(4003, exception, provider)
 
     @classmethod
-    def apiUnicodeError(cls, exception, provider):
+    def apiUnicodeError(cls, exception=None, provider=None):
         return cls(4004, exception, provider)
 
     @classmethod
-    def apiParseError(cls, exception, provider):
+    def apiParseError(cls, exception=None, provider=None):
         return cls(4005, exception, provider)
 
     @classmethod
-    def apiNotFoundError(cls, exception, provider):
+    def apiNotFoundError(cls, exception=None, provider=None):
         return cls(4006, exception, provider)
 
     @classmethod
-    def apiAuthError(cls, exception, provider):
+    def apiAuthError(cls, exception=None, provider=None):
         return cls(4007, exception, provider)
 
 
@@ -322,11 +321,11 @@ class IngestFtpError(SuperdeskIngestError):
     }
 
     @classmethod
-    def ftpError(cls, exception, provider):
+    def ftpError(cls, exception=None, provider=None):
         return IngestFtpError(5000, exception, provider)
 
     @classmethod
-    def ftpUnknownParserError(cls, exception, provider, filename):
+    def ftpUnknownParserError(cls, exception=None, provider=None, filename=None):
         if provider:
             logger.exception("Provider: {} - File: {} unknown file format. "
                              "Parser couldn't be found.".format(provider.get('name', 'Unknown provider'), filename))
@@ -341,13 +340,13 @@ class IngestEmailError(SuperdeskIngestError):
     }
 
     @classmethod
-    def emailLoginError(cls, exception, provider):
+    def emailLoginError(cls, exception=None, provider=None):
         return IngestEmailError(6000, exception, provider)
 
     @classmethod
-    def emailParseError(cls, exception, provider):
+    def emailParseError(cls, exception=None, provider=None):
         return IngestEmailError(6001, exception, provider)
 
     @classmethod
-    def emailError(cls, exception, provider):
+    def emailError(cls, exception=None, provider=None):
         return IngestEmailError(6002, exception, provider)

--- a/server/superdesk/io/__init__.py
+++ b/server/superdesk/io/__init__.py
@@ -19,6 +19,7 @@ from superdesk.celery_app import celery
 parsers = []
 providers = {}
 allowed_providers = []
+provider_errors = {}
 logger = logging.getLogger(__name__)
 
 from .commands.remove_expired_content import RemoveExpiredContent
@@ -32,10 +33,16 @@ def init_app(app):
     service = IngestProviderService(endpoint_name, backend=superdesk.get_backend())
     IngestProviderResource(endpoint_name, app=app, service=service)
 
+    from .ingest_errors import IngestErrorsService
+    endpoint_name = 'ingest_errors'
+    service = IngestErrorsService(endpoint_name, backend=superdesk.get_backend())
+    IngestProviderResource(endpoint_name, app=app, service=service)
 
-def register_provider(type, provider):
+
+def register_provider(type, provider, errors):
     providers[type] = provider
     allowed_providers.append(type)
+    provider_errors[type] = dict(errors)
 
 
 @celery.task(soft_time_limit=15)

--- a/server/superdesk/io/aap.py
+++ b/server/superdesk/io/aap.py
@@ -24,9 +24,9 @@ from superdesk.errors import ParserError, ProviderError
 
 logger = logging.getLogger(__name__)
 PROVIDER = 'aap'
-errors = [ParserError.nitfParserError(None, None).get_error_description(),
-          ProviderError.ingestError(None, None).get_error_description(),
-          ParserError.parseFileError(None, None, None, None).get_error_description()]
+errors = [ParserError.nitfParserError().get_error_description(),
+          ProviderError.ingestError().get_error_description(),
+          ParserError.parseFileError().get_error_description()]
 
 
 class AAPIngestService(FileIngestService):

--- a/server/superdesk/io/aap.py
+++ b/server/superdesk/io/aap.py
@@ -24,6 +24,9 @@ from superdesk.errors import ParserError, ProviderError
 
 logger = logging.getLogger(__name__)
 PROVIDER = 'aap'
+errors = [ParserError.nitfParserError(None, None).get_error_description(),
+          ProviderError.ingestError(None, None).get_error_description(),
+          ParserError.parseFileError(None, None, None, None).get_error_description()]
 
 
 class AAPIngestService(FileIngestService):
@@ -83,4 +86,4 @@ class AAPIngestService(FileIngestService):
             self.move_file(self.path, filename, provider=provider, success=False)
             raise ParserError.parseFileError('AAP', filename, ex, provider)
 
-register_provider(PROVIDER, AAPIngestService())
+register_provider(PROVIDER, AAPIngestService(), errors)

--- a/server/superdesk/io/afp.py
+++ b/server/superdesk/io/afp.py
@@ -25,8 +25,8 @@ from superdesk.errors import ParserError, ProviderError
 
 logger = logging.getLogger(__name__)
 PROVIDER = 'afp'
-errors = [ParserError.newsmlOneParserError(None, None).get_error_description(),
-          ProviderError.ingestError(None, None).get_error_description()]
+errors = [ParserError.newsmlOneParserError().get_error_description(),
+          ProviderError.ingestError().get_error_description()]
 
 
 class AFPIngestService(FileIngestService):

--- a/server/superdesk/io/afp.py
+++ b/server/superdesk/io/afp.py
@@ -25,6 +25,8 @@ from superdesk.errors import ParserError, ProviderError
 
 logger = logging.getLogger(__name__)
 PROVIDER = 'afp'
+errors = [ParserError.newsmlOneParserError(None, None).get_error_description(),
+          ProviderError.ingestError(None, None).get_error_description()]
 
 
 class AFPIngestService(FileIngestService):
@@ -67,4 +69,4 @@ class AFPIngestService(FileIngestService):
         push_notification('ingest:update')
 
 
-register_provider(PROVIDER, AFPIngestService())
+register_provider(PROVIDER, AFPIngestService(), errors)

--- a/server/superdesk/io/commands/update_ingest_tests.py
+++ b/server/superdesk/io/commands/update_ingest_tests.py
@@ -116,7 +116,23 @@ class UpdateIngestTest(TestCase):
             self.assertFalse(provider.get('is_closed'))
             provider_service = self._get_provider_service(provider)
             provider_service.provider = provider
-            provider_service.close_provider(provider, ProviderError.anpaError(None, None))
+            provider_service.close_provider(provider, ProviderError.anpaError())
+            provider = self._get_provider(provider_name)
+            self.assertTrue(provider.get('is_closed'))
+
+    def test_ingest_provider_calls_close_provider(self):
+        def mock_update(provider):
+            raise ProviderError.anpaError()
+
+        provider_name = 'AAP'
+        with self.app.app_context():
+            provider = self._get_provider(provider_name)
+            self.assertFalse(provider.get('is_closed'))
+            provider_service = self._get_provider_service(provider)
+            provider_service.provider = provider
+            provider_service._update = mock_update
+            with assert_raises(ProviderError):
+                provider_service.update(provider)
             provider = self._get_provider(provider_name)
             self.assertTrue(provider.get('is_closed'))
 

--- a/server/superdesk/io/commands/update_ingest_tests.py
+++ b/server/superdesk/io/commands/update_ingest_tests.py
@@ -109,6 +109,17 @@ class UpdateIngestTest(TestCase):
         ex = error_context.exception
         self.assertTrue(ex.status_code == 500)
 
+    def test_ingest_provider_closed_when_critical_error_raised(self):
+        provider_name = 'AAP'
+        with self.app.app_context():
+            provider = self._get_provider(provider_name)
+            self.assertFalse(provider.get('is_closed'))
+            provider_service = self._get_provider_service(provider)
+            provider_service.provider = provider
+            provider_service.close_provider(provider, ProviderError.anpaError(None, None))
+            provider = self._get_provider(provider_name)
+            self.assertTrue(provider.get('is_closed'))
+
     def test_is_scheduled(self):
         self.assertTrue(ingest.is_scheduled({}), 'run after create')
         self.assertFalse(ingest.is_scheduled({'last_updated': utcnow()}), 'wait default time 5m')

--- a/server/superdesk/io/commands/update_ingest_tests.py
+++ b/server/superdesk/io/commands/update_ingest_tests.py
@@ -17,7 +17,7 @@ from nose.tools import assert_raises
 from superdesk import get_resource_service
 from superdesk.utc import utcnow
 from superdesk.tests import setup
-from superdesk.errors import SuperdeskApiError
+from superdesk.errors import SuperdeskApiError, ProviderError
 from superdesk.io import register_provider
 from superdesk.io.tests import setup_providers, teardown_providers
 from superdesk.io.ingest_service import IngestService
@@ -30,7 +30,7 @@ class TestProviderService(IngestService):
         return []
 
 
-register_provider('test', TestProviderService())
+register_provider('test', TestProviderService(), [ProviderError.anpaError(None, None).get_error_description()])
 
 
 class UpdateIngestTest(TestCase):

--- a/server/superdesk/io/dpa.py
+++ b/server/superdesk/io/dpa.py
@@ -21,8 +21,8 @@ from superdesk.io.iptc7901 import Iptc7901FileParser
 
 logger = logging.getLogger(__name__)
 PROVIDER = 'dpa'
-errors = [ParserError.IPTC7901ParserError(None, None).get_error_description(),
-          ProviderError.ingestError(None, None).get_error_description()]
+errors = [ParserError.IPTC7901ParserError().get_error_description(),
+          ProviderError.ingestError().get_error_description()]
 
 
 class DPAIngestService(FileIngestService):

--- a/server/superdesk/io/dpa.py
+++ b/server/superdesk/io/dpa.py
@@ -21,6 +21,8 @@ from superdesk.io.iptc7901 import Iptc7901FileParser
 
 logger = logging.getLogger(__name__)
 PROVIDER = 'dpa'
+errors = [ParserError.IPTC7901ParserError(None, None).get_error_description(),
+          ProviderError.ingestError(None, None).get_error_description()]
 
 
 class DPAIngestService(FileIngestService):
@@ -59,4 +61,4 @@ class DPAIngestService(FileIngestService):
                 self.move_file(self.path, filename, provider=provider, success=False)
                 raise ProviderError.ingestError(ex, provider)
 
-register_provider(PROVIDER, DPAIngestService())
+register_provider(PROVIDER, DPAIngestService(), errors)

--- a/server/superdesk/io/email.py
+++ b/server/superdesk/io/email.py
@@ -17,8 +17,8 @@ from superdesk.errors import IngestEmailError
 from superdesk.io.rfc822 import rfc822Parser
 
 PROVIDER = 'email'
-errors = [IngestEmailError.emailError(None, None).get_error_description(),
-          IngestEmailError.emailLoginError(None, None).get_error_description()]
+errors = [IngestEmailError.emailError().get_error_description(),
+          IngestEmailError.emailLoginError().get_error_description()]
 
 
 class EmailReaderService(IngestService):

--- a/server/superdesk/io/email.py
+++ b/server/superdesk/io/email.py
@@ -17,6 +17,8 @@ from superdesk.errors import IngestEmailError
 from superdesk.io.rfc822 import rfc822Parser
 
 PROVIDER = 'email'
+errors = [IngestEmailError.emailError(None, None).get_error_description(),
+          IngestEmailError.emailLoginError(None, None).get_error_description()]
 
 
 class EmailReaderService(IngestService):
@@ -57,4 +59,4 @@ class EmailReaderService(IngestService):
     def prepare_href(self, href):
         return url_for_media(href)
 
-register_provider(PROVIDER, EmailReaderService())
+register_provider(PROVIDER, EmailReaderService(), errors)

--- a/server/superdesk/io/ftp.py
+++ b/server/superdesk/io/ftp.py
@@ -18,8 +18,8 @@ from superdesk.etree import etree
 from superdesk.io import get_xml_parser, register_provider
 from .ingest_service import IngestService
 from superdesk.errors import IngestFtpError
-errors = [IngestFtpError.ftpUnknownParserError(None, None, None).get_error_description(),
-          IngestFtpError.ftpError(None, None).get_error_description()]
+errors = [IngestFtpError.ftpUnknownParserError().get_error_description(),
+          IngestFtpError.ftpError().get_error_description()]
 
 try:
     from urllib.parse import urlparse

--- a/server/superdesk/io/ftp.py
+++ b/server/superdesk/io/ftp.py
@@ -18,6 +18,8 @@ from superdesk.etree import etree
 from superdesk.io import get_xml_parser, register_provider
 from .ingest_service import IngestService
 from superdesk.errors import IngestFtpError
+errors = [IngestFtpError.ftpUnknownParserError(None, None, None).get_error_description(),
+          IngestFtpError.ftpError(None, None).get_error_description()]
 
 try:
     from urllib.parse import urlparse
@@ -95,4 +97,4 @@ class FTPService(IngestService):
         except Exception as ex:
             raise IngestFtpError.ftpError(ex, provider)
 
-register_provider('ftp', FTPService())
+register_provider('ftp', FTPService(), errors)

--- a/server/superdesk/io/ingest_errors.py
+++ b/server/superdesk/io/ingest_errors.py
@@ -19,14 +19,11 @@ logger = logging.getLogger(__name__)
 class IngestErrorsService(superdesk.Service):
     def get(self, req, lookup):
         """Return all ingest errors."""
-        try:
-            source_type = getattr(req, 'args', {}).get('source_type')
-            if source_type:
-                return ListCursor([self.get_errors_by_source_type(source_type)])
-            else:
-                return ListCursor([self.get_all_errors()])
-        except Exception as ex:
-            print(ex)
+        source_type = getattr(req, 'args', {}).get('source_type')
+        if source_type:
+            return ListCursor([self.get_errors_by_source_type(source_type)])
+        else:
+            return ListCursor([self.get_all_errors()])
 
     def get_errors_by_source_type(self, source_type):
         return {'source_errors': provider_errors[source_type.lower()],
@@ -44,9 +41,8 @@ class IngestErrorsService(superdesk.Service):
 
 
 class IngestErrorsResource(superdesk.Resource):
-    resource_methods = ['GET', 'POST']
+    resource_methods = ['GET']
     item_methods = []
-    privileges = {'POST': 'archive'}
 
     schema = {
         'ingest_error': {

--- a/server/superdesk/io/ingest_errors.py
+++ b/server/superdesk/io/ingest_errors.py
@@ -29,7 +29,7 @@ class IngestErrorsService(superdesk.Service):
             print(ex)
 
     def get_errors_by_source_type(self, source_type):
-        return {'source_errors': provider_errors[source_type],
+        return {'source_errors': provider_errors[source_type.lower()],
                 'all_errors': self._get_all_errors()}
 
     def get_all_errors(self):

--- a/server/superdesk/io/ingest_errors.py
+++ b/server/superdesk/io/ingest_errors.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013, 2014 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+import logging
+import superdesk
+from superdesk.io import provider_errors
+from superdesk.utils import ListCursor
+
+logger = logging.getLogger(__name__)
+
+
+class IngestErrorsService(superdesk.Service):
+    def get(self, req, lookup):
+        """Return all ingest errors."""
+        try:
+            source_type = getattr(req, 'args', {}).get('source_type')
+            if source_type:
+                return ListCursor([self.get_errors_by_source_type(source_type)])
+            else:
+                return ListCursor([self.get_all_errors()])
+        except Exception as ex:
+            print(ex)
+
+    def get_errors_by_source_type(self, source_type):
+        return {'source_errors': provider_errors[source_type],
+                'all_errors': self._get_all_errors()}
+
+    def get_all_errors(self):
+        return {'all_errors': self._get_all_errors()}
+
+    def _get_all_errors(self):
+        all_errors = {}
+        for k, v in provider_errors.items():
+            all_errors.update(v)
+
+        return all_errors
+
+
+class IngestErrorsResource(superdesk.Resource):
+    resource_methods = ['GET', 'POST']
+    item_methods = []
+    privileges = {'POST': 'archive'}
+
+    schema = {
+        'ingest_error': {
+            'type': 'string',
+            'required': True
+        },
+        'source_type': {
+            'type': 'string'
+        },
+    }

--- a/server/superdesk/io/ingest_provider_model.py
+++ b/server/superdesk/io/ingest_provider_model.py
@@ -102,7 +102,10 @@ class IngestProviderResource(Resource):
             }
         },
         'critical_errors': {
-            'type': 'list'
+            'type': 'dict',
+            'keyschema': {
+                'type': 'boolean'
+            }
         }
     }
 

--- a/server/superdesk/io/ingest_provider_model.py
+++ b/server/superdesk/io/ingest_provider_model.py
@@ -100,6 +100,9 @@ class IngestProviderResource(Resource):
                 'opened_at': {'type': 'datetime'},
                 'opened_by': Resource.rel('users', nullable=True)
             }
+        },
+        'critical_errors': {
+            'type': 'list'
         }
     }
 

--- a/server/superdesk/io/reuters.py
+++ b/server/superdesk/io/reuters.py
@@ -28,12 +28,12 @@ from flask import current_app as app
 
 
 PROVIDER = 'reuters'
-errors = [IngestApiError.apiTimeoutError(None, None).get_error_description(),
-          IngestApiError.apiRedirectError(None, None).get_error_description(),
-          IngestApiError.apiRequestError(None, None).get_error_description(),
-          IngestApiError.apiUnicodeError(None, None).get_error_description(),
-          IngestApiError.apiParseError(None, None).get_error_description(),
-          IngestApiError.apiGeneralError(None, None).get_error_description()]
+errors = [IngestApiError.apiTimeoutError().get_error_description(),
+          IngestApiError.apiRedirectError().get_error_description(),
+          IngestApiError.apiRequestError().get_error_description(),
+          IngestApiError.apiUnicodeError().get_error_description(),
+          IngestApiError.apiParseError().get_error_description(),
+          IngestApiError.apiGeneralError().get_error_description()]
 
 
 class ReutersIngestService(IngestService):

--- a/server/superdesk/io/reuters.py
+++ b/server/superdesk/io/reuters.py
@@ -28,6 +28,12 @@ from flask import current_app as app
 
 
 PROVIDER = 'reuters'
+errors = [IngestApiError.apiTimeoutError(None, None).get_error_description(),
+          IngestApiError.apiRedirectError(None, None).get_error_description(),
+          IngestApiError.apiRequestError(None, None).get_error_description(),
+          IngestApiError.apiUnicodeError(None, None).get_error_description(),
+          IngestApiError.apiParseError(None, None).get_error_description(),
+          IngestApiError.apiGeneralError(None, None).get_error_description()]
 
 
 class ReutersIngestService(IngestService):
@@ -130,7 +136,7 @@ class ReutersIngestService(IngestService):
             raise IngestApiError.apiRequestError(ex, self.provider)
         except Exception as error:
             traceback.print_exc()
-            raise IngestApiError(error, self.provider)
+            raise IngestApiError.apiGeneralError(error, self.provider)
 
         if response.status_code == 404:
             raise LookupError('Not found %s' % payload)
@@ -147,7 +153,7 @@ class ReutersIngestService(IngestService):
             raise IngestApiError.apiParseError(error, self.provider)
         except Exception as error:
             traceback.print_exc()
-            raise IngestApiError(error, self.provider)
+            raise IngestApiError.apiGeneralError(error, self.provider)
 
     def get_url(self, endpoint):
         """Get API url for given endpoint."""
@@ -163,4 +169,4 @@ class ReutersIngestService(IngestService):
         return '%s?auth_token=%s' % (new_href, self.get_token())
 
 
-register_provider(PROVIDER, ReutersIngestService())
+register_provider(PROVIDER, ReutersIngestService(), errors)

--- a/server/superdesk/io/rss.py
+++ b/server/superdesk/io/rss.py
@@ -26,10 +26,10 @@ PROVIDER = 'rss'
 
 utcfromtimestamp = datetime.utcfromtimestamp
 
-errors = [IngestApiError.apiAuthError(None, None).get_error_description(),
-          IngestApiError.apiNotFoundError(None, None).get_error_description(),
-          IngestApiError.apiGeneralError(None, None).get_error_description(),
-          ParserError.parseMessageError(None, None).get_error_description()]
+errors = [IngestApiError.apiAuthError().get_error_description(),
+          IngestApiError.apiNotFoundError().get_error_description(),
+          IngestApiError.apiGeneralError().get_error_description(),
+          ParserError.parseMessageError().get_error_description()]
 
 
 class RssIngestService(IngestService):

--- a/server/superdesk/io/rss.py
+++ b/server/superdesk/io/rss.py
@@ -26,6 +26,11 @@ PROVIDER = 'rss'
 
 utcfromtimestamp = datetime.utcfromtimestamp
 
+errors = [IngestApiError.apiAuthError(None, None).get_error_description(),
+          IngestApiError.apiNotFoundError(None, None).get_error_description(),
+          IngestApiError.apiGeneralError(None, None).get_error_description(),
+          ParserError.parseMessageError(None, None).get_error_description()]
+
 
 class RssIngestService(IngestService):
     """Ingest service for providing feeds received in RSS 2.0 format.
@@ -160,4 +165,4 @@ class RssIngestService(IngestService):
         return item
 
 
-register_provider(PROVIDER, RssIngestService())
+register_provider(PROVIDER, RssIngestService(), errors)

--- a/server/superdesk/io/teletype.py
+++ b/server/superdesk/io/teletype.py
@@ -21,9 +21,9 @@ from superdesk.io.zczc import ZCZCParser
 
 logger = logging.getLogger(__name__)
 PROVIDER = 'teletype'
-errors = [ParserError.ZCZCParserError(None, None).get_error_description(),
-          ProviderError.ingestError(None, None).get_error_description(),
-          ParserError.parseFileError(None, None, None, None).get_error_description()]
+errors = [ParserError.ZCZCParserError().get_error_description(),
+          ProviderError.ingestError().get_error_description(),
+          ParserError.parseFileError().get_error_description()]
 
 
 class TeletypeIngestService(FileIngestService):

--- a/server/superdesk/io/teletype.py
+++ b/server/superdesk/io/teletype.py
@@ -21,6 +21,9 @@ from superdesk.io.zczc import ZCZCParser
 
 logger = logging.getLogger(__name__)
 PROVIDER = 'teletype'
+errors = [ParserError.ZCZCParserError(None, None).get_error_description(),
+          ProviderError.ingestError(None, None).get_error_description(),
+          ParserError.parseFileError(None, None, None, None).get_error_description()]
 
 
 class TeletypeIngestService(FileIngestService):
@@ -87,4 +90,4 @@ class TeletypeIngestService(FileIngestService):
             raise ParserError.parseFileError('Teletype', filename, ex, provider)
 
 
-register_provider(PROVIDER, TeletypeIngestService())
+register_provider(PROVIDER, TeletypeIngestService(), errors)

--- a/server/superdesk/io/tests.py
+++ b/server/superdesk/io/tests.py
@@ -38,7 +38,8 @@ def setup_providers(context):
              'config': {'username': app.config['REUTERS_USERNAME'],
                         'password': app.config['REUTERS_PASSWORD']}},
             {'name': 'AAP', 'type': 'aap', 'source': 'AAP Ingest', 'is_closed': False,
-             'config': {'path': os.path.join(os.path.abspath(os.path.dirname(__file__)), 'fixtures')}},
+             'config': {'path': os.path.join(os.path.abspath(os.path.dirname(__file__)), 'fixtures')},
+             'critical_errors': {'2005': True}},
             {'name': 'teletype', 'type': 'teletype', 'source': 'AAP Teletype', 'is_closed': False,
              'config': {'path': os.path.join(os.path.abspath(os.path.dirname(__file__)), 'fixtures')}}
         ]


### PR DESCRIPTION
List of changes for this task:
- A new end point "ingest_errors" to get the list of errors per provider
- Change in provider end point to save the selected critcal errors for that provider
- UI change to have a "critical errors" tab to select the errors that supposed to close the channel
- provider_service catches all SuperdeskIngestErrors and closes the channel if the error code is in the list of critical errors