### PR TITLE
Public API: add behave tests for returning an error on invalid request parameters

### DIFF
--- a/server/publicapi/features/returning_errors.feature
+++ b/server/publicapi/features/returning_errors.feature
@@ -1,0 +1,17 @@
+Feature: Returning error on invalid request parameters
+
+    Scenario: Sending an unknown parameter when retrieving items
+        When we get "/items?parameter_x=foo"
+        Then we get error 422
+
+    Scenario: Sending an unknown parameter when retrieving packages
+        When we get "/packages?parameter_x=foo"
+        Then we get response code 422
+
+    Scenario: Trying to apply filters when fetching a single item
+        When we get "/items/someItemId?q={\"language\": \"en\"}"
+        Then we get error 422
+
+    Scenario: Trying to apply filters when fetching a single package
+        When we get "/packages/somePackageId?q={\"language\": \"en\"}"
+        Then we get error 422


### PR DESCRIPTION
Resolves [SD-2171](https://dev.sourcefabric.org/browse/SD-2171).

Edit: it seems that we have a [broken test](https://travis-ci.org/superdesk/superdesk/jobs/62370645#L1034) in master, something about the desks service (client).

Update: the failing tests do not fail locally and they seem to have been automagically fixed without even touching the relevant code. This build can thus be considered as successful IMO.