### PR TITLE
public API: return HTTP 422 if request contains unexpected parameters

### DIFF
--- a/server/publicapi/errors.py
+++ b/server/publicapi/errors.py
@@ -24,17 +24,17 @@ class PublicApiError(SuperdeskError):
     }
     """A mapping of error codes to error messages."""
 
-    def __init__(self, error_code=10000):
-        super().__init__(error_code)
+    def __init__(self, error_code=10000, desc=None):
+        super().__init__(error_code, desc=desc)
 
 
-class UnknownParameterError(PublicApiError):
-    """Used when request contains an unknown parameter."""
+class UnexpectedParameterError(PublicApiError):
+    """Used when request contains an unexpected parameter."""
 
-    PublicApiError._codes[10001] = "Unknown parameter."
+    PublicApiError._codes[10001] = "Unexpected parameter."
 
-    def __init__(self):
-        super().__init__(10001)
+    def __init__(self, desc=None):
+        super().__init__(10001, desc=desc)
 
 
 class BadParameterValueError(PublicApiError):
@@ -42,5 +42,5 @@ class BadParameterValueError(PublicApiError):
 
     PublicApiError._codes[10002] = "Bad parameter value."
 
-    def __init__(self):
-        super().__init__(10002)
+    def __init__(self, desc=None):
+        super().__init__(10002, desc=desc)

--- a/server/publicapi/items/service.py
+++ b/server/publicapi/items/service.py
@@ -8,11 +8,13 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 
-from flask import current_app as app
 import logging
-from urllib.parse import urljoin, quote
 
+from eve.utils import ParsedRequest
+from flask import current_app as app
+from publicapi.errors import UnexpectedParameterError
 from superdesk.services import BaseService
+from urllib.parse import urljoin, quote
 
 
 logger = logging.getLogger(__name__)
@@ -26,6 +28,60 @@ class ItemsService(BaseService):
     Serves mainly as a proxy to the data layer.
     """
 
+    def find_one(self, req, **lookup):
+        """Retrieve a specific item.
+
+        :param req: object representing the HTTP request
+        :type req: `eve.utils.ParsedRequest`
+        :param dict lookup: requested item lookup, contains its ID
+
+        :return: requested item (if found)
+        :rtype: dict or None
+        """
+        request_params = req.args or {}
+        params = list(request_params.keys())
+
+        if len(params) > 0:
+            if 'q' not in params:
+                desc = "Unexpected parameter ({})".format(params[0])
+            else:
+                desc = (
+                    "Filtering is not supported when retrieving a single "
+                    "item (the \"q\" parameter)"
+                )
+            raise UnexpectedParameterError(desc=desc)
+
+        return super().find_one(req, **lookup)
+
+    def get(self, req, lookup):
+        """Retrieve a list of items that match the filter criteria (if any)
+        pssed along the HTTP request.
+
+        :param req: object representing the HTTP request
+        :type req: `eve.utils.ParsedRequest`
+        :param dict lookup: sub-resource lookup from the endpoint URL
+
+        :return: database results cursor object
+        :rtype: `pymongo.cursor.Cursor`
+        """
+        if req is None:
+            req = ParsedRequest()
+
+        request_params = req.args or {}
+        allowed_params = ('q',)
+
+        for param in request_params.keys():
+            if param not in allowed_params:
+                raise UnexpectedParameterError(
+                    desc="Unexpected parameter ({})".format(param)
+                )
+
+        if 'q' in request_params:
+            req.where = request_params['q']
+
+        return super().get(req, lookup)
+
+    # TODO: add docstrings and tests for the methods below
     def _set_uri(self, doc):
         resource_url = app.config['PUBLICAPI_URL'] + '/' + app.config['URLS'][self.datasource] + '/'
         doc['uri'] = urljoin(resource_url, quote(doc['_id']))

--- a/server/publicapi/tests/errors_test.py
+++ b/server/publicapi/tests/errors_test.py
@@ -42,6 +42,10 @@ class PublicApiErrorTestCase(ApiTestCase):
         error = self._make_one()
         self.assertEqual(error.message, "Unknown API error.")
 
+    def test_uses_error_description_if_given(self):
+        error = self._make_one(desc='Detailed description')
+        self.assertEqual(error.desc, "Detailed description")
+
 
 class UnknownParameterErrorTestCase(ApiTestCase):
 
@@ -51,11 +55,11 @@ class UnknownParameterErrorTestCase(ApiTestCase):
         Make the test fail immediately if the class cannot be imported.
         """
         try:
-            from publicapi.errors import UnknownParameterError
+            from publicapi.errors import UnexpectedParameterError
         except ImportError:
             self.fail("Could not import class under test")
         else:
-            return UnknownParameterError(*args, **kwargs)
+            return UnexpectedParameterError(*args, **kwargs)
 
     def test_inherits_from_base_publicapi_error(self):
         from publicapi.errors import PublicApiError
@@ -68,7 +72,11 @@ class UnknownParameterErrorTestCase(ApiTestCase):
 
     def test_error_message(self):
         error = self._make_one()
-        self.assertEqual(error.message, "Unknown parameter.")
+        self.assertEqual(error.message, "Unexpected parameter.")
+
+    def test_uses_error_description_if_given(self):
+        error = self._make_one(desc='More detailed description')
+        self.assertEqual(error.desc, 'More detailed description')
 
 
 class BadParameterValueTestCase(ApiTestCase):
@@ -97,3 +105,7 @@ class BadParameterValueTestCase(ApiTestCase):
     def test_error_message(self):
         error = self._make_one()
         self.assertEqual(error.message, "Bad parameter value.")
+
+    def test_uses_error_description_if_given(self):
+        error = self._make_one(desc='Integer expected for max results')
+        self.assertEqual(error.desc, 'Integer expected for max results')

--- a/server/publicapi/tests/items_service_test.py
+++ b/server/publicapi/tests/items_service_test.py
@@ -8,7 +8,10 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 
+
 from publicapi.tests import ApiTestCase
+from unittest import mock
+from unittest.mock import MagicMock
 
 
 class ItemsServiceTestCase(ApiTestCase):
@@ -26,5 +29,126 @@ class ItemsServiceTestCase(ApiTestCase):
         else:
             return ItemsService
 
-    def test_class_exists(self):
-        self._get_target_class()  # fails if the class cannot be obtained
+    def _make_one(self, *args, **kwargs):
+        """Create a new instance of the class under test."""
+        return self._get_target_class()(*args, **kwargs)
+
+
+fake_super_get = MagicMock(name='fake super().get')
+
+
+@mock.patch('publicapi.items.service.BaseService.get', fake_super_get)
+class GetMethodTestCase(ItemsServiceTestCase):
+    """Tests for the get() method."""
+
+    def setUp(self):
+        super().setUp()
+        fake_super_get.reset_mock()
+
+    def test_invokes_superclass_method_with_given_arguments(self):
+        request = MagicMock()
+        lookup = {}
+
+        instance = self._make_one()
+        instance.get(request, lookup)
+
+        self.assertTrue(fake_super_get.called)
+        args, kwargs = fake_super_get.call_args
+        self.assertEqual(len(args), 2)
+        self.assertIs(args[0], request)
+        self.assertIs(args[1], lookup)
+
+    def test_provides_request_object_to_superclass_if_not_given(self):
+        lookup = {}
+
+        instance = self._make_one()
+        instance.get(None, lookup)
+
+        self.assertTrue(fake_super_get.called)
+        args, kwargs = fake_super_get.call_args
+        self.assertEqual(len(args), 2)
+        self.assertIsNotNone(args[0])
+
+    def test_sets_query_filter_on_request_object_if_present(self):
+        request = MagicMock()
+        request.args = dict(q='{"language": "de"}')
+        lookup = {}
+
+        instance = self._make_one()
+        instance.get(request, lookup)
+
+        self.assertTrue(fake_super_get.called)
+        args, kwargs = fake_super_get.call_args
+        self.assertGreater(len(args), 0)
+        self.assertEqual(args[0].where, '{"language": "de"}')
+
+    def test_raises_correct_error_on_unexpected_parameters(self):
+        request = MagicMock()
+        request.args = dict(foo='bar')
+        lookup = {}
+
+        from publicapi.errors import UnexpectedParameterError
+        instance = self._make_one()
+
+        with self.assertRaises(UnexpectedParameterError) as context:
+            instance.get(request, lookup)
+
+        ex = context.exception
+        self.assertEqual(ex.desc, 'Unexpected parameter (foo)')
+
+
+fake_super_find_one = MagicMock(name='fake super().find_one')
+
+
+@mock.patch('publicapi.items.service.BaseService.find_one', fake_super_find_one)
+class FindOneMethodTestCase(ItemsServiceTestCase):
+    """Tests for the find_one() method."""
+
+    def setUp(self):
+        super().setUp()
+        fake_super_find_one.reset_mock()
+
+    def test_invokes_superclass_method_with_given_arguments(self):
+        request = MagicMock()
+        lookup = {'_id': 'my_item'}
+
+        instance = self._make_one()
+        instance.find_one(request, **lookup)
+
+        self.assertTrue(fake_super_find_one.called)
+        args, kwargs = fake_super_find_one.call_args
+        self.assertEqual(len(args), 1)
+        self.assertIs(args[0], request)
+        self.assertEqual(kwargs, lookup)
+
+    def test_raises_correct_error_on_unexpected_parameters(self):
+        request = MagicMock()
+        request.args = dict(foo='bar')
+        lookup = {'_id': 'my_item'}
+
+        from publicapi.errors import UnexpectedParameterError
+        instance = self._make_one()
+
+        with self.assertRaises(UnexpectedParameterError) as context:
+            instance.find_one(request, **lookup)
+
+        ex = context.exception
+        self.assertEqual(ex.desc, 'Unexpected parameter (foo)')
+
+    def test_raises_error_with_descriptive_msg_on_filtering_attempt(self):
+        request = MagicMock()
+        request.args = dict(q='{"language": "en"}')
+        lookup = {'_id': 'my_item'}
+
+        from publicapi.errors import UnexpectedParameterError
+        instance = self._make_one()
+
+        with self.assertRaises(UnexpectedParameterError) as context:
+            instance.find_one(request, **lookup)
+
+        ex = context.exception
+        self.assertEqual(
+            ex.desc,
+            'Filtering is not supported when retrieving a single item '
+            '(the "q" parameter)'
+        )


### PR DESCRIPTION
Resolves [SD-2242](https://dev.sourcefabric.org/browse/SD-2242).

NOTE: the behave tests will be updated under a [separate ticket](https://dev.sourcefabric.org/browse/SD-2171) that we've opened.