### PR TITLE
fix(docker): fix unittests for publicapi in docker

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -45,8 +45,8 @@ backend:
    - logstash
    - postfix
   environment:
-   - MONGOLAB_URI=mongodb://mongodb:27017/test
-   - LEGAL_ARCHIVE_URI=mongodb://mongodb:27017/test
+   - MONGOLAB_URI=mongodb://mongodb/test
+   - LEGAL_ARCHIVE_URI=mongodb://mongodb/test
    - ELASTICSEARCH_URL=http://elastic:9200
    - ELASTICSEARCH_INDEX
    - CELERY_BROKER_URL=redis://redis:6379/1

--- a/server/publicapi/tests/items_service_test.py
+++ b/server/publicapi/tests/items_service_test.py
@@ -666,7 +666,7 @@ class OnFetchedItemMethodTestCase(ItemsServiceTestCase):
     def setUp(self):
         super().setUp()
 
-        self.app = Flask('test_app')
+        self.app = Flask(__name__)
         self.app.config['PUBLICAPI_URL'] = 'http://api.com'
         self.app.config['URLS'] = {'items': 'items_endpoint'}
 
@@ -733,7 +733,7 @@ class OnFetchedMethodTestCase(ItemsServiceTestCase):
     def setUp(self):
         super().setUp()
 
-        self.app = Flask('test_app')
+        self.app = Flask(__name__)
         self.app.config['PUBLICAPI_URL'] = 'http://api.com'
         self.app.config['URLS'] = {'items': 'items_endpoint'}
 

--- a/server/settings.py
+++ b/server/settings.py
@@ -64,6 +64,7 @@ X_HEADERS = ['Content-Type', 'Authorization', 'If-Match']
 
 
 MONGO_DBNAME = env('MONGO_DBNAME', 'superdesk')
+MONGO_URI = env('MONGO_URI', 'mongodb://localhost/%s' % MONGO_DBNAME)
 if env('MONGOLAB_URI'):
     MONGO_URI = env('MONGOLAB_URI')
 elif env('MONGODB_PORT'):
@@ -75,6 +76,7 @@ if env('LEGAL_ARCHIVE_URI'):
 elif env('LEGAL_ARCHIVEDB_PORT'):
     LEGAL_ARCHIVE_URI = '{0}/{1}'.format(env('LEGAL_ARCHIVEDB_PORT').replace('tcp:', 'mongodb:'),
                                          LEGAL_ARCHIVE_DBNAME)
+PUBLICAPI_URI = env('PUBLICAPI_URI', MONGO_URI)
 
 ELASTICSEARCH_URL = env('ELASTICSEARCH_URL', 'http://localhost:9200')
 ELASTICSEARCH_INDEX = env('ELASTICSEARCH_INDEX', 'superdesk')


### PR DESCRIPTION
it was missing config with prefix which works fine on localhost,
but not when mongo is running in a container