### PR TITLE
modals.less: style issue with flex positioning fixed

### DIFF
--- a/client/app/styles/less/modals.less
+++ b/client/app/styles/less/modals.less
@@ -62,10 +62,6 @@ body:not(:-moz-handler-blocked) .modal{
 		max-height: 100%;
 	}
 	.modal-content {
-		display: flex;
-		justify-content: center;
-		align-items: flex-start;
-		flex-direction: column;
 		flex: 1 1 auto;
 		margin: 10px;
 		.box-shadow(0 0 8px 2px rgba(0, 0, 0, 0.3));


### PR DESCRIPTION
I removed these lines to fix this issue we have on Liveblog:
![modal](http://i.imgur.com/e0shmGN.png)