### PR TITLE
Content API: Allow filtering items/packages by creation date

### DIFF
--- a/server/publicapi/__init__.py
+++ b/server/publicapi/__init__.py
@@ -24,7 +24,7 @@ import logging
 import os
 
 from publicapi import settings
-from publicapi.errors import UnexpectedParameterError
+from publicapi.errors import BadParameterValueError, UnexpectedParameterError
 import superdesk
 from superdesk.datalayer import SuperdeskDataLayer
 from superdesk.errors import SuperdeskError, SuperdeskApiError
@@ -43,6 +43,10 @@ def _set_error_handlers(app):
     :param app: an instance of `Eve <http://python-eve.org/>`_ application
     """
     @app.errorhandler(UnexpectedParameterError)
+    def unknown_parameter_handler(error):
+        return str(error), 422
+
+    @app.errorhandler(BadParameterValueError)
     def unknown_parameter_handler(error):
         return str(error), 422
 

--- a/server/publicapi/demo_data/README.md
+++ b/server/publicapi/demo_data/README.md
@@ -3,7 +3,7 @@ To populate the public API database with demo data, run the following command
 in the console (from inside the `publicapi/demo_data` directory):
 
 ```sh
-$ mongoimport -h localhost:27017 -d publicapi -c items --drop --jsonArray --file data.json
+$ mongoimport -h localhost:27017 -d publicapi -c items --drop --file data.json
 ```
 
 WARNING: any existing data in the `publicapi.items` collection gets removed.

--- a/server/publicapi/features/prepopulate.feature
+++ b/server/publicapi/features/prepopulate.feature
@@ -7,7 +7,7 @@ Feature: Prepopulate public content
     	"""
         Then we get response code 201
 
-        When we get "/items"
+        When we get "/items?start_date=1970-01-01"
         Then we get list with 1 items
         """
         {
@@ -20,7 +20,7 @@ Feature: Prepopulate public content
         }
         """
 
-        When we get "/packages"
+        When we get "/packages?start_date=1970-01-01"
         Then we get list with 1 items
         """
         {

--- a/server/publicapi/items/service.py
+++ b/server/publicapi/items/service.py
@@ -11,6 +11,7 @@
 import json
 import logging
 
+from datetime import datetime
 from eve.utils import ParsedRequest
 from flask import current_app as app
 from publicapi.errors import BadParameterValueError, UnexpectedParameterError
@@ -29,40 +30,6 @@ class ItemsService(BaseService):
 
     Serves mainly as a proxy to the data layer.
     """
-
-    def _check_request_params(self, request, whitelist, allow_filtering=True):
-        """Check if the request contains only valid parameters.
-
-        :param req: object representing the HTTP request
-        :type req: `eve.utils.ParsedRequest`
-        :param whitelist: iterable containing the names of allowed parameters.
-        :param bool allow_filtering: whether or not the filtering parameter is
-            allowed (True by default). Used for disallowing it when retrieving
-            a single object.
-
-        :raises BadParameterValueError: if the request contains more than one
-            value for any of the parameters
-        :raises UnexpectedParameterError: if the request contains a parameter
-            that is not whitelisted
-        """
-        request_params = (request.args or MultiDict())
-
-        if not allow_filtering and 'q' in request_params.keys():
-            desc = (
-                "Filtering is not supported when retrieving a single "
-                "object (the \"q\" parameter)"
-            )
-            raise UnexpectedParameterError(desc=desc)
-
-        for param_name in request_params.keys():
-            if param_name not in whitelist:
-                raise UnexpectedParameterError(
-                    desc="Unexpected parameter ({})".format(param_name)
-                )
-
-            if len(request_params.getlist(param_name)) > 1:
-                desc = "Multiple values received for parameter ({})"
-                raise BadParameterValueError(desc=desc.format(param_name))
 
     def find_one(self, req, **lookup):
         """Retrieve a specific item.
@@ -101,32 +68,87 @@ class ItemsService(BaseService):
         request_params = req.args or {}
         query_filter = {}
 
+        # set the "q" filter
         if 'q' in request_params:
             # TODO: add validation for the "q" parameter when we define its
             # format and implement the corresponding actions
             query_filter = json.loads(request_params['q'])
 
-        # ### set date filters
-        # TODO: validate date format! helper function..
-        # check for no ValueError: datetime.strptime(date_text, '%Y-%m-%d')
-        # if yes, raise BadParameterValueError (from None, of course)
-        date_filter = {'versioncreated': {}}
-
-        start_date = request_params.get('start_date')
-        if start_date is not None:
-            date_filter['versioncreated']['$gte'] = start_date
-
-        end_date = request_params.get('end_date')
-        if end_date is not None:
-            date_filter['versioncreated']['$lte'] = end_date
-
-        if start_date or end_date:
-            query_filter.update(date_filter)
-        # ### end setting date filters
+        # set the date range filter
+        start_date, end_date = self._get_date_range(request_params)
+        date_filter = self._create_date_range_filter(start_date, end_date)
+        query_filter.update(date_filter)
 
         req.where = json.dumps(query_filter)
 
         return super().get(req, lookup)
+
+    def _check_request_params(self, request, whitelist, allow_filtering=True):
+        """Check if the request contains only valid parameters.
+
+        :param req: object representing the HTTP request
+        :type req: `eve.utils.ParsedRequest`
+        :param whitelist: iterable containing the names of allowed parameters.
+        :param bool allow_filtering: whether or not the filtering parameter is
+            allowed (True by default). Used for disallowing it when retrieving
+            a single object.
+
+        :raises BadParameterValueError: if the request contains more than one
+            value for any of the parameters
+        :raises UnexpectedParameterError: if the request contains a parameter
+            that is not whitelisted
+        """
+        request_params = (request.args or MultiDict())
+
+        if not allow_filtering and 'q' in request_params.keys():
+            desc = (
+                "Filtering is not supported when retrieving a single "
+                "object (the \"q\" parameter)"
+            )
+            raise UnexpectedParameterError(desc=desc)
+
+        for param_name in request_params.keys():
+            if param_name not in whitelist:
+                raise UnexpectedParameterError(
+                    desc="Unexpected parameter ({})".format(param_name)
+                )
+
+            if len(request_params.getlist(param_name)) > 1:
+                desc = "Multiple values received for parameter ({})"
+                raise BadParameterValueError(desc=desc.format(param_name))
+
+    def _get_date_range(self, request_params):
+        """TODO: helper method  to extract day, srt default values etc."""
+        # TODO: add tests, comments, format checking, implement...
+
+        # TODO: validate date format! helper function..
+        # check for no ValueError: datetime.strptime(date_text, '%Y-%m-%d')
+        # if yes, raise BadParameterValueError (from None, of course)
+
+        start_date = request_params.get('start_date')
+        if start_date:
+            start_date = datetime.strptime(start_date, '%Y-%m-%d')
+
+        end_date = request_params.get('end_date')
+        if end_date:
+            end_date = datetime.strptime(end_date, '%Y-%m-%d')
+
+        return start_date, end_date
+
+    def _create_date_range_filter(self, start_date, end_date):
+        """TODO: docstrings, perhaps tests etc."""
+        if (start_date is None) and (end_date is None):
+            return {}  # nothing to set for the date range filter
+
+        date_filter = {'versioncreated': {}}
+
+        if start_date is not None:
+            date_filter['versioncreated']['$gte'] = start_date.isoformat()
+
+        if end_date is not None:
+            date_filter['versioncreated']['$lte'] = end_date.isoformat()
+
+        return date_filter
 
     # TODO: add docstrings and tests for the methods below
     def _set_uri(self, doc):

--- a/server/publicapi/items/service.py
+++ b/server/publicapi/items/service.py
@@ -12,9 +12,10 @@ import logging
 
 from eve.utils import ParsedRequest
 from flask import current_app as app
-from publicapi.errors import UnexpectedParameterError
+from publicapi.errors import BadParameterValueError, UnexpectedParameterError
 from superdesk.services import BaseService
 from urllib.parse import urljoin, quote
+from werkzeug.datastructures import MultiDict
 
 
 logger = logging.getLogger(__name__)
@@ -28,6 +29,40 @@ class ItemsService(BaseService):
     Serves mainly as a proxy to the data layer.
     """
 
+    def _check_request_params(self, request, whitelist, allow_filtering=True):
+        """Check if the request contains only valid parameters.
+
+        :param req: object representing the HTTP request
+        :type req: `eve.utils.ParsedRequest`
+        :param whitelist: iterable containing the names of allowed parameters.
+        :param bool allow_filtering: whether or not the filtering parameter is
+            allowed (True by default). Used for disallowing it when retrieving
+            a single object.
+
+        :raises BadParameterValueError: if the request contains more than one
+            value for any of the parameters
+        :raises UnexpectedParameterError: if the request contains a parameter
+            that is not whitelisted
+        """
+        request_params = (request.args or MultiDict())
+
+        if not allow_filtering and 'q' in request_params.keys():
+            desc = (
+                "Filtering is not supported when retrieving a single "
+                "object (the \"q\" parameter)"
+            )
+            raise UnexpectedParameterError(desc=desc)
+
+        for param_name in request_params.keys():
+            if param_name not in whitelist:
+                raise UnexpectedParameterError(
+                    desc="Unexpected parameter ({})".format(param_name)
+                )
+
+            if len(request_params.getlist(param_name)) > 1:
+                desc = "Multiple values received for parameter ({})"
+                raise BadParameterValueError(desc=desc.format(param_name))
+
     def find_one(self, req, **lookup):
         """Retrieve a specific item.
 
@@ -38,18 +73,7 @@ class ItemsService(BaseService):
         :return: requested item (if found)
         :rtype: dict or None
         """
-        request_params = req.args or {}
-        params = list(request_params.keys())
-
-        if len(params) > 0:
-            if 'q' not in params:
-                desc = "Unexpected parameter ({})".format(params[0])
-            else:
-                desc = (
-                    "Filtering is not supported when retrieving a single "
-                    "item (the \"q\" parameter)"
-                )
-            raise UnexpectedParameterError(desc=desc)
+        self._check_request_params(req, whitelist=(), allow_filtering=False)
 
         return super().find_one(req, **lookup)
 
@@ -67,15 +91,9 @@ class ItemsService(BaseService):
         if req is None:
             req = ParsedRequest()
 
+        self._check_request_params(req, whitelist=('q',))
+
         request_params = req.args or {}
-        allowed_params = ('q',)
-
-        for param in request_params.keys():
-            if param not in allowed_params:
-                raise UnexpectedParameterError(
-                    desc="Unexpected parameter ({})".format(param)
-                )
-
         if 'q' in request_params:
             req.where = request_params['q']
 

--- a/server/publicapi/items/service.py
+++ b/server/publicapi/items/service.py
@@ -11,7 +11,7 @@
 import json
 import logging
 
-from datetime import datetime
+from datetime import date, datetime, timedelta
 from eve.utils import ParsedRequest
 from flask import current_app as app
 from publicapi.errors import BadParameterValueError, UnexpectedParameterError
@@ -132,15 +132,22 @@ class ItemsService(BaseService):
             raise BadParameterValueError(
                 desc="Invalid parameter value (end_date)") from None
 
+        # TODO: start_date not bigger than today! same as end date!
+
         if (
             (start_date is not None) and (end_date is not None) and
             (start_date > end_date)
         ):
-            # NOTE: we allow start_date == end_date (for exact date queries)
+            # NOTE: we allow start_date == end_date (for specific date queries)
             raise BadParameterValueError(
                 desc="Start date must not be greater than end date")
 
-        # TODO: set default values if missing
+        # set default values if missing
+        if end_date is None:
+            end_date = date.today()
+
+        if start_date is None:
+            start_date = end_date - timedelta(1)
 
         return start_date, end_date
 

--- a/server/publicapi/items/service.py
+++ b/server/publicapi/items/service.py
@@ -74,6 +74,9 @@ class ItemsService(BaseService):
         :return: requested item (if found)
         :rtype: dict or None
         """
+        if req is None:
+            req = ParsedRequest()
+
         self._check_request_params(req, whitelist=(), allow_filtering=False)
 
         return super().find_one(req, **lookup)

--- a/server/publicapi/items/service.py
+++ b/server/publicapi/items/service.py
@@ -132,8 +132,27 @@ class ItemsService(BaseService):
             raise BadParameterValueError(
                 desc="Invalid parameter value (end_date)") from None
 
-        # TODO: start_date not bigger than today! same as end date!
+        # disallow dates in the future
+        future_err_msg = (
+            "{} date ({}) must not be set in the future "
+            "(current server date: {})")
+        today = date.today()
 
+        if (start_date is not None) and (start_date > today):
+            raise BadParameterValueError(
+                desc=future_err_msg.format(
+                    'Start', start_date.isoformat(), today.isoformat()
+                )
+            )
+
+        if (end_date is not None) and (end_date > today):
+            raise BadParameterValueError(
+                desc=future_err_msg.format(
+                    'End', end_date.isoformat(), today.isoformat()
+                )
+            )
+
+        # make sure that the date range limits make sense
         if (
             (start_date is not None) and (end_date is not None) and
             (start_date > end_date)
@@ -142,7 +161,7 @@ class ItemsService(BaseService):
             raise BadParameterValueError(
                 desc="Start date must not be greater than end date")
 
-        # set default values if missing
+        # set default date range values if missing
         if end_date is None:
             end_date = date.today()
 

--- a/server/publicapi/items/service.py
+++ b/server/publicapi/items/service.py
@@ -185,7 +185,7 @@ class ItemsService(BaseService):
             end_date = today
 
         if start_date is None:
-            start_date = end_date - timedelta(1)
+            start_date = end_date
 
         return start_date, end_date
 

--- a/server/publicapi/items/service.py
+++ b/server/publicapi/items/service.py
@@ -129,7 +129,6 @@ class ItemsService(BaseService):
         :return: a (start_date, end_date) tuple with both values being
             instances of Python's datetime.date
 
-
         :raises BadParameterValueError:
             * if any of the dates is not in the ISO 8601 format
             * if any of the dates is set in the future

--- a/server/publicapi/items/service.py
+++ b/server/publicapi/items/service.py
@@ -118,16 +118,31 @@ class ItemsService(BaseService):
                 raise BadParameterValueError(desc=desc.format(param_name))
 
     def _get_date_range(self, request_params):
-        """TODO: helper method  to extract day, srt default values etc."""
-        # TODO: add tests, comments, format checking, implement...
+        """Extract the start and end date limits from request parameters.
+
+        If start and/or end date parameter is not present, a default value is
+        returned for the missing parameter(s).
+
+        :param dict request_params: request parameter names and their
+            corresponding values
+
+        :return: a (start_date, end_date) tuple with both values being
+            instances of Python's datetime.date
+
+
+        :raises BadParameterValueError:
+            * if any of the dates is not in the ISO 8601 format
+            * if any of the dates is set in the future
+            * if the start date is bigger than the end date
+        """
         try:
-            start_date = self.parse_iso_date(request_params.get('start_date'))
+            start_date = self._parse_iso_date(request_params.get('start_date'))
         except ValueError:
             raise BadParameterValueError(
                 desc="Invalid parameter value (start_date)") from None
 
         try:
-            end_date = self.parse_iso_date(request_params.get('end_date'))
+            end_date = self._parse_iso_date(request_params.get('end_date'))
         except ValueError:
             raise BadParameterValueError(
                 desc="Invalid parameter value (end_date)") from None
@@ -170,16 +185,20 @@ class ItemsService(BaseService):
 
         return start_date, end_date
 
-    @staticmethod
-    def parse_iso_date(date_str):
-        """TODO: docstring, test... parses given date string"""
-        if date_str is None:
-            return None
-        else:
-            return datetime.strptime(date_str, '%Y-%m-%d').date()
-
     def _create_date_range_filter(self, start_date, end_date):
-        """TODO: docstrings, perhaps tests etc."""
+        """Create a MongoDB date range query filter from the given dates.
+
+        If both the start date and the end date are None, an empty filter is
+        returned. The filtering is performed on the `versioncreated` field in
+        database.
+
+        :param start_date: the minimum version creation date (inclusive)
+        :type start_date: datetime.date or None
+        :param end_date: the maximum version creation date (inclusive)
+        :type end_date: datetime.date or None
+
+        :return: MongoDB date range filter (as a dictionary)
+        """
         if (start_date is None) and (end_date is None):
             return {}  # nothing to set for the date range filter
 
@@ -192,6 +211,21 @@ class ItemsService(BaseService):
             date_filter['versioncreated']['$lte'] = end_date.isoformat()
 
         return date_filter
+
+    @staticmethod
+    def _parse_iso_date(date_str):
+        """Create a date object from the given string in ISO 8601 format.
+
+        :param date_str:
+        :type date_str: str or None
+
+        :return: resulting date object or None if None is given
+        :rtype: datetime.date
+        """
+        if date_str is None:
+            return None
+        else:
+            return datetime.strptime(date_str, '%Y-%m-%d').date()
 
     # TODO: add docstrings and tests for the methods below
     def _set_uri(self, doc):

--- a/server/publicapi/items/service.py
+++ b/server/publicapi/items/service.py
@@ -120,20 +120,37 @@ class ItemsService(BaseService):
     def _get_date_range(self, request_params):
         """TODO: helper method  to extract day, srt default values etc."""
         # TODO: add tests, comments, format checking, implement...
+        try:
+            start_date = self.parse_iso_date(request_params.get('start_date'))
+        except ValueError:
+            raise BadParameterValueError(
+                desc="Invalid parameter value (start_date)") from None
 
-        # TODO: validate date format! helper function..
-        # check for no ValueError: datetime.strptime(date_text, '%Y-%m-%d')
-        # if yes, raise BadParameterValueError (from None, of course)
+        try:
+            end_date = self.parse_iso_date(request_params.get('end_date'))
+        except ValueError:
+            raise BadParameterValueError(
+                desc="Invalid parameter value (end_date)") from None
 
-        start_date = request_params.get('start_date')
-        if start_date:
-            start_date = datetime.strptime(start_date, '%Y-%m-%d')
+        if (
+            (start_date is not None) and (end_date is not None) and
+            (start_date > end_date)
+        ):
+            # NOTE: we allow start_date == end_date (for exact date queries)
+            raise BadParameterValueError(
+                desc="Start date must not be greater than end date")
 
-        end_date = request_params.get('end_date')
-        if end_date:
-            end_date = datetime.strptime(end_date, '%Y-%m-%d')
+        # TODO: set default values if missing
 
         return start_date, end_date
+
+    @staticmethod
+    def parse_iso_date(date_str):
+        """TODO: docstring, test... parses given date string"""
+        if date_str is None:
+            return None
+        else:
+            return datetime.strptime(date_str, '%Y-%m-%d').date()
 
     def _create_date_range_filter(self, start_date, end_date):
         """TODO: docstrings, perhaps tests etc."""

--- a/server/publicapi/prepopulate/prepopulate-data/app_prepopulate_data.json
+++ b/server/publicapi/prepopulate/prepopulate-data/app_prepopulate_data.json
@@ -3,7 +3,8 @@
 		"resource": "items",
 		"data": {
 			"_id": "tag:example.com,0000:newsml_BRE9A605",
-			"type": "picture"
+			"type": "picture",
+			"versioncreated": "2014-03-16T08:12:00Z"
 		}
 	},
 	{
@@ -11,7 +12,8 @@
 		"data": {
 			"_id": "tag:example.com,0001:newsml_BRE9A606",
 			"type": "composite",
-			"headline": "foo bar"
+			"headline": "foo bar",
+			"versioncreated": "2015-02-10T16:20:08Z"
 		}
 	}
 ]

--- a/server/publicapi/tests/items_service_test.py
+++ b/server/publicapi/tests/items_service_test.py
@@ -10,6 +10,7 @@
 
 import json
 
+from eve.utils import ParsedRequest
 from publicapi.tests import ApiTestCase
 from unittest import mock
 from unittest.mock import MagicMock
@@ -156,7 +157,7 @@ class GetMethodTestCase(ItemsServiceTestCase):
         self.assertTrue(fake_super_get.called)
         args, kwargs = fake_super_get.call_args
         self.assertEqual(len(args), 2)
-        self.assertIsNotNone(args[0])
+        self.assertIsInstance(args[0], ParsedRequest)
 
     def test_sets_query_filter_on_request_object_if_present(self):
         request = MagicMock()
@@ -239,3 +240,14 @@ class FindOneMethodTestCase(ItemsServiceTestCase):
         self.assertEqual(len(args), 1)
         self.assertIs(args[0], request)
         self.assertEqual(kwargs, lookup)
+
+    def test_provides_request_object_to_superclass_if_not_given(self):
+        lookup = {'_id': 'my_item'}
+
+        instance = self._make_one()
+        instance.find_one(None, **lookup)
+
+        self.assertTrue(fake_super_find_one.called)
+        args, kwargs = fake_super_find_one.call_args
+        self.assertEqual(len(args), 1)
+        self.assertIsInstance(args[0], ParsedRequest)

--- a/server/publicapi/tests/items_service_test.py
+++ b/server/publicapi/tests/items_service_test.py
@@ -170,7 +170,9 @@ class GetMethodTestCase(ItemsServiceTestCase):
         self.assertTrue(fake_super_get.called)
         args, kwargs = fake_super_get.call_args
         self.assertGreater(len(args), 0)
-        self.assertEqual(args[0].where, '{"language": "de"}')
+
+        query_filter = json.loads(args[0].where)
+        self.assertEqual(query_filter.get('language'), 'de')
 
     def test_includes_given_date_range_into_query_filter_if_given(self):
         request = MagicMock()
@@ -188,7 +190,10 @@ class GetMethodTestCase(ItemsServiceTestCase):
         self.assertGreater(len(args), 0)
 
         date_filter = json.loads(args[0].where).get('versioncreated', {})
-        expected_filter = {'$gte': '2012-08-21', '$lte': '2012-08-26'}
+        expected_filter = {
+            '$gte': '2012-08-21T00:00:00',
+            '$lte': '2012-08-26T00:00:00'
+        }
         self.assertEqual(date_filter, expected_filter)
 
 

--- a/server/publicapi/tests/items_service_test.py
+++ b/server/publicapi/tests/items_service_test.py
@@ -352,7 +352,23 @@ class GetMethodTestCase(ItemsServiceTestCase):
         )
 
 
-# TODO: parse_iso_date() helper method tests
+class ParseIsoDateMethodTestCase(ItemsServiceTestCase):
+    """Tests for the parse_iso_date() helper method."""
+
+    def test_returns_none_if_none_given(self):
+        klass = self._get_target_class()
+        result = klass.parse_iso_date(None)
+        self.assertIsNone(result)
+
+    def test_returns_date_object_on_valid_iso_date_string(self):
+        klass = self._get_target_class()
+        result = klass.parse_iso_date('2015-05-15')
+        self.assertEqual(result, date(2015, 5, 15))
+
+    def test_raises_value_error_on_invalid_iso_date_string(self):
+        klass = self._get_target_class()
+        with self.assertRaises(ValueError):
+            klass.parse_iso_date('5th May 2015')
 
 
 fake_super_find_one = MagicMock(name='fake super().find_one')

--- a/server/publicapi/tests/items_service_test.py
+++ b/server/publicapi/tests/items_service_test.py
@@ -175,7 +175,7 @@ class GetMethodTestCase(ItemsServiceTestCase):
         query_filter = json.loads(args[0].where)
         self.assertEqual(query_filter.get('language'), 'de')
 
-    def test_raises_correct_error_on_invalid_date_parameter(self):
+    def test_raises_correct_error_on_invalid_start_date_parameter(self):
         request = MagicMock()
         request.args = MultiDict([('start_date', '2015-13-35')])
         lookup = {}
@@ -189,6 +189,21 @@ class GetMethodTestCase(ItemsServiceTestCase):
         ex = context.exception
         self.assertEqual(
             ex.desc, "Invalid parameter value (start_date)")
+
+    def test_raises_correct_error_on_invalid_end_date_parameter(self):
+        request = MagicMock()
+        request.args = MultiDict([('end_date', '2015-13-35')])
+        lookup = {}
+
+        from publicapi.errors import BadParameterValueError
+        instance = self._make_one()
+
+        with self.assertRaises(BadParameterValueError) as context:
+            instance.get(request, lookup)
+
+        ex = context.exception
+        self.assertEqual(
+            ex.desc, "Invalid parameter value (end_date)")
 
     def test_raises_correct_error_if_start_date_greater_than_end_date(self):
         request = MagicMock()
@@ -353,22 +368,22 @@ class GetMethodTestCase(ItemsServiceTestCase):
 
 
 class ParseIsoDateMethodTestCase(ItemsServiceTestCase):
-    """Tests for the parse_iso_date() helper method."""
+    """Tests for the _parse_iso_date() helper method."""
 
     def test_returns_none_if_none_given(self):
         klass = self._get_target_class()
-        result = klass.parse_iso_date(None)
+        result = klass._parse_iso_date(None)
         self.assertIsNone(result)
 
     def test_returns_date_object_on_valid_iso_date_string(self):
         klass = self._get_target_class()
-        result = klass.parse_iso_date('2015-05-15')
+        result = klass._parse_iso_date('2015-05-15')
         self.assertEqual(result, date(2015, 5, 15))
 
     def test_raises_value_error_on_invalid_iso_date_string(self):
         klass = self._get_target_class()
         with self.assertRaises(ValueError):
-            klass.parse_iso_date('5th May 2015')
+            klass._parse_iso_date('5th May 2015')
 
 
 fake_super_find_one = MagicMock(name='fake super().find_one')

--- a/server/publicapi/tests/items_service_test.py
+++ b/server/publicapi/tests/items_service_test.py
@@ -285,7 +285,7 @@ class GetMethodTestCase(ItemsServiceTestCase):
         }
         self.assertEqual(date_filter, expected_filter)
 
-    def test_sets_start_date_to_end_date_minus_one_if_not_given(self):
+    def test_sets_start_date_equal_to_end_date_if_not_given(self):
         request = MagicMock()
         request.args = MultiDict([('end_date', '2012-08-21')])
         lookup = {}
@@ -299,13 +299,13 @@ class GetMethodTestCase(ItemsServiceTestCase):
 
         date_filter = json.loads(args[0].where).get('versioncreated', {})
         expected_filter = {
-            '$gte': '2012-08-20',
+            '$gte': '2012-08-21',
             '$lt': '2012-08-22'  # end_date + 1 day
         }
         self.assertEqual(date_filter, expected_filter)
 
     @mock.patch('publicapi.items.service.utcnow')
-    def test_sets_end_date_to_today_and_start_day_to_yesterday_if_both_not_given(
+    def test_sets_end_date_and_start_date_to_today_if_both_not_given(
         self, fake_utcnow
     ):
         request = MagicMock()
@@ -323,7 +323,7 @@ class GetMethodTestCase(ItemsServiceTestCase):
 
         date_filter = json.loads(args[0].where).get('versioncreated', {})
         expected_filter = {
-            '$gte': '2014-07-14',
+            '$gte': '2014-07-15',
             '$lt': '2014-07-16'  # today + 1 day
         }
         self.assertEqual(date_filter, expected_filter)

--- a/server/publicapi/tests/items_service_test.py
+++ b/server/publicapi/tests/items_service_test.py
@@ -309,10 +309,50 @@ class GetMethodTestCase(ItemsServiceTestCase):
         }
         self.assertEqual(date_filter, expected_filter)
 
-    # TODO: not bigger than current day? return server time in ex. msg
+    @mock.patch('publicapi.items.service.date', wraps=date)
+    def test_raises_correct_error_for_start_date_in_future(self, fake_date_class):
+        request = MagicMock()
+        request.args = MultiDict([('start_date', '2007-10-31')])
+        lookup = {}
+
+        fake_date_class.today.return_value = date(2007, 10, 30)
+
+        from publicapi.errors import BadParameterValueError
+        instance = self._make_one()
+
+        with self.assertRaises(BadParameterValueError) as context:
+            instance.get(request, lookup)
+
+        ex = context.exception
+        self.assertEqual(
+            ex.desc,
+            "Start date (2007-10-31) must not be set in the future "
+            "(current server date: 2007-10-30)"
+        )
+
+    @mock.patch('publicapi.items.service.date', wraps=date)
+    def test_raises_correct_error_for_end_date_in_future(self, fake_date_class):
+        request = MagicMock()
+        request.args = MultiDict([('end_date', '2007-10-31')])
+        lookup = {}
+
+        fake_date_class.today.return_value = date(2007, 10, 30)
+
+        from publicapi.errors import BadParameterValueError
+        instance = self._make_one()
+
+        with self.assertRaises(BadParameterValueError) as context:
+            instance.get(request, lookup)
+
+        ex = context.exception
+        self.assertEqual(
+            ex.desc,
+            "End date (2007-10-31) must not be set in the future "
+            "(current server date: 2007-10-30)"
+        )
 
 
-# TODO: + three test cases for helper methods (parse_iso_date - _get_target_class)
+# TODO: parse_iso_date() helper method tests
 
 
 fake_super_find_one = MagicMock(name='fake super().find_one')


### PR DESCRIPTION
Also did refactored parameter parsing out into helper methods to keep the `ItemsService.get()` method clean and readable.

Resolves [SD-2252](https://dev.sourcefabric.org/browse/SD-2252)