### PR TITLE
[SD-2046] Allow a stage to be marked as a published stage one per desk

### DIFF
--- a/client/app/scripts/superdesk-desks/desks.js
+++ b/client/app/scripts/superdesk-desks/desks.js
@@ -521,6 +521,9 @@
                     fetchCurrentDesk: function() {
                         return api.desks.getById(this.getCurrentDeskId());
                     },
+                    fetchDeskById: function(Id) {
+                        return api.desks.getById(Id);
+                    },
                     setCurrentDesk: function(desk) {
                         this.setCurrentDeskId(desk ? desk._id : null);
                     },
@@ -750,8 +753,8 @@
                 }
             };
         }])
-        .directive('sdDeskeditStages', ['gettext', 'api', 'WizardHandler', 'tasks', '$rootScope',
-            function(gettext, api, WizardHandler, tasks, $rootScope) {
+        .directive('sdDeskeditStages', ['gettext', 'api', 'WizardHandler', 'tasks', '$rootScope', 'desks',
+            function(gettext, api, WizardHandler, tasks, $rootScope, desks) {
             return {
 
                 link: function(scope, elem, attrs) {
@@ -769,18 +772,21 @@
                             scope.stages = [];
                             scope.selected = null;
                             scope.message = null;
+                            scope.getstages(previous);
+                        }
+                    });
 
-                            if (scope.desk.edit && scope.desk.edit._id) {
-                                scope.message = null;
-                                api('stages').query({where: {desk: scope.desk.edit._id}})
+                    scope.getstages = function(previous) {
+                        if (scope.desk.edit && scope.desk.edit._id) {
+                            scope.message = null;
+                            api('stages').query({where: {desk: scope.desk.edit._id}})
                                 .then(function(result) {
                                     scope.stages = result._items;
                                 });
-                            } else {
-                                WizardHandler.wizard('desks').goTo(previous);
-                            }
+                        } else {
+                            WizardHandler.wizard('desks').goTo(previous);
                         }
-                    });
+                    };
 
                     scope.previous = function() {
                         WizardHandler.wizard('desks').previous();
@@ -836,6 +842,10 @@
                                 scope.select(item);
                                 scope.message = null;
                                 broadcastChange();
+                                scope.getstages();
+                                desks.fetchDeskById(item.desk).then(function(desk) {
+                                    scope.desk.edit = desk;
+                                });
                             }, errorMessage);
                         } else {
                             api('stages').save(orig, scope.editStage)
@@ -844,6 +854,10 @@
                                 scope.message = null;
                                 scope.select(item);
                                 broadcastChange();
+                                scope.getstages();
+                                desks.fetchDeskById(item.desk).then(function(desk) {
+                                    scope.desk.edit = desk;
+                                });
                             }, errorMessage);
                         }
                     };
@@ -881,6 +895,9 @@
                             _.remove(scope.stages, stage);
                             scope.message = null;
                             broadcastChange(stage._id);
+                            desks.fetchDeskById(stage.desk).then(function(desk) {
+                                scope.desk.edit = desk;
+                            });
                         }, function(result) {
                             scope.message = gettext('There was a problem, stage was not deleted.');
                         });

--- a/client/app/scripts/superdesk-desks/views/desk-config-modal.html
+++ b/client/app/scripts/superdesk-desks/views/desk-config-modal.html
@@ -111,6 +111,12 @@
 							<label translate>Global Read: <label class="label globalread">
 								{{(selected.is_visible == null || selected.is_visible) ? 'ON' : 'OFF'}}
 							</label></label>
+							<label class="label globalread" ng-if="selected.default_incoming == null || selected.default_incoming">
+								{{:: 'Default incomming stage' }}
+							</label>
+							<label class="label globalread" ng-if="selected.published_stage !== null && selected.published_stage">
+								{{:: 'Published Stage' }}
+							</label>
 							<label translate>Stage description: {{ selected.description}}</label>
 							<div sd-content-expiry data-item="selected" data-preview="true" data-expiryfield="content_expiry"></div>
 						</div>
@@ -120,6 +126,14 @@
 							<div class="field">
 								<label translate>Global Read</label>
 								<span sd-switch ng-model="editStage.is_visible"></span>
+							</div>
+							<div class="field">
+								<label>{{:: 'Default incoming stage' | translate }}</label>
+								<span sd-switch ng-model="editStage.default_incoming"></span>
+							</div>
+							<div class="field">
+								<label>{{:: 'Default published stage' | translate }}</label>
+								<span sd-switch ng-model="editStage.published_stage"></span>
 							</div>
 							<div class="field">
 								<label translate>Stage description</label>

--- a/server/apps/desks.py
+++ b/server/apps/desks.py
@@ -35,6 +35,7 @@ desks_schema = {
         }
     },
     'incoming_stage': Resource.rel('stages', True),
+    'published_stage': Resource.rel('stages', False),
     'spike_expiry': {
         'type': 'integer'
     }

--- a/server/features/stages.feature
+++ b/server/features/stages.feature
@@ -482,3 +482,29 @@ Feature: Stages
 
 
         Then we get 2 visible stages
+
+    @auth
+    Scenario: Set stage as publish stage
+        Given empty "stages"
+        Given empty "desks"
+        Given "desks"
+        """
+        [{"name": "Sports Desk"}]
+        """
+        When we post to "/stages"
+        """
+        {
+        "name": "Publish stage",
+        "task_status": "todo",
+        "desk": "#desks._id#",
+        "published_stage": true
+        }
+        """
+        When we get "/desks/#desks._id#"
+        Then we get existing resource
+        """
+        {
+        "name": "Sports Desk",
+        "published_stage": "#stages._id#"
+        }
+        """


### PR DESCRIPTION
This change allows you to nominate a (only one) stage in a desk as a published stage. The intention is that when an item is published it will be moved to this stage.

I thought it would be nice to be able to change which stage is the default incoming stage as well!