### PR TITLE
Fix/error-with-latest-pip-version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ import os
 
 SOURCE_FOLDER = 'server'
 LONG_DESCRIPTION = open(os.path.join(SOURCE_FOLDER, 'README.md')).read()
-REQUIREMENTS = [str(ir.req) for ir in parse_requirements('server/requirements.txt', session=PipSession()) if not ir.url]
+REQUIREMENTS = [str(ir.req) for ir in parse_requirements('server/requirements.txt', session=PipSession())
+                if not (getattr(ir, 'link', False) or getattr(ir, 'url', False))]
 
 setup(
     name='Superdesk-Server',


### PR DESCRIPTION
Or recent pip version, `url` was renamed by `link` (https://github.com/pypa/pip/commit/e8e2566279879b7df04394edfcaa9c63c0ce9e67)
