### PR TITLE
Add a file with sample NINJS data

### DIFF
--- a/server/publicapi/demo_data/README.md
+++ b/server/publicapi/demo_data/README.md
@@ -1,0 +1,9 @@
+
+To populate the public API database with demo data, run the following command
+in the console (from inside the `publicapi/demo_data` directory):
+
+```sh
+$ mongoimport -h localhost:27017 -d publicapi -c items --drop --jsonArray --file data.json
+```
+
+WARNING: any existing data in the `publicapi.items` collection gets removed.

--- a/server/publicapi/demo_data/data.json
+++ b/server/publicapi/demo_data/data.json
@@ -1,0 +1,483 @@
+{
+    "_id": "tag:demodata.org,0001:ninjs_XYZ123",
+    "uri": "http://new.demodata.org/archive/20150316pic1234",
+    "type": "picture",
+    "version": 3,
+    "versioncreated": "2015-03-16T08:12:00Z",
+    "usageterms": "You can use this photo in any way you want.",
+    "byline": "Andy Catlover",
+    "headline": "Amazing! A very cute fluffy cat!",
+    "description_text": "This is a cute picture of our cat.",
+    "description_xhtml": "<p>This is a <em>cute</em> picture of our cat.</p>",
+    "place": [
+        {"name": "my neighbour's backyard"},
+        {"name": "Berlin"},
+        {"name": "Germany"}
+    ],
+    "located": "Some backyard in one of the many Berlin houses",
+    "renditions": {
+        "main": {
+            "href": "http:/pictures.com/photos/cat-big.jpg",
+            "mimetype": "image/jpg",
+            "title": "Cat Full Resolution",
+            "height": 720,
+            "width": 1050
+        },
+        "small": {
+            "href": "http:/pictures.com/photos/cat-small.jpg",
+            "mimetype": "image/jpg",
+            "title": "Cat Low Resolution",
+            "height": 180,
+            "width": 262
+        }
+    }
+}
+
+{
+    "_id": "tag:demodata.org,0002:ninjs_XYZ123",
+    "uri": "http://new.demodata.org/archive/20130520vid222",
+    "type": "video",
+    "version": 1,
+    "versioncreated": "2013-05-20T11:40:00Z",
+    "usageterms": "May use with writen permission from Red Bull only.",
+    "byline": "Mike the Spike",
+    "headline": "B.A.S.E. jumpers gather in Savoy Alps",
+    "description_text": "Adrenaline junkies preparing for a jump.",
+    "description_xhtml": "<p>Adrenaline junkies preparing for a jump.</p>",
+    "place": [
+        {"name": "Savoy"},
+        {"name": "France"}
+    ],
+    "located": "On top of a big cliff in Savoy Alps, France",
+    "renditions": {
+        "main": {
+            "href": "http:/pictures.com/videos/base_jumpers_savoy.avi",
+            "mimetype": "video/mp4",
+            "title": "Full HD video",
+            "height": 1080,
+            "width": 1920,
+            "sizeinbytes": 36100214
+        }
+    }
+}
+
+{
+    "_id": "tag:demodata.org,0003:ninjs_XYZ123",
+    "uri": "http://ninjs.example.com/newsitems/20150101fgt117",
+    "type": "text",
+    "profile": "text-only",
+    "version": 1,
+    "versioncreated": "2015-01-01T00:00:01Z",
+    "copyrightnotice": "Copyright 2015 Santa & Friends - Free to use for children.",
+    "language": "en",
+    "person": [
+        {
+            "name": "John McWriter",
+            "rel": "author"
+        }
+    ],
+    "organisation": [
+        {"name": "DemoData ltd."}
+    ],
+    "place": [
+        {"name": "London"},
+        {"name": "UK"},
+        {"name": "Europe"}
+    ],
+    "located": "London, UK, Europe",
+    "subject": [
+        {"name": "London", "rel": "about"},
+        {"name": "Holidays", "rel": "about"},
+        {"name": "Entertainment", "rel": "about"}
+    ],
+    "byline": "Santa Claus and John McWriter",
+    "headline": "People in London celebrate New Year",
+    "body_text": "LONDON, UK (DD.org) -- Everybody happily celebrating.",
+    "body_xhtml": "<p>LONDON, UK (DD.org) -- Everybody happily celebrating.</p>"
+}
+
+{
+    "_id": "tag:demodata.org,0004:ninjs_XYZ123",
+    "uri": "http://ninjs.example.com/newsitems/20150101fgt220",
+    "type": "text",
+    "profile": "text-only",
+    "version": 2,
+    "versioncreated": "2015-01-01T01:25:08Z",
+    "copyrightnotice": "Copyright 2015 Santa & Friends - Free to use for children.",
+    "language": "en",
+    "person": [
+        {
+            "name": "John McWriter",
+            "rel": "author"
+        }
+    ],
+    "organisation": [
+        {"name": "DemoData ltd."}
+    ],
+    "place": [
+        {"name": "London"},
+        {"name": "UK"},
+        {"name": "Europe"}
+    ],
+    "located": "London, UK, Europe",
+    "subject": [
+        {"name": "London", "rel": "about"},
+        {"name": "Holidays", "rel": "about"},
+        {"name": "Entertainment", "rel": "about"}
+    ],
+    "byline": "Santa Claus and John McWriter",
+    "headline": "People in UK celebrate New Year",
+    "body_text": "LONDON, UK (DD.org) -- Everybody is celebrating.",
+    "body_xhtml": "<p>LONDON, UK (DD.org) -- Everybody is celebrating.</p>"
+}
+
+{
+    "_id": "tag:demodata.org,0005:ninjs_XYZ123",
+    "uri": "http://ninjs.example.com/newsitems/20150131asd101",
+    "type": "text",
+    "profile": "text-only",
+    "version": 1,
+    "versioncreated": "2015-01-31T12:41:55Z",
+    "copyrightnotice": "Copyright 2015 DemoData ltd., All Rights Reserved.",
+    "language": "en",
+    "person": [
+        {
+            "name": "Donald Banks",
+            "rel": "author"
+        }
+    ],
+    "organisation": [
+        {"name": "DemoData ltd."}
+    ],
+    "place": [
+        {"name": "Paris"},
+        {"name": "France"}
+    ],
+    "located": "Paris city center, France",
+    "subject": [
+        {"name": "France", "rel": "about"},
+        {"name": "Politics", "rel": "about"},
+        {"name": "Daily news", "rel": "about"}
+    ],
+    "byline": "Donald Banks",
+    "headline": "Hollande proposes a new law",
+    "body_text": "PARIS, FR -- At the press conference, there was...",
+    "body_xhtml": "<p>PARIS, FR -- At the press conference, there was...</p>"
+}
+
+{
+    "_id": "tag:demodata.org,0006:ninjs_XYZ123",
+    "uri": "http://ninjs.example.com/newsitems/20141206abc",
+    "type": "text",
+    "profile": "text-only",
+    "version": 1,
+    "versioncreated": "2014-12-06T08:35:25Z",
+    "copyrightnotice": "Copyright 2014 DemoData ltd., All Rights Reserved.",
+    "language": "en",
+    "person": [
+        {
+            "name": "Mister Journalist",
+            "rel": "author"
+        }
+    ],
+    "organisation": [
+        {"name": "DemoData ltd."}
+    ],
+    "place": [
+        {"name": "Berlin"},
+        {"name": "Germany"}
+    ],
+    "located": "Somewhere in Berlin, Germany",
+    "subject": [
+        {"name": "Politics", "rel": "about"},
+        {"name": "Daily news", "rel": "about"}
+    ],
+    "byline": "Mister Journalist & co-workers",
+    "headline": "Merkel says 2014 was 'successful'",
+    "body_text": "BERLIN, DE -- The German Chancellor seemed convinced",
+    "body_xhtml": "<p>BERLIN, DE -- The German Chancellor seemed convinced</p>"
+}
+
+{
+    "_id": "tag:demodata.org,0007:ninjs_XYZ123",
+    "uri": "http://ninjs.example.com/newsitems/20141206abc",
+    "type": "text",
+    "profile": "text-only",
+    "version": 1,
+    "versioncreated": "2014-12-06T08:35:25Z",
+    "copyrightnotice": "Copyright 2014 DemoData ltd., All Rights Reserved.",
+    "language": "en",
+    "person": [
+        {
+            "name": "Mister Journalist",
+            "rel": "author"
+        }
+    ],
+    "organisation": [
+        {"name": "DemoData ltd."}
+    ],
+    "place": [
+        {"name": "Berlin"},
+        {"name": "Germany"}
+    ],
+    "located": "Somewhere in Berlin, Germany",
+    "subject": [
+        {"name": "Politics", "rel": "about"},
+        {"name": "Daily news", "rel": "about"}
+    ],
+    "byline": "Mister Journalist & co-workers",
+    "headline": "Merkel says 2014 was 'successful'",
+    "body_text": "BERLIN, DE -- The German Chancellor seemed convinced",
+    "body_xhtml": "<p>BERLIN, DE -- The German Chancellor seemed convinced</p>"
+}
+
+{
+    "_id": "tag:demodata.org,0008:ninjs_XYZ123",
+    "uri": "http://ninjs.example.com/newsitems/20150502_abc",
+    "type": "text",
+    "profile": "text-only",
+    "version": 1,
+    "versioncreated": "2015-05-02T17:12:39Z",
+    "copyrightnotice": "Free for non-commercial use",
+    "language": "en",
+    "person": [
+        {
+            "name": "Mr. Ice",
+            "rel": "author"
+        }
+    ],
+    "place": [
+        {"name": "Ostrava"},
+        {"name": "Czech Republic"}
+    ],
+    "located": "Ostrava Ice Hockey Hall",
+    "subject": [
+        {"name": "Sports", "rel": "about"},
+        {"name": "Hockey", "rel": "about"}
+    ],
+    "byline": "Mr. Ice",
+    "headline": "USA beats the Finns",
+    "body_text": "OSTRAVA, CZ -- The result was 5:1.",
+    "body_xhtml": "<p>OSTRAVA, CZ -- The result was 5:1.</p>"
+}
+
+{
+    "_id": "tag:demodata.org,0009:ninjs_XYZ123",
+    "uri": "http://ninjs.example.com/newsitems/20150520abc",
+    "type": "text",
+    "profile": "text-only",
+    "version": 1,
+    "versioncreated": "2015-05-20T22:19:10Z",
+    "copyrightnotice": "Ask Surcefabrcic z.ú. for permission",
+    "language": "en",
+    "person": [
+        {
+            "name": "Peter Lamut",
+            "rel": "author"
+        }
+    ],
+    "organisation": [
+        {"name": "Surcefabrcic z.ú."}
+    ],
+    "place": [
+        {"name": "Rijeka"},
+        {"name": "Croatia"}
+    ],
+    "located": "Croatian coast",
+    "subject": [
+        {"name": "Tourism", "rel": "about"}
+    ],
+    "byline": "Peter Lamut",
+    "headline": "API demo content under development",
+    "description_text": "The goal is to provide sample items & packages for testing",
+    "description_xhtml": "<p>The goal is to provide sample items &amp; packages for testing</p>",
+    "body_text": "This body text describes the whole thing.",
+    "body_xhtml": "<p>This body text describes the whole thing.</p>"
+}
+
+{
+    "_id": "tag:demodata.org,0010:ninjs_XYZ123",
+    "uri": "http://ninjs.example.com/newsitems/20150321abc",
+    "type": "text",
+    "profile": "text-only",
+    "version": 1,
+    "versioncreated": "2015-03-21T12:05:49Z",
+    "language": "sl",
+    "person": [
+        {
+            "name": "Peter Lamut",
+            "rel": "author"
+        }
+    ],
+    "organisation": [
+        {"name": "Surcefabrcic z.ú."}
+    ],
+    "place": [
+        {"name": "Ljubljana"},
+        {"name": "Slovenija"}
+    ],
+    "located": "V glavnem mestu Slovenije",
+    "subject": [
+        {"name": "Food", "rel": "about"},
+        {"name": "Foreign News", "rel": "about"}
+    ],
+    "byline": "avtor prispevka je Peter Lamut",
+    "headline": "Peter je šel na odlično kosilo",
+    "description_text": "V gostilni pod Rožnikom so spekli okusne čevapčiče",
+    "body_text": "Kosilo je bilo pripravljeno v 10-ih minutah in to je to.",
+    "body_xhtml": "<p>Kosilo je bilo pripravljeno v 10-ih minutah in to je to.</p>"
+}
+
+{
+    "_id": "tag:demodata.org,0011:ninjs_XYZ123",
+    "uri": "http://ninjs.example.com/stories/20150503_1c",
+    "type": "composite",
+    "profile": "text-photo",
+    "version": 1,
+    "versioncreated": "2015-05-03T07:48:51Z",
+    "copyrightnotice": "Licensed under MIT public license",
+    "language": "en",
+    "person": [
+        {
+            "name": "Vito Corleone",
+            "rel": "about"
+        },
+        {
+            "name": "Franco di Banco",
+            "rel": "author"
+        },
+        {
+            "name": "Photo Grapher jr.",
+            "rel": "photographer"
+        }
+    ],
+    "place": [
+        {"name": "Naples"},
+        {"name": "Italy"}
+    ],
+    "organisation": [
+        {
+            "name": "Mafia Underground inc.",
+            "rel": "about"
+        }
+    ],
+    "subject": [
+        {
+            "name": "Celebrities",
+            "rel": "about"
+        },
+        {
+            "name": "Interviews",
+            "rel": "about"
+        }
+    ],
+    "byline": "Franco di Banco, Photo Grapher jr. and an anonymous mafia source",
+    "located": "Naples, Italy",
+    "headline": "Exclusive interview with the great mafia boss", 
+    "body_text": "Reporter: \"Don Vito Corleone, bongiorno!\", etc.",
+    "body_xhtml": "<b>Reporter:</b> &quot;Don Vito Corleone, bongiorno!&quot;, etc.",
+    "associations": {
+        "mainpic": {
+            "uri": "http://ninjs.example.com/pictures/don_vito.png",
+            "type": "picture",
+            "versioncreated": "2015-04-26T11:50:14Z",
+            "byline": "Photo Grapher jr.",
+            "headline": "Don Vito Corleone in a restaurant", 
+            "description_text": "Mafia boss enjoying red wine at lunch",
+            "description_xhtml": "<p>Mafia boss enjoying red wine at lunch</p>",
+            "renditions": {
+                "main": {
+                    "href": "http://ninjs.example.com/pictures/don_vito.png",
+                    "mimetype": "image/png",
+                    "title": "Original Resolution",
+                    "height": 780,
+                    "width": 965
+                },
+                "small": {
+                    "href": "http://ninjs.example.com/pictures/small/don_vito.png",
+                    "mimetype": "image/png",
+                    "title": "Low Resolution",
+                    "height": 260,
+                    "width": 320
+                }
+            }
+        }
+    }
+}
+
+{
+    "_id": "tag:demodata.org,0012:ninjs_XYZ123",
+    "uri": "http://ninjs.example.com/stories/20140815_ghb",
+    "type": "composite",
+    "profile": "text-photo",
+    "version": 1,
+    "versioncreated": "2014-08-15T11:33:42Z",
+    "copyrightnotice": "Free to use for everyone",
+    "language": "en",
+    "person": [
+        {
+            "name": "Hulk Hogan",
+            "rel": "author"
+        },
+        {
+            "name": "The Phototaker",
+            "rel": "photographer"
+        }
+    ],
+    "place": [
+        {"name": "Bilbao"},
+        {"name": "Spain"}
+    ],
+    "organisation": [
+        {
+            "name": "McDonalds",
+            "rel": "about"
+        }
+    ],
+    "subject": [
+        {
+            "name": "Business",
+            "rel": "about"
+        },
+        {
+            "name": "Economy",
+            "rel": "about"
+        },
+        {
+            "name": "Entertainment",
+            "rel": "about"
+        }
+    ],
+    "byline": "Hulk Hogan, The Undertaker",
+    "located": "Bilbao city center, Spain",
+    "headline": "McDonalds opens its own theme park",
+    "body_text": "Want to try McRide or McGhostHouse?",
+    "body_xhtml": "<p>Want to try <em>McRide</em> or <em>McGhostHouse</em>?</p>",
+    "associations": {
+        "mainpic": {
+            "uri": "http://ninjs.example.com/pictures/mcthemepark.jpg",
+            "type": "picture",
+            "versioncreated": "2014-08-11T09:39:02Z",
+            "byline": "The Phototaker",
+            "headline": "Spain's first McTheme Park, main entrance",
+            "description_text": "Visitors waiting in a queue to visit McTheme Park",
+            "description_xhtml": "<p>Visitors waiting in a queue to visit McTheme Park</p>",
+            "renditions": {
+                "main": {
+                    "href": "http://ninjs.example.com/pictures/mcthemepark_orig.jpg",
+                    "mimetype": "image/jpg",
+                    "title": "Original Resolution",
+                    "height": 900,
+                    "width": 1500
+                },
+                "thumbnail": {
+                    "href": "http://ninjs.example.com/pictures/small/mcthemepark_thumb.jpg",
+                    "mimetype": "image/jpg",
+                    "title": "Thumbnail Size",
+                    "height": 300,
+                    "width": 500
+                }
+            }
+        }
+    }
+}

--- a/server/publicapi/demo_data/data.json
+++ b/server/publicapi/demo_data/data.json
@@ -1,6 +1,5 @@
 {
     "_id": "tag:demodata.org,0001:ninjs_XYZ123",
-    "uri": "http://new.demodata.org/archive/20150316pic1234",
     "type": "picture",
     "version": 3,
     "versioncreated": "2015-03-16T08:12:00Z",
@@ -35,7 +34,6 @@
 
 {
     "_id": "tag:demodata.org,0002:ninjs_XYZ123",
-    "uri": "http://new.demodata.org/archive/20130520vid222",
     "type": "video",
     "version": 1,
     "versioncreated": "2013-05-20T11:40:00Z",
@@ -63,7 +61,6 @@
 
 {
     "_id": "tag:demodata.org,0003:ninjs_XYZ123",
-    "uri": "http://ninjs.example.com/newsitems/20150101fgt117",
     "type": "text",
     "profile": "text-only",
     "version": 1,
@@ -98,7 +95,6 @@
 
 {
     "_id": "tag:demodata.org,0004:ninjs_XYZ123",
-    "uri": "http://ninjs.example.com/newsitems/20150101fgt220",
     "type": "text",
     "profile": "text-only",
     "version": 2,
@@ -133,7 +129,6 @@
 
 {
     "_id": "tag:demodata.org,0005:ninjs_XYZ123",
-    "uri": "http://ninjs.example.com/newsitems/20150131asd101",
     "type": "text",
     "profile": "text-only",
     "version": 1,
@@ -167,7 +162,6 @@
 
 {
     "_id": "tag:demodata.org,0006:ninjs_XYZ123",
-    "uri": "http://ninjs.example.com/newsitems/20141206abc",
     "type": "text",
     "profile": "text-only",
     "version": 1,
@@ -200,7 +194,6 @@
 
 {
     "_id": "tag:demodata.org,0007:ninjs_XYZ123",
-    "uri": "http://ninjs.example.com/newsitems/20141206abc",
     "type": "text",
     "profile": "text-only",
     "version": 1,
@@ -233,7 +226,6 @@
 
 {
     "_id": "tag:demodata.org,0008:ninjs_XYZ123",
-    "uri": "http://ninjs.example.com/newsitems/20150502_abc",
     "type": "text",
     "profile": "text-only",
     "version": 1,
@@ -263,7 +255,6 @@
 
 {
     "_id": "tag:demodata.org,0009:ninjs_XYZ123",
-    "uri": "http://ninjs.example.com/newsitems/20150520abc",
     "type": "text",
     "profile": "text-only",
     "version": 1,
@@ -297,7 +288,6 @@
 
 {
     "_id": "tag:demodata.org,0010:ninjs_XYZ123",
-    "uri": "http://ninjs.example.com/newsitems/20150321abc",
     "type": "text",
     "profile": "text-only",
     "version": 1,
@@ -330,7 +320,6 @@
 
 {
     "_id": "tag:demodata.org,0011:ninjs_XYZ123",
-    "uri": "http://ninjs.example.com/stories/20150503_1c",
     "type": "composite",
     "profile": "text-photo",
     "version": 1,
@@ -378,7 +367,6 @@
     "body_xhtml": "<b>Reporter:</b> &quot;Don Vito Corleone, bongiorno!&quot;, etc.",
     "associations": {
         "mainpic": {
-            "uri": "http://ninjs.example.com/pictures/don_vito.png",
             "type": "picture",
             "versioncreated": "2015-04-26T11:50:14Z",
             "byline": "Photo Grapher jr.",
@@ -407,7 +395,6 @@
 
 {
     "_id": "tag:demodata.org,0012:ninjs_XYZ123",
-    "uri": "http://ninjs.example.com/stories/20140815_ghb",
     "type": "composite",
     "profile": "text-photo",
     "version": 1,
@@ -455,7 +442,6 @@
     "body_xhtml": "<p>Want to try <em>McRide</em> or <em>McGhostHouse</em>?</p>",
     "associations": {
         "mainpic": {
-            "uri": "http://ninjs.example.com/pictures/mcthemepark.jpg",
             "type": "picture",
             "versioncreated": "2014-08-11T09:39:02Z",
             "byline": "The Phototaker",


### PR DESCRIPTION
The file contains data with more variety (item types, authors, creation dates, etc.) for easier testing and development of the public API.

Resolves SD-2198

P.S.: The items' and packages schema differs a bit from the current format we use, because it closely follows the NINJS specification.
P.P.S.: The packages in demo data contain full items, not just the references to them. We might need to change them to only contain links to the contained items (i.e. the `uri` field of each object in the package's `associations` list).