### PR TITLE
public API: slightly improve the invalid date error message

### DIFF
--- a/server/publicapi/items/service.py
+++ b/server/publicapi/items/service.py
@@ -208,7 +208,7 @@ class ItemsService(BaseService):
             * if the start date is bigger than the end date
         """
         # check date limits' format...
-        err_msg = ("{} parameter must be an ISO 8601 date (YYYY-MM-DD) "
+        err_msg = ("{} parameter must be a valid ISO 8601 date (YYYY-MM-DD) "
                    "without the time part")
 
         try:

--- a/server/publicapi/tests/items_service_test.py
+++ b/server/publicapi/tests/items_service_test.py
@@ -246,7 +246,7 @@ class GetMethodTestCase(ItemsServiceTestCase):
         ex = context.exception
         self.assertEqual(
             ex.desc,
-            ("start_date parameter must be an ISO 8601 date (YYYY-MM-DD) "
+            ("start_date parameter must be a valid ISO 8601 date (YYYY-MM-DD) "
              "without the time part"))
 
     def test_raises_correct_error_on_invalid_end_date_parameter(self):
@@ -263,7 +263,7 @@ class GetMethodTestCase(ItemsServiceTestCase):
         ex = context.exception
         self.assertEqual(
             ex.desc,
-            ("end_date parameter must be an ISO 8601 date (YYYY-MM-DD) "
+            ("end_date parameter must be a valid ISO 8601 date (YYYY-MM-DD) "
              "without the time part"))
 
     def test_raises_correct_error_if_start_date_greater_than_end_date(self):


### PR DESCRIPTION
I added a word "valid" to the error message to make it more clear that a date like 2015-04-31 is rejected not because of its format, but because it is does not represent a _valid_ date (due to the incorrect number of days in this case).