### PR TITLE
Add an option to provide a detailed description to all custom exceptions

### DIFF
--- a/server/superdesk/errors.py
+++ b/server/superdesk/errors.py
@@ -41,12 +41,23 @@ class SuperdeskError(ValidationError):
     _codes = {}
     system_exception = None
 
-    def __init__(self, code):
+    def __init__(self, code, desc=None):
+        """
+        :param int code: numeric error code
+        :param desc: optional detailed error description, defaults to None
+        """
         self.code = code
         self.message = self._codes.get(code, 'Unknown error')
+        self.desc = desc
 
     def __str__(self):
-        return "{} Error {} - {}".format(self.__class__.__name__, self.code, self.message)
+        desc_text = '' if not self.desc else (' Details: ' + self.desc)
+        return "{} Error {} - {}{desc}".format(
+            self.__class__.__name__,
+            self.code,
+            self.message,
+            desc=desc_text
+        )
 
     def get_error_description(self):
         return self.code, self._codes[self.code]

--- a/server/superdesk/errors_test.py
+++ b/server/superdesk/errors_test.py
@@ -15,6 +15,7 @@ from superdesk.tests import TestCase, setup_notification
 from nose.tools import assert_raises
 from superdesk.tests import setup
 import logging
+import unittest
 
 
 class MockLoggingHandler(logging.Handler):
@@ -35,6 +36,55 @@ class MockLoggingHandler(logging.Handler):
             'error': [],
             'critical': [],
         }
+
+
+class SuperdeskErrorTestCase(unittest.TestCase):
+    """Tests for the `superdesk.errors.SuperdeskError` class."""
+
+    def _get_target_class(self):
+        """Return the class under test.
+
+        Make the test fail immediately if the class cannot be imported.
+        """
+        try:
+            from superdesk.errors import SuperdeskError
+        except ImportError:
+            self.fail("Could not import class under test (SuperdeskError).")
+        else:
+            return SuperdeskError
+
+    def test_sets_error_description_to_none_by_default(self):
+        klass = self._get_target_class()
+        instance = klass(1234)
+        self.assertIsNone(instance.desc)
+
+    def test_stores_given_detailed_error_description(self):
+        klass = self._get_target_class()
+        instance = klass(1234, desc='Detailed error description.')
+        self.assertEqual(instance.desc, 'Detailed error description.')
+
+    def test_string_representation_of_the_instance_no_description(self):
+        klass = self._get_target_class()
+        instance = klass(1234)
+        instance.code = 101
+        instance.message = 'Foobar error'
+        instance.desc = None
+
+        self.assertEqual(
+            str(instance), 'SuperdeskError Error 101 - Foobar error')
+
+    def test_string_representation_of_the_instance_description_given(self):
+        klass = self._get_target_class()
+        instance = klass(1234)
+        instance.code = 101
+        instance.message = 'Foobar error'
+        instance.desc = 'This is a detailed description'
+
+        self.assertEqual(
+            str(instance),
+            ('SuperdeskError Error 101 - Foobar error '
+             'Details: This is a detailed description')
+        )
 
 
 class ErrorsTestCase(TestCase):


### PR DESCRIPTION
This is needed in cases when the static pre-defined exception error messages by themselves are not descriptive enough.

Resolves [SD-2262](https://dev.sourcefabric.org/browse/SD-2262).