### PR TITLE
Fix create an administrator user command example

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -102,5 +102,5 @@ This will give you list of available commands.
 This command will create an administrator user.
 
 ```sh
-$ python manage.py users:create -u <username> -p <password> -e <email>
+$ python manage.py users:create -u <username> -p <password> -e <email> -a
 ```


### PR DESCRIPTION
parameter ```a``` was missing