### PR TITLE
Publish endpoint, publish queue and formatters

### DIFF
--- a/server/apps/archive/archive.py
+++ b/server/apps/archive/archive.py
@@ -99,12 +99,7 @@ class ArchiveResource(Resource):
         'task': {'type': 'dict'},
         'destination_groups': {
             'type': 'list',
-            'schema': {
-                'type': 'dict',
-                'schema': {
-                    'group': Resource.rel('destination_groups', True)
-                }
-            }
+            'schema': Resource.rel('destination_groups', True)
         }
     }
 

--- a/server/apps/duplication/archive_fetch.py
+++ b/server/apps/duplication/archive_fetch.py
@@ -41,12 +41,7 @@ class FetchResource(Resource):
         },
         'destination_groups': {
             'type': 'list',
-            'schema': {
-                'type': 'dict',
-                'schema': {
-                    'group': Resource.rel('destination_groups', True)
-                }
-            }
+            'schema': Resource.rel('destination_groups', True)
         }
     }
 

--- a/server/apps/publish/__init__.py
+++ b/server/apps/publish/__init__.py
@@ -16,6 +16,7 @@ from apps.publish.archive_publish import ArchivePublishResource, ArchivePublishS
 from apps.publish.destination_groups import DestinationGroupsResource, DestinationGroupsService
 from apps.publish.output_channels import OutputChannelsResource, OutputChannelsService
 from apps.publish.subscribers import SubscribersResource, SubscribersService
+from apps.publish.publish_queue import PublishQueueResource, PublishQueueService
 from superdesk import get_backend
 
 logger = logging.getLogger(__name__)
@@ -30,6 +31,10 @@ def init_app(app):
     endpoint_name = 'subscribers'
     service = SubscribersService(endpoint_name, backend=get_backend())
     SubscribersResource(endpoint_name, app=app, service=service)
+
+    endpoint_name = 'publish_queue'
+    service = PublishQueueService(endpoint_name, backend=get_backend())
+    PublishQueueResource(endpoint_name, app=app, service=service)
 
     endpoint_name = 'output_channels'
     service = OutputChannelsService(endpoint_name, backend=get_backend())
@@ -46,3 +51,5 @@ def init_app(app):
                         description='User can manage output channels')
     superdesk.privilege(name='subscribers', label='Subscribers',
                         description='User can manage subscribers')
+    superdesk.privilege(name='publish_queue', label='Publish Queue',
+                        description='User can update publish queue')

--- a/server/apps/publish/archive_publish_tests.py
+++ b/server/apps/publish/archive_publish_tests.py
@@ -12,6 +12,8 @@
 from superdesk.tests import TestCase
 from apps.publish import archive_publish
 from apps.publish import init_app
+from superdesk.utc import utcnow
+from datetime import timedelta
 
 
 class ArchivePublishTestCase(TestCase):
@@ -27,7 +29,7 @@ class ArchivePublishTestCase(TestCase):
                        'delivery_type': 'Email',
                        'config': {'address': 'send@gmail.com'}}]}]
 
-    output_channels = [{'_id': 1, 'name': 'oc1', 'is_active': True, 'format': 'xml', 'destinations': [1]},
+    output_channels = [{'_id': 1, 'name': 'oc1', 'is_active': True, 'format': 'nitf', 'destinations': [1]},
                        {'_id': 2, 'name': 'oc2', 'is_active': False, 'format': 'nitf', 'destinations': [1, 2]},
                        {'_id': 3, 'name': 'oc3', 'is_active': True, 'format': 'anpa', 'destinations': [2]}]
 
@@ -42,7 +44,22 @@ class ArchivePublishTestCase(TestCase):
                            'output_channels': [{'channel': 2, 'selector_codes': ['A']},
                                                {'channel': 3, 'selector_codes': ['X', 'y']}]}]
 
-    articles = [{'_id': 1, 'last_version': 3, 'body_html': 'Test body', 'destination_groups': [4]}]
+    articles = [{'guid': 'tag:localhost:2015:69b961ab-2816-4b8a-a584-a7b402fed4f9',
+                 '_id': 1,
+                 'last_version': 3,
+                 'body_html': 'Test body',
+                 'destination_groups': [4],
+                 'urgency': 4,
+                 'headline': 'Two students missing',
+                 'pubstatus': 'done',
+                 'firstcreated': utcnow(),
+                 'byline': 'By Alan Karben',
+                 'ednote': 'Andrew Marwood contributed to this article',
+                 'dateline': 'Sydney',
+                 'keywords': ['Student', 'Crime', 'Police', 'Missing'],
+                 'subject':[{'qcode': '17004000', 'name': 'Statistics'},
+                            {'qcode': '04001002', 'name': 'Weather'}],
+                 'expiry': utcnow() + timedelta(minutes=20)}]
 
     def setUp(self):
         super().setUp()
@@ -72,8 +89,7 @@ class ArchivePublishTestCase(TestCase):
             self.assertTrue('X' in selector_codes)
             self.assertTrue('B' in selector_codes)
 
-            self.assertEquals(2, len(formatters))
-            self.assertTrue('xml' in formatters)
+            self.assertEquals(1, len(formatters))
             self.assertTrue('nitf' in formatters)
 
     def test_resolve_output_channels_flattened(self):
@@ -90,7 +106,7 @@ class ArchivePublishTestCase(TestCase):
             self.assertTrue('B' in selector_codes)
 
             self.assertEquals(1, len(formatters))
-            self.assertTrue('xml' in formatters)
+            self.assertTrue('nitf' in formatters)
 
     def test_get_subscribers(self):
         with self.app.app_context():

--- a/server/apps/publish/archive_publish_tests.py
+++ b/server/apps/publish/archive_publish_tests.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013, 2014 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+
+from superdesk.tests import TestCase
+from apps.publish import archive_publish
+from apps.publish import init_app
+
+
+class ArchivePublishTestCase(TestCase):
+    subscribers = [{'_id': 1, 'name': 'sub1', 'is_active': True, 'destinations': [{
+                    'name': 'dest1',
+                    'delivery_type': 'ftp',
+                    'config': {'address': '127.0.0.1', 'username': 'test'}}]},
+                   {'_id': 2, 'name': 'sub1', 'is_active': True, 'destinations': [{
+                    'name': 'dest2',
+                    'delivery_type': 'file copy',
+                    'config': {'address': '/share/copy'}}, {
+                       'name': 'dest3',
+                       'delivery_type': 'Email',
+                       'config': {'address': 'send@gmail.com'}}]}]
+
+    output_channels = [{'_id': 1, 'name': 'oc1', 'is_active': True, 'format': 'xml', 'destinations': [1]},
+                       {'_id': 2, 'name': 'oc2', 'is_active': False, 'format': 'nitf', 'destinations': [1, 2]},
+                       {'_id': 3, 'name': 'oc3', 'is_active': True, 'format': 'anpa', 'destinations': [2]}]
+
+    destination_groups = [{'_id': 1, 'name': 'dg1'},
+                          {'_id': 2, 'name': 'dg2', 'destination_groups': [1]},
+                          {'_id': 3, 'name': 'dg3',
+                           'output_channels': [{'channel': 1, 'selector_codes': ['A', 'B']}]},
+                          {'_id': 4, 'name': 'dg4',
+                           'output_channels': [{'channel': 1, 'selector_codes': ['Y']},
+                                               {'channel': 2, 'selector_codes': ['X', 'B']}]},
+                          {'_id': 5, 'name': 'dg5',
+                           'output_channels': [{'channel': 2, 'selector_codes': ['A']},
+                                               {'channel': 3, 'selector_codes': ['X', 'y']}]}]
+
+    articles = [{'_id': 1, 'last_version': 3, 'body_html': 'Test body', 'destination_groups': [4]}]
+
+    def setUp(self):
+        super().setUp()
+        with self.app.app_context():
+            self.app.data.insert('output_channels', self.output_channels)
+            self.app.data.insert('subscribers', self.subscribers)
+            self.app.data.insert('destination_groups', self.destination_groups)
+            self.app.data.insert('archive', self.articles)
+            init_app(self.app)
+
+    def test_resolve_destination_groups(self):
+        with self.app.app_context():
+            resolved_destination_groups = archive_publish.ArchivePublishService().resolve_destination_groups([2])
+            self.assertEquals(2, len(resolved_destination_groups))
+
+    def test_resolve_output_channels(self):
+        with self.app.app_context():
+            resolved_destination_groups = archive_publish.ArchivePublishService().resolve_destination_groups([4])
+            dgs = list(resolved_destination_groups.values())
+            resolved_output_channels, selector_codes, formatters = \
+                archive_publish.ArchivePublishService().resolve_output_channels(dgs)
+            self.assertEquals(2, len(resolved_output_channels))
+            self.assertTrue(2 in resolved_output_channels)
+
+            self.assertEquals(3, len(selector_codes))
+            self.assertTrue('Y' in selector_codes)
+            self.assertTrue('X' in selector_codes)
+            self.assertTrue('B' in selector_codes)
+
+            self.assertEquals(2, len(formatters))
+            self.assertTrue('xml' in formatters)
+            self.assertTrue('nitf' in formatters)
+
+    def test_resolve_output_channels_flattened(self):
+        with self.app.app_context():
+            resolved_destination_groups2 = archive_publish.ArchivePublishService().resolve_destination_groups([3])
+            dgs = list(resolved_destination_groups2.values())
+            resolved_output_channels, selector_codes, formatters = \
+                archive_publish.ArchivePublishService().resolve_output_channels(dgs)
+            self.assertEquals(1, len(resolved_output_channels))
+            self.assertTrue(1 in resolved_output_channels)
+
+            self.assertEquals(2, len(selector_codes))
+            self.assertTrue('A' in selector_codes)
+            self.assertTrue('B' in selector_codes)
+
+            self.assertEquals(1, len(formatters))
+            self.assertTrue('xml' in formatters)
+
+    def test_get_subscribers(self):
+        with self.app.app_context():
+            resolved_destination_groups = archive_publish.ArchivePublishService().resolve_destination_groups([4])
+            dgs = list(resolved_destination_groups.values())
+            resolved_output_channels, selector_codes, formatters = \
+                archive_publish.ArchivePublishService().resolve_output_channels(dgs)
+            subscribers = archive_publish.ArchivePublishService().get_subscribers(resolved_output_channels[1])
+            self.assertEquals(1, subscribers.count())
+
+            subscribers = archive_publish.ArchivePublishService().get_subscribers(resolved_output_channels[2])
+            self.assertEquals(2, subscribers.count())
+
+    def test_queue_transmission(self):
+        with self.app.app_context():
+            queue_items = self.app.data.find('publish_queue', None, None)
+            self.assertEquals(0, queue_items.count())
+            archive_publish.ArchivePublishService().queue_transmission(self.articles[0])
+            queue_items = self.app.data.find('publish_queue', None, None)
+            self.assertEquals(4, queue_items.count())

--- a/server/apps/publish/formatters/__init__.py
+++ b/server/apps/publish/formatters/__init__.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013, 2014 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+import logging
+
+formatters = []
+logger = logging.getLogger(__name__)
+
+
+class FormatterRegistry(type):
+    """Registry metaclass for formatters."""
+
+    def __init__(cls, name, bases, attrs):
+        """Register sub-classes of Formatter class when defined."""
+        super(FormatterRegistry, cls).__init__(name, bases, attrs)
+        if name != 'Formatter':
+            formatters.append(cls())
+
+
+class Formatter(metaclass=FormatterRegistry):
+    """Base Formatter class for all types of Formatters like News ML 1.2, News ML G2, NITF, etc."""
+
+    def format(self, article, provider):
+        """Formats the article and returns the transformed string"""
+        raise NotImplementedError()
+
+    def can_format(self, format_type):
+        """Test if formatter can format for given type."""
+        raise NotImplementedError()
+
+
+def get_formatter(format_type):
+    """Get parser for given xml.
+
+    :param etree: parsed xml
+    """
+    for formatter in formatters:
+        if formatter.can_format(format_type):
+            return formatter
+
+
+import apps.publish.formatters.nitf_formatter  # NOQA

--- a/server/apps/publish/formatters/nitf_formatter.py
+++ b/server/apps/publish/formatters/nitf_formatter.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013, 2014 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+from apps.publish.formatters import Formatter
+from superdesk.errors import FormatterError
+import xml.etree.ElementTree as etree
+from xml.etree.ElementTree import SubElement
+
+
+class NITFFormatter(Formatter):
+    """
+    NITF Formatter
+    """
+    XML_ROOT = '<?xml version="1.0"?><!DOCTYPE nitf SYSTEM "../dtd/nitf-3-2.dtd">'
+
+    def format(self, article, destination):
+        try:
+            nitf = etree.Element("nitf")
+            head = SubElement(nitf, "head")
+            body = SubElement(nitf, "body")
+            body_head = SubElement(body, "body.head")
+            body_content = SubElement(body, "body.content")
+            body_content.text = article['body_html']
+            body_end = SubElement(body, "body.end")
+            etree.Element('doc-id', attrib={'id-string': article['guid']})
+            self.__format_head(article, head)
+            self.__format_body_head(article, body_head)
+            self.__format_body_end(article, body_end)
+            return self.XML_ROOT + str(etree.tostring(nitf))
+        except Exception as ex:
+            raise FormatterError.nitfFormatterError(ex, destination)
+
+    def __format_head(self, article, head):
+        title = SubElement(head, 'title')
+        title.text = article['headline']
+
+        tobject = SubElement(head, 'tobject', {'tobject.type': 'news'})
+        self.__format_subjects(article, tobject)
+
+        docdata = SubElement(head, 'docdata', {'management-status': article['pubstatus']})
+        SubElement(docdata, 'urgency', {'id-string': str(article.get('urgency', ''))})
+        SubElement(docdata, 'date.issue', {'norm': str(article.get('firstcreated', ''))})
+        SubElement(docdata, 'date.expire', {'norm': str(article.get('expiry', ''))})
+
+        self.__format_keywords(article, head)
+
+    def __format_subjects(self, article, tobject):
+        for subject in article.get('subject', []):
+            SubElement(tobject, 'tobject.subject',
+                       {'tobject.subject.refnum': subject['qcode'],
+                        'tobject.subject.matter': subject['name']})
+
+    def __format_keywords(self, article, head):
+        if article.get('keywords'):
+            keylist = SubElement(head, 'key-list')
+            for keyword in article['keywords']:
+                SubElement(keylist, 'keyword', {'key': keyword})
+
+    def __format_body_head(self, article, body_head):
+        hedline = SubElement(body_head, 'hedline')
+        hl1 = SubElement(hedline, 'hl1')
+        hl1.text = article['headline']
+
+        if article.get('byline'):
+            byline = SubElement(body_head, 'byline')
+            byline.text = "By " + article['byline']
+
+        if article.get('dateline'):
+            dateline = SubElement(body_head, 'dateline')
+            dateline.text = article['dateline']
+
+    def __format_body_end(self, article, body_end):
+        if article.get('ednote'):
+            tagline = SubElement(body_end, 'tagline')
+            tagline.text = article['ednote']
+
+    def can_format(self, format_type):
+        return format_type == 'nitf'

--- a/server/apps/publish/publish_queue.py
+++ b/server/apps/publish/publish_queue.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013, 2014 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+import logging
+from superdesk.resource import Resource
+from superdesk.services import BaseService
+from superdesk.utc import utcnow
+
+logger = logging.getLogger(__name__)
+
+
+class PublishQueueResource(Resource):
+    schema = {
+        'item_id': Resource.rel('archive', type='string'),
+        'item_version': {
+            'type': 'string',
+            'nullable': False,
+        },
+        'formatted_item': {
+            'type': 'string',
+            'nullable': False,
+        },
+        'queued_at': {
+            'type': 'datetime'
+        },
+        'completed_at': {
+            'type': 'datetime'
+        },
+        'state': {
+            'type': 'string',
+            'allowed': ['pending', 'in-progress', 'success', 'error'],
+            'nullable': False
+        },
+        'output_channel_id': Resource.rel('output_channels'),
+        'subscriber_id': Resource.rel('subscribers'),
+        'destination': {
+            'type': 'dict',
+            'schema': {
+                'name': {'type': 'string'},
+                'delivery_type': {'type': 'string'},
+                'config': {'type': 'dict'}
+            }
+        }
+    }
+
+    datasource = {'default_sort': [('_created', -1)]}
+    privileges = {'POST': 'publish_queue', 'PATCH': 'publish_queue'}
+
+
+class PublishQueueService(BaseService):
+
+    def on_create(self, docs):
+        for doc in docs:
+            doc['queued_at'] = utcnow()
+            doc['state'] = 'pending'
+
+    def on_update(self, updates, original):
+        pass

--- a/server/apps/rules/routing_rules.py
+++ b/server/apps/rules/routing_rules.py
@@ -57,12 +57,7 @@ class RoutingRuleSchemeResource(Resource):
                                         'macro': {'type': 'string'},
                                         'destination_groups': {
                                             'type': 'list',
-                                            'schema': {
-                                                'type': 'dict',
-                                                'schema': {
-                                                    'group': Resource.rel('destination_groups', True)
-                                                }
-                                            }
+                                            'schema': Resource.rel('destination_groups', True)
                                         }
                                     }
                                 }
@@ -77,12 +72,7 @@ class RoutingRuleSchemeResource(Resource):
                                         'macro': {'type': 'string'},
                                         'destination_groups': {
                                             'type': 'list',
-                                            'schema': {
-                                                'type': 'dict',
-                                                'schema': {
-                                                    'group': Resource.rel('destination_groups', True)
-                                                }
-                                            }
+                                            'schema': Resource.rel('destination_groups', True)
                                         }
                                     }
                                 }

--- a/server/features/auto_routing.feature
+++ b/server/features/auto_routing.feature
@@ -34,10 +34,7 @@ Feature: Auto Routing
                     {
                       "desk": "#desks._id#",
                       "stage": "#desks.incoming_stage#",
-                      "destination_groups": [
-                        {"group": "#dest_groups1#"},
-                        {"group": "#dest_groups2#"}
-                      ]
+                      "destination_groups": ["#dest_groups1#","#dest_groups2#"]
                     }],
                   "exit": false
                 }

--- a/server/features/destination_groups.feature
+++ b/server/features/destination_groups.feature
@@ -60,7 +60,7 @@ Feature:Destination Groups
     """
     [{
       "name":"Group 2", "description": "new stuff",
-      "destination_groups": [{"group":"#destgroup1#"}],
+      "destination_groups": ["#destgroup1#"],
       "output_channels": [{"channel":"#channel1#", "selector_codes": ["PXX", "XYZ"]}]
     }]
     """
@@ -68,7 +68,7 @@ Feature:Destination Groups
     """
     {
       "name":"Group 2", "description": "new stuff",
-      "destination_groups": [{"group":"#destgroup1#"}],
+      "destination_groups": ["#destgroup1#"],
       "output_channels": [{"channel":"#channel1#", "selector_codes": ["PXX", "XYZ"]}]
     }
     """
@@ -126,7 +126,7 @@ Feature:Destination Groups
     """
     [{
       "name":"Group 2", "description": "new stuff",
-      "destination_groups": [{"group":"#destgroup1#"}],
+      "destination_groups": ["#destgroup1#"],
       "output_channels": []
     }]
     """
@@ -134,7 +134,7 @@ Feature:Destination Groups
     """
     {
       "name":"Group 2", "description": "new stuff",
-      "destination_groups": [{"group":"#destgroup1#"}],
+      "destination_groups": ["#destgroup1#"],
       "output_channels": []
     }
     """
@@ -170,7 +170,7 @@ Feature:Destination Groups
     """
     [{
       "name":"Group 2", "description": "new stuff",
-      "destination_groups": [{"group":"#destgroup1#"}],
+      "destination_groups": ["#destgroup1#"],
       "output_channels": []
     }]
     """
@@ -178,7 +178,7 @@ Feature:Destination Groups
     """
     {
       "name":"Group 2", "description": "new stuff",
-      "destination_groups": [{"group":"#destgroup1#"}],
+      "destination_groups": ["#destgroup1#"],
       "output_channels": []
     }
     """
@@ -186,7 +186,7 @@ Feature:Destination Groups
     """
     [{
       "name":"Group 3", "description": "new stuff",
-      "destination_groups": [{"group":"#destgroup2#"}],
+      "destination_groups": ["#destgroup2#"],
       "output_channels": []
     }]
     """
@@ -194,7 +194,7 @@ Feature:Destination Groups
     """
     {
       "name":"Group 3", "description": "new stuff",
-      "destination_groups": [{"group":"#destgroup2#"}],
+      "destination_groups": ["#destgroup2#"],
       "output_channels": []
     }
     """
@@ -202,7 +202,7 @@ Feature:Destination Groups
     """
     {
       "name":"Group 1 testing",
-      "destination_groups": [{"group":"#destgroup2#"}]
+      "destination_groups": ["#destgroup2#"]
     }
     """
     Then we get error 400
@@ -213,7 +213,7 @@ Feature:Destination Groups
     """
     {
       "name":"Group 1 testing",
-      "destination_groups": [{"group":"#destgroup1#"}, {"group": "#destgroup3#"}]
+      "destination_groups": ["#destgroup1#", "#destgroup3#"]
     }
     """
     Then we get error 400
@@ -264,9 +264,9 @@ Feature:Destination Groups
             },
             "actions": {
               "fetch": [{"desk": "#desks._id#", "stage": "#desks.incoming_stage#",
-                        "destination_groups": [{"group": "#destgroup1#"}]}],
+                        "destination_groups": ["#destgroup1#"]}],
               "publish": [{"desk": "#desks._id#", "stage": "#desks.incoming_stage#",
-                        "destination_groups": [{"group": "#destgroup2#"}]}],
+                        "destination_groups": ["#destgroup2#"]}],
               "exit": false
             }
           }
@@ -311,9 +311,8 @@ Feature:Destination Groups
     [
       {
         "guid": "tag:example.com,0000:newsml_BRE9A605",
-        "destination_groups": [
-          {"group": "#destgroup1#"}
-        ], "task" : {"desk": "#sportsdesk#", "user": "#CONTEXT_USER_ID#"}
+        "destination_groups": ["#destgroup1#"],
+        "task" : {"desk": "#sportsdesk#", "user": "#CONTEXT_USER_ID#"}
       }
     ]
     """
@@ -322,9 +321,7 @@ Feature:Destination Groups
     Then we get existing resource
     """
     {"guid": "tag:example.com,0000:newsml_BRE9A605", "state": "draft",
-        "destination_groups": [
-          {"group": "#destgroup1#"}
-        ]
+        "destination_groups": ["#destgroup1#"]
     }
     """
     When we delete "/destination_groups/#destgroup1#"

--- a/server/features/publish_queue.feature
+++ b/server/features/publish_queue.feature
@@ -1,0 +1,127 @@
+
+Feature: Publish Queue
+
+  @auth
+  Scenario: Add a new transmission entry to the queue
+    Given empty "archive"
+    Given empty "output_channels"
+    Given empty "subscribers"
+    When we post to "/archive"
+    """
+    [{"headline": "test"}]
+    """
+    When we post to "/subscribers"
+    """
+    {
+      "name":"Channel 3"
+    }
+    """
+    Then we get latest
+    """
+    {
+      "name":"Channel 3"
+    }
+    """
+    When we post to "/output_channels"
+    """
+    [
+      {
+        "name":"Output Channel", "description": "new stuff",
+        "destinations": ["#subscribers._id#"]
+      }
+    ]
+    """
+    Then we get latest
+    """
+    {
+      "name":"Output Channel"
+    }
+    """
+
+    When we post to "/publish_queue" with success
+    """
+    {
+      "item_id":"#archive._id#","item_version":"2","formatted_item":"This is the formatted item","output_channel_id":"#output_channels._id#","subscriber_id":"#subscribers._id#","destination":{"name":"destination2","delivery_type":"Email","config":{"password":"abc"}}
+    }
+    """
+    And we get "/publish_queue"
+    Then we get list with 1 items
+    """
+    {
+      "_items":
+        [
+          {"formatted_item":"This is the formatted item"}
+        ]
+    }
+    """
+
+  @auth
+  Scenario: Patch a transmission entry
+    Given empty "archive"
+    Given empty "output_channels"
+    Given empty "subscribers"
+    When we post to "/archive"
+    """
+    [{"headline": "test"}]
+    """
+    When we post to "/subscribers"
+    """
+    {
+      "name":"Channel 3"
+    }
+    """
+    Then we get latest
+    """
+    {
+      "name":"Channel 3"
+    }
+    """
+    When we post to "/output_channels"
+    """
+    [
+      {
+        "name":"Output Channel", "description": "new stuff",
+        "destinations": ["#subscribers._id#"]
+      }
+    ]
+    """
+    Then we get latest
+    """
+    {
+      "name":"Output Channel"
+    }
+    """
+
+    When we post to "/publish_queue" with success
+    """
+    {
+      "item_id":"#archive._id#","item_version":"2","formatted_item":"This is the formatted item","output_channel_id":"#output_channels._id#","subscriber_id":"#subscribers._id#","destination":{"name":"destination2","delivery_type":"Email","config":{"password":"abc"}}
+    }
+    """
+    And we get "/publish_queue"
+    Then we get list with 1 items
+    """
+    {
+      "_items":
+        [
+          {"state":"pending"}
+        ]
+    }
+    """
+    When we patch "/publish_queue/#publish_queue._id#"
+    """
+    {
+      "state": "in-progress"
+    }
+    """
+    And we get "/publish_queue"
+    Then we get list with 1 items
+    """
+    {
+      "_items":
+        [
+          {"state":"in-progress"}
+        ]
+    }
+    """
+

--- a/server/features/routing_rules.feature
+++ b/server/features/routing_rules.feature
@@ -38,8 +38,8 @@ Feature: Routing Scheme and Routing Rules
                               "stage": "#desks.incoming_stage#",
                               "macro": "transform",
                               "destination_groups":[
-                                {"group": "#dest_groups1#"},
-                                {"group": "#dest_groups2#"}
+                                "#dest_groups1#",
+                                "#dest_groups2#"
                               ]}]
               }
             }

--- a/server/features/steps/steps.py
+++ b/server/features/steps/steps.py
@@ -1400,7 +1400,7 @@ def validate_routed_item(context, rule_name, is_routed, is_transformed=False):
                 assert item[0]['state'] == state
 
                 if destination.get('destination_groups'):
-                    context_data = [{'group': str(g['group'])} for g in destination.get('destination_groups', [])]
+                    context_data = [str(g) for g in destination.get('destination_groups', [])]
                     response_data = item[0]['destination_groups']
                     assert_equal(json_match(context_data, response_data), True,
                                  msg=str(context_data) + '\n != \n' + str(response_data))


### PR DESCRIPTION
[SD-2052] Publish endpoint
[SD-2053] Publish queue
[SD-2051] NITF Formatter

- Destinations group schema has been re-factored
- Publish endpoint resolves output channels out of destination groups
- When published there are publish queue entries created per destination (transmission)
- There's transformations place holder (yet to be implemented)
- Publish queue end point created
- A basic structure for output formatters
- NITF formatter is implemented
- Initial publish errors are created
- All the tests are in place
