### PR TITLE
fix(auth): reload route when it's a redirect

### DIFF
--- a/client/app/scripts/superdesk/auth/login-modal-directive.js
+++ b/client/app/scripts/superdesk/auth/login-modal-directive.js
@@ -4,8 +4,8 @@ define([], function() {
     /**
      * Login modal is watching session token and displays modal when needed
      */
-    LoginModalDirective.$inject = ['session', 'auth', 'features', 'asset'];
-    function LoginModalDirective(session, auth, features, asset) {
+    LoginModalDirective.$inject = ['session', 'auth', 'features', 'asset', '$route'];
+    function LoginModalDirective(session, auth, features, asset, $route) {
         return {
             replace: true,
             templateUrl: asset.templateUrl('superdesk/auth/login-modal.html'),
@@ -20,6 +20,9 @@ define([], function() {
                         .then(function() {
                             scope.isLoading = false;
                             scope.password = null;
+                            if ($route.current.redirectTo) {
+                                $route.reload();
+                            }
                         }, function(rejection) {
                             scope.isLoading = false;
                             scope.loginError = rejection.status;

--- a/client/app/scripts/superdesk/auth/tests/auth_spec.js
+++ b/client/app/scripts/superdesk/auth/tests/auth_spec.js
@@ -11,4 +11,26 @@ describe('auth', function() {
         $rootScope.$digest();
         expect($location.path()).toBe('/reset-password/');
     }));
+
+    it('can reload a route after login', inject(function($compile, $rootScope, $route, $q, auth) {
+        var elem = $compile('<div sd-login-modal></div>')($rootScope.$new()),
+            scope = elem.scope();
+        $rootScope.$digest();
+        $rootScope.$digest();
+
+        spyOn(auth, 'login').and.returnValue($q.when({}));
+        spyOn($route, 'reload');
+        $route.current = {};
+
+        scope.authenticate();
+        $rootScope.$digest();
+
+        expect($route.reload).not.toHaveBeenCalled();
+
+        $route.current = {redirectTo: '/test'};
+        scope.authenticate();
+        $rootScope.$digest();
+
+        expect($route.reload).toHaveBeenCalled();
+    }));
 });


### PR DESCRIPTION
after session expiry it would stop without an active route so after
login it would continue nowhere.