### PR TITLE
chore(docker): remove hack for liveblog

### DIFF
--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -1,2 +1,1 @@
 env/
-docker-compose.yml

--- a/docker/container_build.sh
+++ b/docker/container_build.sh
@@ -24,7 +24,6 @@ export COMPOSE_PROJECT_NAME=build_$INSTANCE
 
 # clean-up container stuff:
 cd $SCRIPT_DIR &&
-. ./docker-compose.yml.sh > docker-compose.yml &&
 docker-compose stop;
 docker-compose kill;
 docker-compose rm --force;

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,3 @@
-cat <<EOF
 mongodb:
   image: mongo:2.6
   volumes:
@@ -69,8 +68,6 @@ backend:
 
 frontend:
   build: ../client
-  environment:
-   - EMBEDLY_KEY=$bamboo_EMBEDLY_KEY
   command: sh -c "grunt build --server='http://127.0.0.1/api' --ws='ws://127.0.0.1/ws' && nginx"
   volumes:
    - ../results/client/unit:/opt/superdesk-client/unit-test-results
@@ -79,6 +76,3 @@ frontend:
    - "80:80"
   links:
    - backend
-EOF
-
-# vim: set ft=yaml:


### PR DESCRIPTION
that needed to ease inheritance of this doker-compose config from sd-dev docker-compose config (not to repeat all the settings there and not change them in both places every time)

after this PR will be merged changes should be made in stash `qa/superdesk-deploy` repo