### PR TITLE
Add suport for ingesting images linked in RSS entries

### DIFF
--- a/server/superdesk/io/rss.py
+++ b/server/superdesk/io/rss.py
@@ -14,7 +14,6 @@ import requests
 
 from calendar import timegm
 from collections import namedtuple
-from concurrent import futures
 from datetime import datetime
 
 from superdesk.errors import IngestApiError, ParserError
@@ -118,8 +117,8 @@ class RssIngestService(IngestService):
             item = self._create_item(entry, field_aliases)
             self.add_timestamps(item)
 
-            # If the entry references any images, create picture items from
-            # them and create a package containing them and the entry itself.
+            # If the RSS entry references any images, create picture items from
+            # them and create a package referencing them and the entry itself.
             # If there are no image references, treat entry as a simple text
             # item, even if it might reference other media types, e.g. videos.
             image_urls = self._extract_image_links(entry)
@@ -198,50 +197,6 @@ class RssIngestService(IngestService):
 
         return list(img_links)
 
-    # TODO: delete this, the downloads will be handled elsewhere
-    def _fetch_images(self, image_urls, provider):
-        """Fetch images from the given list of URLs.
-
-        It is assumed that each URL points to an image file. The images are
-        downloaded in parallel. If *any* of the downloads fails, an error is
-        raised.
-
-        NOTE: The `image_urls` iterable should not return any duplicates in
-        order to avoid unnecessary repeated downloads of the same image.
-
-        :param image_urls: URLs of the images to fetch
-        :type image_urls: iterable
-        :param provider: data provider instance, needed as an argument when
-            raising ingest errors
-
-        :return: A dictionary containing the successfully downloaded images.
-            The keys are image URLs, and the values the corresponding image
-            data as a binary string.
-        """
-        images = {}
-
-        with futures.ThreadPoolExecutor(max_workers=5) as executor:
-            downloads = []
-
-            for url in image_urls:
-                future = executor.submit(requests.get, url, timeout=10)
-                downloads.append(future)
-
-            for download in futures.as_completed(downloads, timeout=60):
-                try:
-                    response = download.result()
-                except requests.exceptions.RequestException as ex:
-                    raise IngestApiError.apiRequestError(
-                        exception=ex, provider=provider)
-                else:
-                    if response.ok:
-                        images[response.url] = response.content
-                    else:
-                        raise IngestApiError.apiRequestError(
-                            exception=None, provider=provider)
-
-        return images
-
     def _create_item(self, data, field_aliases=None):
         """Create a new content item from RSS feed data.
 
@@ -274,7 +229,17 @@ class RssIngestService(IngestService):
         return item
 
     def _create_image_items(self, image_links, text_item):
-        """ TODO: docstring"""
+        """Create a list of picture items that represent the external images
+        located on given URLs.
+
+        Each created item's `firstcreated` and `versioncreated` fields are set
+        to the same value as the values of these fields in `text_item`.
+
+        :param iterable image_links: list of image URLs
+        :param dict text_item: the "main" text item the images are related to
+
+        :return: list of created image items (as dicts)
+        """
         image_items = []
 
         for image_url in image_links:
@@ -294,16 +259,15 @@ class RssIngestService(IngestService):
         return image_items
 
     def _create_package(self, text_item, image_items):
-        """TODO: change dosctring... explain side effect (versioncrated for
-        image items )
+        """Create a new content package from given content items.
 
-        Wrap given text item and images into a new content package.
+        The package's `main` group contains only the references to given items,
+        not the items themselves. In the list of references, the reference to
+        the text item preceeds the references to image items.
 
-        TODO: change image_links dosctring
-
-        :param dict text_item: text content of the package
-        :param dict images: (image_url, image_data) pairs to be added to the
-            package as picture items
+        :param dict text_item: item representing the text content
+        :param list image_items: list of items (dicts) representing the images
+            related to the text content
         :return: the created content package
         :rtype: dict
         """

--- a/server/superdesk/io/rss.py
+++ b/server/superdesk/io/rss.py
@@ -60,19 +60,18 @@ class RssIngestService(IngestService):
     * type - field's data type
     """
 
-    # TODO: remove bmp, add tiff (to be consistent with media.renditions)
     IMG_MIME_TYPES = (
-        'image/bmp',
         'image/gif',
         'image/jpeg',
         'image/png',
+        'image/tiff',
     )
     """
     Supported MIME types for ingesting external images referenced by the
     RSS entries.
     """
 
-    IMG_FILE_SUFFIXES = ('.bmp', '.gif', '.jpeg', '.jpg', '.png',)
+    IMG_FILE_SUFFIXES = ('.gif', '.jpeg', '.jpg', '.png', '.tif', '.tiff')
     """
     Supported image filename extensions for ingesting (used for the
     <media:thumbnail> tags - they lack the "type" attribute).

--- a/server/superdesk/io/rss_test.py
+++ b/server/superdesk/io/rss_test.py
@@ -344,8 +344,8 @@ class ExtractImageLinksMethodTestCase(RssIngestServiceTest):
                 'type': 'text/html',
             }, {
                 'rel': 'enclosure',
-                'href': 'http://foo.bar/image_1.tiff',
-                'type': 'image/tiff',
+                'href': 'http://foo.bar/image_1.bmp',
+                'type': 'image/bmp',
             }
         ]
 
@@ -356,21 +356,21 @@ class ExtractImageLinksMethodTestCase(RssIngestServiceTest):
     def test_extracts_media_thumbnail_links(self):
         rss_entry = MagicMock()
         rss_entry.media_thumbnail = [
-            {'url': 'http://foo.bar/small_img.jpg'},
-            {'url': 'http://foo.bar/thumb_x.png'},
+            {'url': 'http://foo.bar/small_img.gif'},
+            {'url': 'http://foo.bar/thumb_x.tiff'},
         ]
 
         links = self.instance._extract_image_links(rss_entry)
 
         self.assertCountEqual(
             links,
-            ['http://foo.bar/small_img.jpg', 'http://foo.bar/thumb_x.png']
+            ['http://foo.bar/small_img.gif', 'http://foo.bar/thumb_x.tiff']
         )
 
     def test_omits_media_thumbnail_links_to_non_supported_formats(self):
         rss_entry = MagicMock()
         rss_entry.media_thumbnail = [
-            {'url': 'http://foo.bar/image.tiff'},
+            {'url': 'http://foo.bar/image.bmp'},
         ]
 
         links = self.instance._extract_image_links(rss_entry)
@@ -381,11 +381,11 @@ class ExtractImageLinksMethodTestCase(RssIngestServiceTest):
         rss_entry = MagicMock()
         rss_entry.media_content = [
             {
-                'url': 'http://foo.bar/image_1.jpg',
+                'url': 'http://foo.bar/image_1.jpeg',
                 'type': 'image/jpeg',
             }, {
-                'url': 'http://foo.bar/image_2.png',
-                'type': 'image/png',
+                'url': 'http://foo.bar/image_2.tiff',
+                'type': 'image/tiff',
             }
         ]
 
@@ -393,7 +393,7 @@ class ExtractImageLinksMethodTestCase(RssIngestServiceTest):
 
         self.assertCountEqual(
             links,
-            ['http://foo.bar/image_1.jpg', 'http://foo.bar/image_2.png']
+            ['http://foo.bar/image_1.jpeg', 'http://foo.bar/image_2.tiff']
         )
 
     def test_omits_media_content_links_to_non_supported_mime_types(self):
@@ -406,8 +406,8 @@ class ExtractImageLinksMethodTestCase(RssIngestServiceTest):
                 'url': 'http://foo.bar/video.avi',
                 'type': 'video/avi',
             }, {
-                'url': 'http://foo.bar/image_1.tiff',
-                'type': 'image/tiff',
+                'url': 'http://foo.bar/image_1.bmp',
+                'type': 'image/bmp',
             }
         ]
 


### PR DESCRIPTION
Resolves [SD-2484](https://dev.sourcefabric.org/browse/SD-2482).

NOTE: For some reason I was not able to see any ingested content under the CONTENT tab in my local Superdesk instance, but when debugging the ingest process, it seemed to me that items _have_ been ingested successfully.

For example, peeking into the _all_items_ list [here](https://github.com/superdesk/superdesk/blob/master/server/superdesk/io/commands/update_ingest.py#L320) showed that all items' `state` attribute was set to `'ingested'`, there were no errors, the images have been successfully downloaded (was able to fetch them via the local URL, e.g. `http://localhost:5000/api/upload/.../raw?_schema=http`) etc.