### PR TITLE
feat(docker): add docker compose config for development

### DIFF
--- a/client/bower.json
+++ b/client/bower.json
@@ -1,1 +1,35 @@
-../bower.json
+{
+  "name": "superdesk-client",
+  "dependencies": {
+    "requirejs": "2.1.15",
+    "jquery": "2.1.3",
+    "lodash": "3.0.1",
+    "bootstrap": "3.1.0",
+    "momentjs": "2.9.0",
+    "moment-timezone": "0.3.0",
+    "angular": "1.3.9",
+    "angular-resource": "1.3.9",
+    "angular-route": "1.3.9",
+    "angular-mocks": "1.3.9",
+    "angular-gettext": "2.0.1",
+    "angular-bootstrap": "0.12.1",
+    "gridster": "0.2.1",
+    "d3": "3.5.3",
+    "jcrop": "0.9.12",
+    "ng-file-upload": "1.6.12",
+    "raven-js": "1.1.11",
+    "jquery-ui": "1.11.2",
+    "medium-editor": "4.9.0",
+    "ment.io": "0.9.22"
+  },
+  "ignore": [
+    "**/.*",
+    "server",
+    "docker",
+    "setup.py",
+    "client/docs"
+  ],
+  "resolutions": {
+    "angular": "1.3.9"
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,51 @@
+mongodb:
+  image: mongo:2.6
+  volumes:
+   - data/mongodb:/data/db
+
+redis:
+  image: redis:2.8
+  volumes:
+   - data/redis:/data
+
+elastic:
+  image: elasticsearch:1.5
+  volumes:
+   - data/elastic:/usr/share/elasticsearch/data
+  ports:
+   - "9200:9200"
+
+backend:
+  build: server
+  command: sh /opt/superdesk/scripts/fig_wrapper.sh honcho start
+  links:
+   - mongodb
+   - redis
+   - elastic
+  environment:
+   - MONGOLAB_URI=mongodb://mongodb:27017/test
+   - LEGAL_ARCHIVE_URI=mongodb://mongodb:27017/test
+   - ELASTICSEARCH_URL=http://elastic:9200
+   - ELASTICSEARCH_INDEX
+   - CELERY_BROKER_URL=redis://redis:6379/1
+   - REDIS_URL=redis://redis:6379/1
+   - SUPERDESK_URL=http://localhost:5000/api
+   - SUPERDESK_CLIENT_URL=http://localhost:9000
+   - SUPERDESK_TESTING=True
+   - SUPERDESK_RELOAD=True
+  volumes:
+   - server:/opt/superdesk
+  ports:
+   - "5000:5000"
+   - "5100:5100"
+
+frontend:
+  build: client
+  command: sh -c "grunt --force server --server='http://localhost:5000/api' --ws='ws://localhost:5100'"
+  volumes:
+   - client:/opt/superdesk-client
+  ports:
+   - "9000:9000"
+   - "35729:35729"
+  links:
+   - backend


### PR DESCRIPTION
it runs in dev mode, including livereload, via docker.

if you have docker-compose installed, you can test this via:
```
$ docker-compose build
$ docker-compose up
```
to create admin user, while having it up, run:
```
$ docker-compose run backend python3 manage.py users:create ...
```
client is on localhost:9000, server on localhost:5000/api
let me know if this works for anyone..

fyi bower.json is back in client (and kept in root) because you can't add/copy symlink in dockerfile