### PR TITLE
(fix) NITF Formatter fails to format when subject doesn't have 'qcode'

### DIFF
--- a/server/apps/publish/archive_publish.py
+++ b/server/apps/publish/archive_publish.py
@@ -24,7 +24,6 @@ from superdesk import get_resource_service
 from apps.archive.archive import ArchiveResource, SOURCE as ARCHIVE
 from superdesk.workflow import is_workflow_state_transition_valid
 from apps.publish.formatters import get_formatter
-from apps.duplication.archive_move import MoveService
 
 
 logger = logging.getLogger(__name__)

--- a/server/apps/publish/archive_publish.py
+++ b/server/apps/publish/archive_publish.py
@@ -224,7 +224,7 @@ class ArchivePublishService(BaseService):
         desk = get_resource_service('desks').find_one(req=None, _id=doc['task']['desk'])
         if desk.get('published_stage') and doc['task']['stage'] != desk['published_stage']:
             doc['task']['stage'] = desk['published_stage']
-            return MoveService().move_content(doc['_id'], doc)['task']
+            return get_resource_service('move').move_content(doc['_id'], doc)['task']
 
 
 superdesk.workflow_state('published')

--- a/server/apps/publish/formatters/nitf_formatter.py
+++ b/server/apps/publish/formatters/nitf_formatter.py
@@ -54,7 +54,7 @@ class NITFFormatter(Formatter):
     def __format_subjects(self, article, tobject):
         for subject in article.get('subject', []):
             SubElement(tobject, 'tobject.subject',
-                       {'tobject.subject.refnum': subject['qcode'],
+                       {'tobject.subject.refnum': subject.get('qcode', ''),
                         'tobject.subject.matter': subject['name']})
 
     def __format_keywords(self, article, head):


### PR DESCRIPTION
Used get_resource_service() instead of MoveService()