### PR TITLE
Public API: return more descriptive msg when date range filtering is disallowed

### DIFF
--- a/server/publicapi/items/service.py
+++ b/server/publicapi/items/service.py
@@ -101,12 +101,21 @@ class ItemsService(BaseService):
         """
         request_params = (request.args or MultiDict())
 
-        if not allow_filtering and 'q' in request_params.keys():
-            desc = (
-                "Filtering is not supported when retrieving a single "
-                "object (the \"q\" parameter)"
-            )
-            raise UnexpectedParameterError(desc=desc)
+        if not allow_filtering:
+            err_msg = ("Filtering{} is not supported when retrieving a "
+                       "single object (the \"{param}\" parameter)")
+
+            if 'q' in request_params.keys():
+                desc = err_msg.format('', param='q')
+                raise UnexpectedParameterError(desc=desc)
+
+            if 'start_date' in request_params.keys():
+                desc = err_msg.format(' by date range', param='start_date')
+                raise UnexpectedParameterError(desc=desc)
+
+            if 'end_date' in request_params.keys():
+                desc = err_msg.format(' by date range', param='end_date')
+                raise UnexpectedParameterError(desc=desc)
 
         for param_name in request_params.keys():
             if param_name not in whitelist:

--- a/server/publicapi/tests/items_service_test.py
+++ b/server/publicapi/tests/items_service_test.py
@@ -64,7 +64,7 @@ class CheckRequestParamsMethodTestCase(ItemsServiceTestCase):
         ex = context.exception
         self.assertEqual(ex.desc, 'Unexpected parameter (param_x)')
 
-    def test_raises_more_descriptive_error_on_filtering_disabled(self):
+    def test_raises_descriptive_error_on_filtering_disabled(self):
         request = MagicMock()
         request.args = MultiDict([('q', '{"language": "en"}')])
 
@@ -80,6 +80,42 @@ class CheckRequestParamsMethodTestCase(ItemsServiceTestCase):
             ex.desc,
             'Filtering is not supported when retrieving a single object '
             '(the "q" parameter)'
+        )
+
+    def test_raises_descriptive_error_on_disabled_start_date_filtering(self):
+        request = MagicMock()
+        request.args = MultiDict([('start_date', '2015-01-01')])
+
+        from publicapi.errors import UnexpectedParameterError
+        instance = self._make_one()
+
+        with self.assertRaises(UnexpectedParameterError) as context:
+            instance._check_request_params(
+                request, whitelist=(), allow_filtering=False)
+
+        ex = context.exception
+        self.assertEqual(
+            ex.desc,
+            'Filtering by date range is not supported when retrieving a '
+            'single object (the "start_date" parameter)'
+        )
+
+    def test_raises_descriptive_error_on_disabled_end_date_filtering(self):
+        request = MagicMock()
+        request.args = MultiDict([('end_date', '2015-01-01')])
+
+        from publicapi.errors import UnexpectedParameterError
+        instance = self._make_one()
+
+        with self.assertRaises(UnexpectedParameterError) as context:
+            instance._check_request_params(
+                request, whitelist=(), allow_filtering=False)
+
+        ex = context.exception
+        self.assertEqual(
+            ex.desc,
+            'Filtering by date range is not supported when retrieving a '
+            'single object (the "end_date" parameter)'
         )
 
     def test_raises_correct_error_on_duplicate_parameters(self):


### PR DESCRIPTION
Resolves [SD-2330](https://dev.sourcefabric.org/browse/SD-2330).