### PR TITLE
[SD-1670] New archive item is deleted if it is closed before it is saved

### DIFF
--- a/client/app/scripts/superdesk-archive/controllers/upload.js
+++ b/client/app/scripts/superdesk-archive/controllers/upload.js
@@ -58,7 +58,6 @@ define(['lodash'], function(_) {
                 item.cssType = item.file.type.split('/')[0];
                 $scope.items.unshift(item);
             });
-            $scope.upload();
         };
 
         $scope.upload = function() {

--- a/client/app/scripts/superdesk-archive/controllers/upload_spec.js
+++ b/client/app/scripts/superdesk-archive/controllers/upload_spec.js
@@ -49,17 +49,22 @@ define(['./upload'], function(UploadController) {
 
             $rootScope.$digest();
 
+            expect(scope.items.length).toBe(1);
+            expect(scope.items[0].file.type).toBe('text/plain');
+            expect(scope.items[0].meta).not.toBe(undefined);
+            expect(scope.items[0].progress).toBe(0);
+
+            scope.items[0].meta.Description = 'test';
+
+            scope.save();
+            $rootScope.$digest();
+
             expect(upload.start).toHaveBeenCalledWith({
                 method: 'POST',
                 url: UPLOAD_URL,
                 data: {media: files[0]},
                 headers: api.archive.getHeaders()
             });
-
-            expect(scope.items.length).toBe(1);
-            expect(scope.items[0].file.type).toBe('text/plain');
-            expect(scope.items[0].meta).not.toBe(undefined);
-            expect(scope.items[0].progress).toBe(0);
 
             upload.defer.notify({
                 total: 100,
@@ -70,10 +75,6 @@ define(['./upload'], function(UploadController) {
 
             expect(scope.items[0].progress).toBe(50);
 
-            scope.items[0].meta.Description = 'test';
-
-            scope.save();
-            $rootScope.$digest();
             upload.defer.resolve({data: {}});
             $rootScope.$digest();
 

--- a/server/apps/archive/archive_lock.py
+++ b/server/apps/archive/archive_lock.py
@@ -62,4 +62,9 @@ class ArchiveUnlockService(BaseService):
         auth = get_auth()
         item_id = request.view_args['item_id']
         item = get_component(ItemLock).unlock({'_id': item_id}, user['_id'], auth['_id'], None)
+
+        if item is None:
+            # version 1 item must have been deleted by now
+            return [0]
+
         return _update_returned_document(docs[0], item)

--- a/server/apps/item_lock/components/item_lock.py
+++ b/server/apps/item_lock/components/item_lock.py
@@ -78,6 +78,12 @@ class ItemLock(BaseComponent):
 
         if can_user_unlock:
             self.app.on_item_unlock(item, user_id)
+
+            # delete the item if nothing is saved so far
+            if item['_version'] == 1 and item['state'] == 'draft':
+                superdesk.get_resource_service('archive').delete(lookup={'_id': item['_id']})
+                return
+
             updates = {LOCK_USER: None, LOCK_SESSION: None, 'lock_time': None, 'force_unlock': True}
             item_model.update(item_filter, updates)
             self.app.on_item_unlocked(item, user_id)

--- a/server/apps/tasks.py
+++ b/server/apps/tasks.py
@@ -135,7 +135,7 @@ class TasksService(BaseService):
         Checks if the content is assigned to a new desk.
         :return: True if the content is being moved to a new desk. False otherwise.
         """
-        return original.get('task', {}).get('desk', '') != str(updates.get('task', {}).get('desk', ''))
+        return original.get('task', {}).get('desk', '') != updates.get('task', {}).get('desk', '')
 
     def __update_state(self, updates, original):
         if self.__is_content_assigned_to_new_desk(original, updates):

--- a/server/apps/users/services.py
+++ b/server/apps/users/services.py
@@ -198,8 +198,12 @@ class UsersService(BaseService):
         items_locked_by_user = archive_service.get(req=None, lookup={'lock_user': user_id})
         if items_locked_by_user and items_locked_by_user.count():
             for item in items_locked_by_user:
-                archive_service.update(item['_id'], doc_to_unlock, item)
-                archive_autosave_service.delete(lookup={'_id': item['_id']})
+                # delete the item if nothing is saved so far
+                if item['_version'] == 1 and item['state'] == 'draft':
+                    get_resource_service('archive').delete(lookup={'_id': item['_id']})
+                else:
+                    archive_service.update(item['_id'], doc_to_unlock, item)
+                    archive_autosave_service.delete(lookup={'_id': item['_id']})
 
     def on_deleted(self, doc):
         """

--- a/server/features/auth.feature
+++ b/server/features/auth.feature
@@ -224,7 +224,7 @@ Feature: Authentication
         """
         Given "archive"
         """
-        [{"_id": "item-1", "guid": "item-1", "headline": "test"}]
+        [{"_id": "item-1", "guid": "item-1", "headline": "test", "_version": 1}]
         """
         When we post to "/archive/item-1/lock"
         """

--- a/server/features/content_lock.feature
+++ b/server/features/content_lock.feature
@@ -22,6 +22,50 @@ Feature: Content Locking
         Then we get OK response
 
     @auth
+    Scenario: Unlocking version 1 draft item deletes the item
+        Given "archive"
+        """
+        [{"_id": "item-1", "guid": "item-1", "headline": "test", "_version": 1, "state": "draft"}]
+        """
+        When we post to "/archive/item-1/lock"
+        """
+        {}
+        """
+        Then we get new resource
+        """
+        {"_id": "item-1", "guid": "item-1", "headline": "test"}
+        """
+
+        When we post to "/archive/item-1/unlock"
+        """
+        {}
+        """
+        And we get "/archive/item-1"
+        Then we get error 404
+
+    @auth
+    Scenario: Unlocking version 1+ item unlockes the item
+        Given "archive"
+        """
+        [{"_id": "item-1", "guid": "item-1", "headline": "test", "_version": 2}]
+        """
+        When we post to "/archive/item-1/lock"
+        """
+        {}
+        """
+        Then we get new resource
+        """
+        {"_id": "item-1", "guid": "item-1", "headline": "test"}
+        """
+
+        When we post to "/archive/item-1/unlock"
+        """
+        {}
+        """
+        And we get "/archive/item-1"
+        Then we get response code 200
+
+    @auth
     Scenario: Fail edit on locked item
         Given "archive"
         """
@@ -69,7 +113,7 @@ Feature: Content Locking
         """
         Given "archive"
         """
-        [{"_id": "item-1", "guid": "item-1", "headline": "test",
+        [{"_id": "item-1", "guid": "item-1", "headline": "test", "_version": 2,
         "task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#", "user": "#CONTEXT_USER_ID#"}}]
         """
         When we post to "/archive/item-1/lock"
@@ -152,7 +196,7 @@ Feature: Content Locking
     Scenario: Force unlock if item is locked in another session
         Given "archive"
         """
-        [{"_id": "item-1", "guid": "item-1", "headline": "test"}]
+        [{"_id": "item-1", "guid": "item-1", "headline": "test", "_version": 2}]
         """
         When we post to "/archive/item-1/lock"
         """


### PR DESCRIPTION
- When a new content item is created, there's an empty record in the archive collection. If that content item is closed by user without making any change (that is still version 1) then the item sits there with no information in it.
- Now if the user closes the newly created item without making any change, system will delete the empty record.
- These type of items will also be deleted on session recycle and log out events as well.
- This PR also addresses the problem in image upload: When user selects an image but then presses cancel button we are left with the empty item. Now when an image is loaded we don't save it until user presses the save button.
- This also solves the issue [SD-2140]