### PR TITLE
fix(storage): disable task to check consistency

### DIFF
--- a/server/settings.py
+++ b/server/settings.py
@@ -125,10 +125,6 @@ CELERYBEAT_SCHEDULE = {
         'task': 'apps.publish.content_purge',
         'schedule': crontab(minute=30)
     },
-    'system:compare_repositories': {
-        'task': 'superdesk.data_consistency.compare_repos',
-        'schedule': timedelta(minutes=30)
-    }
 }
 
 SENTRY_DSN = env('SENTRY_DSN')


### PR DESCRIPTION
it's using too much memory atm which makes oom-killer stop either mongo or
elasticsearch when running this.