### PR TITLE
Public API: remove non-NINJS content fields from fetched items/packages

### DIFF
--- a/server/publicapi/features/items.feature
+++ b/server/publicapi/features/items.feature
@@ -3,10 +3,14 @@ Feature: Public content
     Scenario: Read an item
         Given "items"
         """
-        [{"_id": "tag:example.com,0000:newsml_BRE9A605", "mimetype": "text/plain"}]
+        [{
+            "_id": "tag:example.com,0000:newsml_BRE9A605",
+            "headline": "Breaking news in Timbuktu 123",
+            "mimetype": "text/plain"
+        }]
         """
         When we get "/items/tag:example.com,0000:newsml_BRE9A605"
         Then we get existing resource
         """
-        {"_id": "tag:example.com,0000:newsml_BRE9A605", "mimetype": "text/plain"}
+        {"headline": "Breaking news in Timbuktu 123", "mimetype": "text/plain"}
         """

--- a/server/publicapi/items/service.py
+++ b/server/publicapi/items/service.py
@@ -95,6 +95,37 @@ class ItemsService(BaseService):
 
         return super().get(req, lookup)
 
+    def on_fetched_item(self, document):
+        """Event handler when a single item is retrieved from database.
+
+        It sets the item's `uri` field.
+
+        :param dict document: fetched MongoDB document representing the item
+        """
+        self._set_uri(document)
+
+    def on_fetched(self, result):
+        """Event handler when a collection of items is retrieved from database.
+
+        It sets the `uri` field for each item in the fetched collection.
+
+        :param dict result: dictionary contaning the list of MongoDB documents
+            (the fetched items) and some metadata, e.g. pagination info
+        """
+        for document in result['_items']:
+            self._set_uri(document)
+
+    def _set_uri(self, document):
+        """Set the given document's `uri` content field.
+
+        :param dict document: MongoDB document fetched from database
+        """
+        resource_url = '{api_url}/{endpoint}/'.format(
+            api_url=app.config['PUBLICAPI_URL'],
+            endpoint=app.config['URLS'][self.datasource]
+        )
+        document['uri'] = urljoin(resource_url, quote(document['_id']))
+
     def _check_for_unknown_params(
         self, request, whitelist, allow_filtering=True
     ):
@@ -380,16 +411,3 @@ class ItemsService(BaseService):
             return None
         else:
             return datetime.strptime(date_str, '%Y-%m-%d').date()
-
-    # TODO: add docstrings and tests for the methods below
-    def _set_uri(self, doc):
-        resource_url = app.config['PUBLICAPI_URL'] + '/' + app.config['URLS'][self.datasource] + '/'
-        doc['uri'] = urljoin(resource_url, quote(doc['_id']))
-
-    def on_fetched_item(self, doc):
-        self._set_uri(doc)
-
-    def on_fetched(self, res):
-        for doc in res['_items']:
-            self._set_uri(doc)
-        return res

--- a/server/publicapi/items/service.py
+++ b/server/publicapi/items/service.py
@@ -98,22 +98,33 @@ class ItemsService(BaseService):
     def on_fetched_item(self, document):
         """Event handler when a single item is retrieved from database.
 
-        It sets the item's `uri` field.
+        It sets the item's `uri` field and removes all the fields added by the
+        `Eve` framework that are not part of the NINJS standard (except for
+        the HATEOAS `_links` object).
 
         :param dict document: fetched MongoDB document representing the item
         """
         self._set_uri(document)
 
+        for field_name in ('_id', '_etag', '_created', '_updated'):
+            document.pop(field_name, None)
+
     def on_fetched(self, result):
         """Event handler when a collection of items is retrieved from database.
 
-        It sets the `uri` field for each item in the fetched collection.
+        For each item in the fetched collection it sets its `uri` field and
+        removes from it all the fields added by the `Eve` framework that are
+        not part of the NINJS standard (except for the HATEOAS `_links`
+        object).
 
         :param dict result: dictionary contaning the list of MongoDB documents
             (the fetched items) and some metadata, e.g. pagination info
         """
         for document in result['_items']:
             self._set_uri(document)
+
+            for field_name in ('_id', '_etag', '_created', '_updated'):
+                document.pop(field_name, None)
 
     def _set_uri(self, document):
         """Set the given document's `uri` content field.

--- a/server/publicapi/settings.py
+++ b/server/publicapi/settings.py
@@ -45,6 +45,7 @@ DOMAIN = {}
 
 SUPERDESK_PUBLICAPI_TESTING = False
 
+# NOTE: no trailing slash for the PUBLICAPI_URL setting!
 PUBLICAPI_URL = env('PUBLICAPI_URL', 'http://localhost:5050')
 server_url = urlparse(PUBLICAPI_URL)
 SERVER_NAME = server_url.netloc or None

--- a/server/publicapi/tests/items_service_test.py
+++ b/server/publicapi/tests/items_service_test.py
@@ -12,6 +12,7 @@ import json
 
 from datetime import date
 from eve.utils import ParsedRequest
+from flask import Flask
 from publicapi.tests import ApiTestCase
 from unittest import mock
 from unittest.mock import MagicMock
@@ -657,3 +658,70 @@ class FindOneMethodTestCase(ItemsServiceTestCase):
         args, kwargs = fake_super_find_one.call_args
         self.assertEqual(len(args), 1)
         self.assertIsInstance(args[0], ParsedRequest)
+
+
+class OnFetchedItemMethodTestCase(ItemsServiceTestCase):
+    """Tests for the on_fetched_item() method."""
+
+    def setUp(self):
+        super().setUp()
+        self.app = Flask('test_app')
+        self.app_context = self.app.app_context()
+        self.app_context.push()
+
+    def tearDown(self):
+        super().tearDown()
+        self.app_context.pop()
+
+    def test_sets_uri_field_on_fetched_document(self):
+        document = {
+            '_id': 'item:123',
+            'title': 'a test item'
+        }
+        self.app.config['PUBLICAPI_URL'] = 'http://api.com'
+        self.app.config['URLS'] = {'items': 'items_endpoint'}
+
+        instance = self._make_one(datasource='items')
+        instance.on_fetched_item(document)
+
+        self.assertEqual(
+            document.get('uri'),
+            'http://api.com/items_endpoint/item%3A123'  # %3A == urlquote(':')
+        )
+
+
+class OnFetchedMethodTestCase(ItemsServiceTestCase):
+    """Tests for the on_fetched() method."""
+
+    def setUp(self):
+        super().setUp()
+        self.app = Flask('test_app')
+        self.app_context = self.app.app_context()
+        self.app_context.push()
+
+    def tearDown(self):
+        super().tearDown()
+        self.app_context.pop()
+
+    def test_sets_uri_field_on_all_fetched_documents(self):
+        result = {
+            '_items': [
+                {'_id': 'item:123', 'title': 'a test item'},
+                {'_id': 'item:555', 'title': 'another item'},
+            ]
+        }
+        self.app.config['PUBLICAPI_URL'] = 'http://api.com'
+        self.app.config['URLS'] = {'items': 'items_endpoint'}
+
+        instance = self._make_one(datasource='items')
+        instance.on_fetched(result)
+
+        documents = result['_items']
+        self.assertEqual(
+            documents[0].get('uri'),
+            'http://api.com/items_endpoint/item%3A123'  # %3A == urlquote(':')
+        )
+        self.assertEqual(
+            documents[1].get('uri'),
+            'http://api.com/items_endpoint/item%3A555'  # %3A == urlquote(':')
+        )

--- a/server/publicapi/tests/items_service_test.py
+++ b/server/publicapi/tests/items_service_test.py
@@ -665,21 +665,23 @@ class OnFetchedItemMethodTestCase(ItemsServiceTestCase):
 
     def setUp(self):
         super().setUp()
+
         self.app = Flask('test_app')
+        self.app.config['PUBLICAPI_URL'] = 'http://api.com'
+        self.app.config['URLS'] = {'items': 'items_endpoint'}
+
         self.app_context = self.app.app_context()
         self.app_context.push()
 
     def tearDown(self):
-        super().tearDown()
         self.app_context.pop()
+        super().tearDown()
 
     def test_sets_uri_field_on_fetched_document(self):
         document = {
             '_id': 'item:123',
-            'title': 'a test item'
+            'headline': 'a test item'
         }
-        self.app.config['PUBLICAPI_URL'] = 'http://api.com'
-        self.app.config['URLS'] = {'items': 'items_endpoint'}
 
         instance = self._make_one(datasource='items')
         instance.on_fetched_item(document)
@@ -689,29 +691,66 @@ class OnFetchedItemMethodTestCase(ItemsServiceTestCase):
             'http://api.com/items_endpoint/item%3A123'  # %3A == urlquote(':')
         )
 
+    def test_removes_non_ninjs_content_fields_from_fetched_document(self):
+        document = {
+            '_id': 'item:123',
+            '_etag': '12345abcde',
+            '_created': '12345abcde',
+            '_updated': '12345abcde',
+            'headline': 'breaking news'
+        }
+
+        instance = self._make_one(datasource='items')
+        instance.on_fetched_item(document)
+
+        for field in ('_created', '_etag', '_id', '_updated'):
+            self.assertNotIn(field, document)
+
+    def test_does_not_remove_hateoas_links_from_fetched_document(self):
+        document = {
+            '_id': 'item:123',
+            'headline': 'breaking news',
+            '_links': {
+                'self': {
+                    'href': 'link/to/item/itself',
+                    'title': 'Item'
+                }
+            }
+        }
+
+        instance = self._make_one(datasource='items')
+        instance.on_fetched_item(document)
+
+        expected_links = {
+            'self': {'href': 'link/to/item/itself', 'title': 'Item'}
+        }
+        self.assertEqual(document.get('_links'), expected_links)
+
 
 class OnFetchedMethodTestCase(ItemsServiceTestCase):
     """Tests for the on_fetched() method."""
 
     def setUp(self):
         super().setUp()
+
         self.app = Flask('test_app')
+        self.app.config['PUBLICAPI_URL'] = 'http://api.com'
+        self.app.config['URLS'] = {'items': 'items_endpoint'}
+
         self.app_context = self.app.app_context()
         self.app_context.push()
 
     def tearDown(self):
-        super().tearDown()
         self.app_context.pop()
+        super().tearDown()
 
     def test_sets_uri_field_on_all_fetched_documents(self):
         result = {
             '_items': [
-                {'_id': 'item:123', 'title': 'a test item'},
-                {'_id': 'item:555', 'title': 'another item'},
+                {'_id': 'item:123', 'headline': 'a test item'},
+                {'_id': 'item:555', 'headline': 'another item'},
             ]
         }
-        self.app.config['PUBLICAPI_URL'] = 'http://api.com'
-        self.app.config['URLS'] = {'items': 'items_endpoint'}
 
         instance = self._make_one(datasource='items')
         instance.on_fetched(result)
@@ -725,3 +764,72 @@ class OnFetchedMethodTestCase(ItemsServiceTestCase):
             documents[1].get('uri'),
             'http://api.com/items_endpoint/item%3A555'  # %3A == urlquote(':')
         )
+
+    def test_removes_non_ninjs_content_fields_from_all_fetched_documents(self):
+        result = {
+            '_items': [{
+                '_id': 'item:123',
+                '_etag': '12345abcde',
+                '_created': '12345abcde',
+                '_updated': '12345abcde',
+                'headline': 'breaking news',
+            }, {
+                '_id': 'item:555',
+                '_etag': '67890fedcb',
+                '_created': '2121abab',
+                '_updated': '2121abab',
+                'headline': 'good news',
+            }]
+        }
+
+        instance = self._make_one(datasource='items')
+        instance.on_fetched(result)
+
+        documents = result['_items']
+        for doc in documents:
+            for field in ('_created', '_etag', '_id', '_updated'):
+                self.assertNotIn(field, doc)
+
+    def test_does_not_remove_hateoas_links_from_fetched_documents(self):
+        result = {
+            '_items': [{
+                '_id': 'item:123',
+                '_etag': '12345abcde',
+                '_created': '12345abcde',
+                '_updated': '12345abcde',
+                'headline': 'breaking news',
+                '_links': {
+                    'self': {
+                        'href': 'link/to/item_123',
+                        'title': 'Item'
+                    }
+                }
+            }, {
+                '_id': 'item:555',
+                '_etag': '67890fedcb',
+                '_created': '2121abab',
+                '_updated': '2121abab',
+                'headline': 'good news',
+                '_links': {
+                    'self': {
+                        'href': 'link/to/item_555',
+                        'title': 'Item'
+                    }
+                }
+            }]
+        }
+
+        instance = self._make_one(datasource='items')
+        instance.on_fetched(result)
+
+        documents = result['_items']
+
+        expected_links = {
+            'self': {'href': 'link/to/item_123', 'title': 'Item'}
+        }
+        self.assertEqual(documents[0].get('_links'), expected_links)
+
+        expected_links = {
+            'self': {'href': 'link/to/item_555', 'title': 'Item'}
+        }
+        self.assertEqual(documents[1].get('_links'), expected_links)


### PR DESCRIPTION
NOTE: the HATEOAS `_links` object is left intact.

Resolves [SD-2241](https://dev.sourcefabric.org/browse/SD-2241).