### PR TITLE
[WIP] RSS ingest: extract referenced images' URLs from RSS entries

### DIFF
--- a/server/superdesk/io/rss.py
+++ b/server/superdesk/io/rss.py
@@ -14,6 +14,7 @@ import requests
 
 from calendar import timegm
 from collections import namedtuple
+from concurrent import futures
 from datetime import datetime
 
 from superdesk.errors import IngestApiError, ParserError
@@ -118,7 +119,8 @@ class RssIngestService(IngestService):
             # reference other media types, e.g. video clips).
             image_urls = self._extract_image_links(entry)
             if image_urls:
-                raise NotImplementedError()  # TODO: create a package
+                images = self._fetch_images(image_urls)  # TODO: test is called
+                raise NotImplementedError(images)  # TODO: create a package
             else:
                 item = self._create_item(entry, field_aliases)
                 self.add_timestamps(item)
@@ -189,6 +191,46 @@ class RssIngestService(IngestService):
                 img_links.add(item['url'])
 
         return list(img_links)
+
+    def _fetch_images(self, image_urls):
+        """Fetch images from the given list of URLs.
+
+        It is assumed that each URL points to an image file. The images are
+        downloaded in parallel. Any errors are silently ignored and the image
+        whose download has failed is exluded from the result.
+
+        NOTE: The `image_urls` iterable should not return any duplicates in
+        order to avoid unnecessary repeated downloads of the same image.
+
+        :param image_urls: URLs of the images to fetch
+        :type image_urls: iterable
+
+        :return: A dictionary containing the successfully downloaded images.
+            The keys are image URLs, and the values the corresponding image
+            data as a binary string.
+        """
+        images = {}
+
+        with futures.ThreadPoolExecutor(max_workers=5) as executor:
+            downloads = []
+
+            for url in image_urls:
+                future = executor.submit(requests.get, url, timeout=10)
+                downloads.append(future)
+
+            for download in futures.as_completed(downloads, timeout=60):
+                try:
+                    response = download.result()
+                except requests.exceptions.RequestException:
+                    pass  # TODO: what here? error or silently ignore?
+                    # url = ex.request.url (if exists)... there's also ex.args
+                else:
+                    if response.ok:
+                        images[response.url] = response.content
+                    else:
+                        pass  # TODO: what here? error or silently ignore?
+
+        return images
 
     def _create_item(self, data, field_aliases=None):
         """Create a new content item from RSS feed data.


### PR DESCRIPTION
I am adding support for ingesting external images referenced by entries (items) in an RSS feed. The first step is to find all URLs that reference an external image.

Please check the MIME types and the file extensions for the image types we want to support and let me know if anything should be changed. Please also verify that the list of RSS tags we take into account when looking for image URLs is indeed complete.

Thanks!