### PR TITLE
Register the public API "packages" app so that the endpoint becomes avai...

### DIFF
--- a/server/publicapi/settings.py
+++ b/server/publicapi/settings.py
@@ -18,6 +18,6 @@ The meaning of configuration options is described in the Eve framework
 
 MONGO_DBNAME = 'publicapi'
 
-INSTALLED_APPS = ['publicapi.items']
+INSTALLED_APPS = ['publicapi.items', 'publicapi.packages']
 
 DOMAIN = {}


### PR DESCRIPTION
Fix: make the `/packages` endpoint publicly available by adding the `publicapi.packages` app to the list of installed applications.