### PR TITLE
Improvements on publishing

### DIFF
--- a/client/app/scripts/superdesk-publish/publish.js
+++ b/client/app/scripts/superdesk-publish/publish.js
@@ -8,13 +8,9 @@
             label: 'FTP',
             templateUrl: 'scripts/superdesk-publish/views/ftp-config.html'
         },
-        teletype: {
-            label: 'Teletype',
-            templateUrl: 'scripts/superdesk-ingest/views/settings/teletypeConfig.html'
-        },
         email: {
             label: 'Email',
-            templateUrl: 'scripts/superdesk-ingest/views/settings/emailConfig.html'
+            templateUrl: 'scripts/superdesk-publish/views/email-config.html'
         }
     });
 

--- a/client/app/scripts/superdesk-publish/views/email-config.html
+++ b/client/app/scripts/superdesk-publish/views/email-config.html
@@ -1,0 +1,6 @@
+<div class="field">
+	<label for="recipients" translate>Recipients</label>
+	<input type="text" id="recipients" placeholder="{{:: 'Recipients'|translate }}"
+      ng-model="destination.config.recipients" required
+      ng-change="$parent.setConfig(provider)">
+</div>

--- a/client/app/scripts/superdesk-publish/views/publish-queue.html
+++ b/client/app/scripts/superdesk-publish/views/publish-queue.html
@@ -1,0 +1,36 @@
+<div class="subnav">
+    <h3 class="page-nav-title" translate>Publish Queue</h3>
+</div>
+<section class="main-section ingest-dashboard">
+	<table class="table">
+		<thead>
+			<tr>
+				<td>Queue Id</td>
+				<td>Article Id</td>
+				<td>Formatted Article Id</td>
+				<td>Output Channel</td>
+				<td>Subscriber</td>
+				<td>Destination</td>
+				<td>Queued At</td>
+				<td>Transmit Started At</td>
+				<td>Transmit Completed At</td>
+				<td>Status</td>
+			</tr>
+		</thead>
+		<tbody>
+			<tr ng-repeat="queue_item in publish_queue" class="{{queue_item.state | queueStatus}}">
+				<td>{{queue_item._id}}</td>
+				<td>{{queue_item.item_id}}</td>
+				<td>{{queue_item.formatted_item_id}}</td>
+				<td>{{outputChannelLookup[queue_item.output_channel_id].name}}</td>
+				<td>{{subscriberLookup[queue_item.subscriber_id].name}}</td>
+				<td>{{queue_item.destination.name}}</td>
+				<td>{{queue_item._created | dateTimeString}}</td>
+				<td>{{queue_item.tdansmit_started_at | dateTimeString}}</td>
+				<td>{{queue_item.completed_at | dateTimeString}}</td>
+				<td>{{queue_item.state}}</td>
+			</tr>
+		</tbody>
+	</table>
+</section>
+

--- a/client/app/scripts/superdesk/filters.js
+++ b/client/app/scripts/superdesk/filters.js
@@ -98,5 +98,16 @@ define([
                     return $filter('date')(input, 'dd.MM.yyyy HH:mm');
                 }
             };
+        }])
+        .filter('queueStatus', ['$filter', function($filter)  {
+            return function(input) {
+                if (input === 'pending') {
+                    return 'warning';
+                } else if (input === 'success') {
+                    return 'success';
+                } else if (input === 'error') {
+                    return 'danger';
+                }
+            };
         }]);
 });

--- a/server/apps/duplication/archive_move.py
+++ b/server/apps/duplication/archive_move.py
@@ -44,42 +44,46 @@ class MoveResource(Resource):
 class MoveService(BaseService):
     def create(self, docs, **kwargs):
         guid_of_item_to_be_moved = request.view_args['guid']
-
         guid_of_moved_items = []
 
         for doc in docs:
-            archive_service = get_resource_service(ARCHIVE)
-
-            archived_doc = archive_service.find_one(req=None, _id=guid_of_item_to_be_moved)
-            if not archived_doc:
-                raise SuperdeskApiError.notFoundError('Fail to found item with guid: %s' %
-                                                      guid_of_item_to_be_moved)
-
-            current_stage_of_item = archived_doc.get('task', {}).get('stage')
-            if current_stage_of_item and str(current_stage_of_item) == str(doc.get('stage')):
-                raise SuperdeskApiError.preconditionFailedError(message='Move is not allowed within the same stage.')
-
-            if not is_workflow_state_transition_valid('submit_to_desk', archived_doc[config.CONTENT_STATE]):
-                raise InvalidStateTransitionError()
-
-            original = dict(archived_doc)
-
-            send_to(archived_doc, doc.get('desk'), doc.get('stage'))
-            archived_doc[config.CONTENT_STATE] = 'submitted'
-            resolve_document_version(archived_doc, ARCHIVE, 'PATCH', original)
-
-            del archived_doc['_id']
-            archive_service.update(original['_id'], archived_doc, original)
-
-            insert_into_versions(guid=original['_id'])
-
-            guid_of_moved_items.append(archived_doc['guid'])
+            guid_of_moved_items.append(self.move_content(guid_of_item_to_be_moved, doc))
 
         return guid_of_moved_items
+
+    def move_content(self, id, doc):
+        archive_service = get_resource_service(ARCHIVE)
+        archived_doc = archive_service.find_one(req=None, _id=id)
+
+        if not archived_doc:
+            raise SuperdeskApiError.notFoundError('Fail to found item with guid: %s' % id)
+
+        current_stage_of_item = archived_doc.get('task', {}).get('stage')
+        if current_stage_of_item and str(current_stage_of_item) == str(doc.get('stage')):
+            raise SuperdeskApiError.preconditionFailedError(message='Move is not allowed within the same stage.')
+
+        if not is_workflow_state_transition_valid('submit_to_desk', archived_doc[config.CONTENT_STATE]):
+            raise InvalidStateTransitionError()
+
+        original = dict(archived_doc)
+
+        send_to(archived_doc, doc.get('desk'), doc.get('stage'))
+
+        if archived_doc[config.CONTENT_STATE] != 'published':
+            archived_doc[config.CONTENT_STATE] = 'submitted'
+
+        resolve_document_version(archived_doc, ARCHIVE, 'PATCH', original)
+
+        del archived_doc['_id']
+        archive_service.update(original['_id'], archived_doc, original)
+
+        insert_into_versions(guid=original['_id'])
+
+        return archived_doc['guid']
 
 
 superdesk.workflow_action(
     name='submit_to_desk',
-    include_states=['draft', 'fetched', 'routed', 'submitted', 'in_progress'],
+    include_states=['draft', 'fetched', 'routed', 'submitted', 'in_progress', 'published'],
     privileges=['archive', 'move']
 )

--- a/server/apps/publish/__init__.py
+++ b/server/apps/publish/__init__.py
@@ -17,6 +17,7 @@ from apps.publish.destination_groups import DestinationGroupsResource, Destinati
 from apps.publish.output_channels import OutputChannelsResource, OutputChannelsService
 from apps.publish.subscribers import SubscribersResource, SubscribersService
 from apps.publish.publish_queue import PublishQueueResource, PublishQueueService
+from apps.publish.formatted_item import FormattedItemResource, FormattedItemService
 from superdesk import get_backend
 
 logger = logging.getLogger(__name__)
@@ -35,6 +36,10 @@ def init_app(app):
     endpoint_name = 'publish_queue'
     service = PublishQueueService(endpoint_name, backend=get_backend())
     PublishQueueResource(endpoint_name, app=app, service=service)
+
+    endpoint_name = 'formatted_item'
+    service = FormattedItemService(endpoint_name, backend=get_backend())
+    FormattedItemResource(endpoint_name, app=app, service=service)
 
     endpoint_name = 'output_channels'
     service = OutputChannelsService(endpoint_name, backend=get_backend())

--- a/server/apps/publish/archive_publish.py
+++ b/server/apps/publish/archive_publish.py
@@ -90,18 +90,23 @@ class ArchivePublishService(BaseService):
                     subscribers = self.get_subscribers(output_channel)
                     if subscribers.count() > 0:
                         formatter = get_formatter(output_channel['format'])
-                        formatted_item = formatter.format(doc, output_channel)
+
+                        formatted_item = {}
+                        formatted_item['formatted_item'] = formatter.format(doc, output_channel)
+                        formatted_item['format'] = output_channel['format']
+                        formatted_item['item_id'] = doc['_id']
+                        formatted_item['item_version'] = doc.get('last_version', 0)
+                        formatted_item_id = get_resource_service('formatted_item').post([formatted_item])[0]
+
                         publish_queue_items = []
 
                         for subscriber in subscribers:
                             for destination in subscriber.get('destinations', []):
                                 publish_queue_item = {}
-                                publish_queue_item['formatted_item'] = formatted_item
-                                publish_queue_item['format'] = output_channel['format']
-                                publish_queue_item['destination'] = destination
                                 publish_queue_item['item_id'] = doc['_id']
-                                publish_queue_item['item_version'] = doc.get('last_version', 0)
+                                publish_queue_item['formatted_item_id'] = formatted_item_id
                                 publish_queue_item['subscriber_id'] = subscriber['_id']
+                                publish_queue_item['destination'] = destination
                                 publish_queue_item['output_channel_id'] = output_channel['_id']
                                 publish_queue_items.append(publish_queue_item)
 

--- a/server/apps/publish/archive_publish.py
+++ b/server/apps/publish/archive_publish.py
@@ -218,7 +218,7 @@ class ArchivePublishService(BaseService):
         desk = get_resource_service('desks').find_one(req=None, _id=doc['task']['desk'])
         if desk.get('published_stage') and doc['task']['stage'] != desk['published_stage']:
             doc['task']['stage'] = desk['published_stage']
-            MoveService().move_content(doc['guid'], doc)
+            MoveService().move_content(doc['_id'], doc)
 
 
 superdesk.workflow_state('published')

--- a/server/apps/publish/archive_publish_tests.py
+++ b/server/apps/publish/archive_publish_tests.py
@@ -31,7 +31,8 @@ class ArchivePublishTestCase(TestCase):
 
     output_channels = [{'_id': 1, 'name': 'oc1', 'is_active': True, 'format': 'nitf', 'destinations': [1]},
                        {'_id': 2, 'name': 'oc2', 'is_active': False, 'format': 'nitf', 'destinations': [1, 2]},
-                       {'_id': 3, 'name': 'oc3', 'is_active': True, 'format': 'anpa', 'destinations': [2]}]
+                       {'_id': 3, 'name': 'oc3', 'is_active': True, 'format': 'anpa', 'destinations': [2]},
+                       {'_id': 4, 'name': 'oc4', 'is_active': True, 'format': 'nitf', 'destinations': [2]}]
 
     destination_groups = [{'_id': 1, 'name': 'dg1'},
                           {'_id': 2, 'name': 'dg2', 'destination_groups': [1]},
@@ -39,7 +40,8 @@ class ArchivePublishTestCase(TestCase):
                            'output_channels': [{'channel': 1, 'selector_codes': ['A', 'B']}]},
                           {'_id': 4, 'name': 'dg4',
                            'output_channels': [{'channel': 1, 'selector_codes': ['Y']},
-                                               {'channel': 2, 'selector_codes': ['X', 'B']}]},
+                                               {'channel': 2, 'selector_codes': ['X', 'B']},
+                                               {'channel': 4}]},
                           {'_id': 5, 'name': 'dg5',
                            'output_channels': [{'channel': 2, 'selector_codes': ['A']},
                                                {'channel': 3, 'selector_codes': ['X', 'y']}]}]
@@ -81,13 +83,14 @@ class ArchivePublishTestCase(TestCase):
             dgs = list(resolved_destination_groups.values())
             resolved_output_channels, selector_codes, formatters = \
                 archive_publish.ArchivePublishService().resolve_output_channels(dgs)
-            self.assertEquals(2, len(resolved_output_channels))
+            self.assertEquals(3, len(resolved_output_channels))
             self.assertTrue(2 in resolved_output_channels)
 
-            self.assertEquals(3, len(selector_codes))
-            self.assertTrue('Y' in selector_codes)
-            self.assertTrue('X' in selector_codes)
-            self.assertTrue('B' in selector_codes)
+            self.assertTrue(1 in selector_codes)
+            self.assertTrue(2 in selector_codes)
+            self.assertTrue('Y' in selector_codes[1])
+            self.assertTrue('X' in selector_codes[2])
+            self.assertTrue('B' in selector_codes[2])
 
             self.assertEquals(1, len(formatters))
             self.assertTrue('nitf' in formatters)
@@ -101,9 +104,9 @@ class ArchivePublishTestCase(TestCase):
             self.assertEquals(1, len(resolved_output_channels))
             self.assertTrue(1 in resolved_output_channels)
 
-            self.assertEquals(2, len(selector_codes))
-            self.assertTrue('A' in selector_codes)
-            self.assertTrue('B' in selector_codes)
+            self.assertTrue(1 in selector_codes)
+            self.assertTrue('A' in selector_codes[1])
+            self.assertTrue('B' in selector_codes[1])
 
             self.assertEquals(1, len(formatters))
             self.assertTrue('nitf' in formatters)
@@ -126,4 +129,4 @@ class ArchivePublishTestCase(TestCase):
             self.assertEquals(0, queue_items.count())
             archive_publish.ArchivePublishService().queue_transmission(self.articles[0])
             queue_items = self.app.data.find('publish_queue', None, None)
-            self.assertEquals(4, queue_items.count())
+            self.assertEquals(6, queue_items.count())

--- a/server/apps/publish/formatted_item.py
+++ b/server/apps/publish/formatted_item.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013, 2014 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+import logging
+from superdesk.resource import Resource
+from superdesk.services import BaseService
+
+logger = logging.getLogger(__name__)
+
+
+class FormattedItemResource(Resource):
+    schema = {
+        'item_id': Resource.rel('archive', type='string'),
+        'item_version': {
+            'type': 'string',
+            'nullable': False,
+        },
+        'formatted_item': {
+            'type': 'string',
+            'nullable': False,
+        },
+        'format': {
+            'type': 'string',
+            'nullable': False,
+        }
+    }
+
+    datasource = {'default_sort': [('_created', -1)]}
+    privileges = {'POST': 'publish_queue', 'PATCH': 'publish_queue'}
+
+
+class FormattedItemService(BaseService):
+    pass

--- a/server/apps/publish/publish_queue.py
+++ b/server/apps/publish/publish_queue.py
@@ -40,6 +40,9 @@ class PublishQueueResource(Resource):
                 'config': {'type': 'dict'}
             }
         },
+        'selector_codes': {
+            'type': 'list'
+        },
         'error_message': {
             'type': 'string'
         }

--- a/server/apps/publish/publish_queue.py
+++ b/server/apps/publish/publish_queue.py
@@ -18,17 +18,7 @@ logger = logging.getLogger(__name__)
 class PublishQueueResource(Resource):
     schema = {
         'item_id': Resource.rel('archive', type='string'),
-        'item_version': {
-            'type': 'string',
-            'nullable': False,
-        },
-        'formatted_item': {
-            'type': 'string',
-            'nullable': False,
-        },
-        'format': {
-            'type': 'string'
-        },
+        'formatted_item_id': Resource.rel('formatted_item', type='string'),
         'transmit_started_at': {
             'type': 'datetime'
         },

--- a/server/features/content_move.feature
+++ b/server/features/content_move.feature
@@ -8,7 +8,7 @@ Feature: Move or Send Content to another desk
         """
         When we post to "archive"
         """
-        [{"type":"text", "headline": "test1", "guid": "123", "state": "draft", "task": {"user": "#CONTEXT_USER_ID#"}}]
+        [{"guid": "123", "type":"text", "headline": "test1", "guid": "123", "state": "draft", "task": {"user": "#CONTEXT_USER_ID#"}}]
         """
         And we post to "/archive/123/move"
         """
@@ -160,10 +160,7 @@ Feature: Move or Send Content to another desk
         """
         [{"desk": "#desks._id#", "stage": "#desks.incoming_stage#"}]
         """
-        Then we get error 412
-        """
-        {"_message": "Workflow transition is invalid.", "_status": "ERR"}
-        """
+        Then we get response code 201
 
     @auth
     Scenario: User can't move content without a privilege

--- a/server/features/content_publish.feature
+++ b/server/features/content_publish.feature
@@ -1,16 +1,52 @@
 Feature: Content Publishing
 
     @auth
-    Scenario: Publish a user content
+    Scenario: Publish a user content and moves to publish stage
+      Given "desks"
+      """
+      [{"name": "Sports"}]
+      """
       Given "archive"
       """
-      [{"headline": "test", "_version": 1, "state": "fetched"}]
+      [{"guid": "123", "headline": "test", "_version": 1, "state": "fetched",
+        "task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#", "user": "#CONTEXT_USER_ID#"}}]
+      """
+
+      When we post to "/stages" with success
+      """
+      [
+        {
+        "name": "another stage",
+        "description": "another stage",
+        "task_status": "in_progress",
+        "desk": "#desks._id#",
+        "published_stage": true
+        }
+      ]
+      """
+      And we publish "#archive._id#"
+      Then we get OK response
+      And we get existing resource
+      """
+      {"_version": 2, "state": "published", "task":{"desk": "#desks._id#", "stage": "#stages._id#"}}
+      """
+
+    @auth
+    Scenario: Publish a user content and stays on the same stage
+      Given "desks"
+      """
+      [{"name": "Sports"}]
+      """
+      Given "archive"
+      """
+      [{"guid": "123", "headline": "test", "_version": 1, "state": "fetched",
+        "task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#", "user": "#CONTEXT_USER_ID#"}}]
       """
       When we publish "#archive._id#"
       Then we get OK response
       And we get existing resource
       """
-      {"_version": 2, "state": "published"}
+      {"_version": 2, "state": "published", "task":{"desk": "#desks._id#", "stage": "#desks.incoming_stage#"}}
       """
 
     @auth
@@ -37,9 +73,14 @@ Feature: Content Publishing
 
     @auth
     Scenario: User can't update a published item
+      Given "desks"
+      """
+      [{"name": "Sports"}]
+      """
       Given "archive"
       """
-      [{"headline": "test", "_version": 1, "state": "fetched"}]
+      [{"guid": "123", "headline": "test", "_version": 1, "state": "fetched",
+        "task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#", "user": "#CONTEXT_USER_ID#"}}]
       """
       When we publish "#archive._id#"
       Then we get OK response

--- a/server/features/formatted_item.feature
+++ b/server/features/formatted_item.feature
@@ -1,0 +1,69 @@
+
+Feature: Formatted Item
+
+  @auth
+  Scenario: Add a new formatted item
+    Given empty "archive"
+    Given empty "output_channels"
+    Given empty "subscribers"
+    When we post to "/archive"
+    """
+    [{"headline": "test"}]
+    """
+    When we post to "/formatted_item" with success
+    """
+    {
+      "item_id":"#archive._id#","item_version":"2","formatted_item":"This is the formatted item","format": "nitf"
+    }
+    """
+    And we get "/formatted_item"
+    Then we get list with 1 items
+    """
+    {
+      "_items":
+        [
+          {"formatted_item":"This is the formatted item"}
+        ]
+    }
+    """
+
+  @auth
+  Scenario: Patch a formatted item
+    Given empty "archive"
+    When we post to "/archive"
+    """
+    [{"headline": "test"}]
+    """
+    When we post to "/formatted_item" with success
+    """
+    {
+      "item_id":"#archive._id#","item_version":"2","formatted_item":"This is the formatted item","format":"nitf"
+    }
+    """
+    And we get "/formatted_item"
+    Then we get list with 1 items
+    """
+    {
+      "_items":
+        [
+          {"format":"nitf"}
+        ]
+    }
+    """
+    When we patch "/formatted_item/#formatted_item._id#"
+    """
+    {
+      "format": "xml"
+    }
+    """
+    And we get "/formatted_item"
+    Then we get list with 1 items
+    """
+    {
+      "_items":
+        [
+          {"format":"xml"}
+        ]
+    }
+    """
+

--- a/server/features/publish_queue.feature
+++ b/server/features/publish_queue.feature
@@ -4,11 +4,24 @@ Feature: Publish Queue
   @auth
   Scenario: Add a new transmission entry to the queue
     Given empty "archive"
+    Given empty "formatted_item"
     Given empty "output_channels"
     Given empty "subscribers"
     When we post to "/archive"
     """
     [{"headline": "test"}]
+    """
+    And we post to "/formatted_item"
+    """
+    {
+      "item_id":"#archive._id#","item_version":"2","formatted_item":"This is the formatted item","format":"nitf"
+    }
+    """
+    Then we get latest
+    """
+    {
+      "format":"nitf"
+    }
     """
     When we post to "/subscribers"
     """
@@ -41,7 +54,7 @@ Feature: Publish Queue
     When we post to "/publish_queue" with success
     """
     {
-      "item_id":"#archive._id#","item_version":"2","formatted_item":"This is the formatted item","output_channel_id":"#output_channels._id#","subscriber_id":"#subscribers._id#","destination":{"name":"destination2","delivery_type":"Email","config":{"password":"abc"}}
+       "item_id":"#archive._id#","formatted_item_id":"#formatted_item._id#","output_channel_id":"#output_channels._id#","subscriber_id":"#subscribers._id#","destination":{"name":"destination2","delivery_type":"Email","config":{"password":"abc"}}
     }
     """
     And we get "/publish_queue"
@@ -50,7 +63,7 @@ Feature: Publish Queue
     {
       "_items":
         [
-          {"formatted_item":"This is the formatted item"}
+          {"destination":{"name":"destination2"}}
         ]
     }
     """
@@ -58,11 +71,24 @@ Feature: Publish Queue
   @auth
   Scenario: Patch a transmission entry
     Given empty "archive"
+    Given empty "formatted_item"
     Given empty "output_channels"
     Given empty "subscribers"
     When we post to "/archive"
     """
     [{"headline": "test"}]
+    """
+    And we post to "/formatted_item"
+    """
+    {
+      "item_id":"#archive._id#","item_version":"2","formatted_item":"This is the formatted item","format":"nitf"
+    }
+    """
+    Then we get latest
+    """
+    {
+      "format":"nitf"
+    }
     """
     When we post to "/subscribers"
     """
@@ -95,7 +121,7 @@ Feature: Publish Queue
     When we post to "/publish_queue" with success
     """
     {
-      "item_id":"#archive._id#","item_version":"2","formatted_item":"This is the formatted item","output_channel_id":"#output_channels._id#","subscriber_id":"#subscribers._id#","destination":{"name":"destination2","delivery_type":"Email","config":{"password":"abc"}}
+      "item_id":"#archive._id#","formatted_item_id":"#formatted_item._id#","output_channel_id":"#output_channels._id#","subscriber_id":"#subscribers._id#","destination":{"name":"destination2","delivery_type":"Email","config":{"password":"abc"}}
     }
     """
     And we get "/publish_queue"

--- a/server/superdesk/errors.py
+++ b/server/superdesk/errors.py
@@ -417,3 +417,18 @@ class PublishFtpError(SuperdeskPublishError):
     @classmethod
     def ftpError(cls, exception=None, provider=None):
         return PublishFtpError(10000, exception, provider)
+
+
+class PublishEmailError(SuperdeskPublishError):
+    _codes = {
+        11000: "Email publish error",
+        11001: "Recipient could not be found for destination"
+    }
+
+    @classmethod
+    def emailError(cls, exception=None, provider=None):
+        return PublishEmailError(11000, exception, provider)
+
+    @classmethod
+    def recipientNotFoundError(cls, exception=None, provider=None):
+        return PublishEmailError(11001, exception, provider)

--- a/server/superdesk/io/ftp_tests.py
+++ b/server/superdesk/io/ftp_tests.py
@@ -30,7 +30,7 @@ class FTPTestCase(unittest.TestCase):
         if 'FTP_URL' not in os.environ:
             return
 
-        config = service.configFromURL(os.environ['FTP_URL'])
+        config = service.config_from_url(os.environ['FTP_URL'])
         self.assertEqual('test', config['path'])
         self.assertEqual('localhost', config['host'])
 

--- a/server/superdesk/publish/__init__.py
+++ b/server/superdesk/publish/__init__.py
@@ -30,3 +30,4 @@ def transmit():
 
 # must be imported for registration
 import superdesk.publish.ftp  # NOQA
+import superdesk.publish.email  # NOQA

--- a/server/superdesk/publish/email.py
+++ b/server/superdesk/publish/email.py
@@ -28,16 +28,16 @@ class EmailPublishService(PublishService):
                 raise PublishEmailError.recipientNotFoundError(LookupError('recipient field not found!'))
 
             admins = app.config['ADMINS']
+            recipients = config.get('recipients').rstrip(';').split(';')
             subject = "Story: {}".format(formatted_item['item_id'])
-            text_body = formatted_item
-            html_body = formatted_item
+            text_body = formatted_item['formatted_item']
 
             # sending email synchronously
             send_email(subject=subject,
                        sender=admins[0],
-                       recipients=config.get('recipients'),
+                       recipients=recipients,
                        text_body=text_body,
-                       html_body=html_body)
+                       html_body=None)
 
         except PublishEmailError:
             raise

--- a/server/superdesk/publish/email.py
+++ b/server/superdesk/publish/email.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013, 2014 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+from superdesk.emails import send_email
+from flask import current_app as app
+from superdesk.publish import register_transmitter
+from superdesk.publish.publish_service import PublishService
+from superdesk.errors import PublishEmailError
+
+errors = [PublishEmailError.emailError().get_error_description()]
+
+
+class EmailPublishService(PublishService):
+    """Email Publish Service."""
+
+    def _transmit(self, formatted_item, subscriber, destination):
+        config = destination.get('config', {})
+
+        try:
+            if not config.get('recipients'):
+                raise PublishEmailError.recipientNotFoundError(LookupError('recipient field not found!'))
+
+            admins = app.config['ADMINS']
+            subject = "Story: {}".format(formatted_item['item_id'])
+            text_body = formatted_item
+            html_body = formatted_item
+
+            # sending email synchronously
+            send_email(subject=subject,
+                       sender=admins[0],
+                       recipients=config.get('recipients'),
+                       text_body=text_body,
+                       html_body=html_body)
+
+        except PublishEmailError:
+            raise
+        except Exception as ex:
+            raise PublishEmailError.emailError(ex, destination)
+
+register_transmitter('email', EmailPublishService(), errors)

--- a/server/superdesk/publish/ftp.py
+++ b/server/superdesk/publish/ftp.py
@@ -37,7 +37,7 @@ class FTPPublishService(PublishService):
             'path': url_parts.path.lstrip('/'),
         }
 
-    def _transmit(self, item, subscriber, destination):
+    def _transmit(self, formatted_item, subscriber, destination):
         config = destination.get('config', {})
 
         try:
@@ -46,8 +46,9 @@ class FTPPublishService(PublishService):
                 ftp.cwd(config.get('path', '').lstrip('/'))
                 ftp.set_pasv(config.get('passive', False))
 
-                filename = '{}.{}'.format(item['item_id'].replace(':', '-'), get_file_extension(item))
-                b = BytesIO(bytes(item['formatted_item'], 'UTF-8'))
+                filename = '{}.{}'.format(formatted_item['item_id'].replace(':', '-'),
+                                          get_file_extension(formatted_item))
+                b = BytesIO(bytes(formatted_item['formatted_item'], 'UTF-8'))
                 ftp.storbinary("STOR " + filename, b)
 
         except PublishFtpError:

--- a/server/superdesk/publish/ftp.py
+++ b/server/superdesk/publish/ftp.py
@@ -22,7 +22,7 @@ except ImportError:
 
 
 class FTPPublishService(PublishService):
-    """FTP Ingest Service."""
+    """FTP Publish Service."""
 
     def config_from_url(self, url):
         """Parse given url into ftp config. Used for tests.

--- a/server/superdesk/publish/publish_content.py
+++ b/server/superdesk/publish/publish_content.py
@@ -79,7 +79,7 @@ def transmit_items(queue_items, subscriber, destination):
             failed_items.append(queue_item)
 
     if len(failed_items) > 0:
-        logger.error('Failed to ingest the following items: %s', str(failed_items))
+        logger.error('Failed to publish the following items: %s', str(failed_items))
 
 
 superdesk.command('publish:transmit', PublishContent())

--- a/server/superdesk/publish/publish_content.py
+++ b/server/superdesk/publish/publish_content.py
@@ -60,19 +60,23 @@ def publish(subscriber, destination):
                                  subscriber[superdesk.config.ID_FIELD])
 
 
-def transmit_items(items, subscriber, destination):
+def transmit_items(queue_items, subscriber, destination):
     failed_items = []
 
-    for item in items:
+    for queue_item in queue_items:
         try:
             # update the status of the item to in-progress
             queue_update = {'state': 'in-progress', 'transmit_started_at': utcnow()}
-            superdesk.get_resource_service('publish_queue').patch(item.get('_id'), queue_update)
+            superdesk.get_resource_service('publish_queue').patch(queue_item.get('_id'), queue_update)
+
+            # get the formatted item
+            formatted_item = superdesk.get_resource_service('formatted_item').\
+                find_one(req=None, _id=queue_item['item_id'])
 
             transmitter = superdesk.publish.transmitters[destination.get('delivery_type')]
-            transmitter.transmit(item, subscriber, destination)
+            transmitter.transmit(queue_item, formatted_item, subscriber, destination)
         except:
-            failed_items.append(item)
+            failed_items.append(queue_item)
 
     if len(failed_items) > 0:
         logger.error('Failed to ingest the following items: %s', str(failed_items))

--- a/server/superdesk/publish/publish_content.py
+++ b/server/superdesk/publish/publish_content.py
@@ -71,7 +71,7 @@ def transmit_items(queue_items, subscriber, destination):
 
             # get the formatted item
             formatted_item = superdesk.get_resource_service('formatted_item').\
-                find_one(req=None, _id=queue_item['item_id'])
+                find_one(req=None, _id=queue_item['formatted_item_id'])
 
             transmitter = superdesk.publish.transmitters[destination.get('delivery_type')]
             transmitter.transmit(queue_item, formatted_item, subscriber, destination)

--- a/server/superdesk/publish/publish_service.py
+++ b/server/superdesk/publish/publish_service.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 class PublishService():
     """Base publish service class."""
 
-    def _transmit(self, queue_item, formatted_item, subscriber, destination):
+    def _transmit(self, formatted_item, subscriber, destination):
         raise NotImplementedError()
 
     def transmit(self, queue_item, formatted_item, subscriber, destination):


### PR DESCRIPTION
Changes for this PR:

- Archive items are formatted per output channel. The same formatted item will be used for many transmissions because output channels usually contains many destinations (transmission). So created a separate end point for formatted items.
- Selector codes are now resolved as per output channel and added to the queue. 
- Created a simple publish queue page to monitor the status of the transmissions.
- Published items will be moved to designated publish stage on the same desk if there's any
- Created an Email transmission