### PR TITLE
Add more metadata to RSS-ingested package (versioncreated, guid, etc.)

### DIFF
--- a/server/superdesk/io/rss.py
+++ b/server/superdesk/io/rss.py
@@ -299,6 +299,9 @@ class RssIngestService(IngestService):
         not the items themselves. In the list of references, the reference to
         the text item preceeds the references to image items.
 
+        Package's `firstcreated` and `versioncreated` fields are set to values
+        of these fields in `text_item`.
+
         :param dict text_item: item representing the text content
         :param list image_items: list of items (dicts) representing the images
             related to the text content
@@ -307,6 +310,9 @@ class RssIngestService(IngestService):
         """
         package = {
             'type': 'composite',
+            'guid': 'package:' + text_item['guid'],
+            'firstcreated': text_item['firstcreated'],
+            'versioncreated': text_item['versioncreated'],
             'groups': [
                 {
                     'id': 'root',

--- a/server/superdesk/io/rss.py
+++ b/server/superdesk/io/rss.py
@@ -12,6 +12,9 @@
 import feedparser
 import requests
 
+from apps.archive.common import GUID_TAG
+from apps.archive.common import generate_guid
+
 from calendar import timegm
 from collections import namedtuple
 from datetime import datetime
@@ -278,7 +281,7 @@ class RssIngestService(IngestService):
 
         for image_url in image_links:
             img_item = {
-                'guid': image_url,
+                'guid': generate_guid(type=GUID_TAG),
                 'type': 'picture',
                 'firstcreated': text_item.get('firstcreated'),
                 'versioncreated': text_item.get('versioncreated'),
@@ -310,7 +313,7 @@ class RssIngestService(IngestService):
         """
         package = {
             'type': 'composite',
-            'guid': 'package:' + text_item['guid'],
+            'guid': generate_guid(type=GUID_TAG),
             'firstcreated': text_item['firstcreated'],
             'versioncreated': text_item['versioncreated'],
             'groups': [

--- a/server/superdesk/io/rss_test.py
+++ b/server/superdesk/io/rss_test.py
@@ -593,7 +593,11 @@ class CreatePackageMethodTestCase(RssIngestServiceTest):
     """Tests for the _create_package() method."""
 
     def test_creates_package_from_given_text_and_image_items(self):
-        text_item = {'guid': 'main_text'}
+        text_item = {
+            'guid': 'main_text',
+            'firstcreated': datetime(2015, 1, 27, 16, 0, 0),
+            'versioncreated': datetime(2015, 1, 27, 16, 0, 0),
+        }
         img_item_1 = {'guid': 'image_1'}
         img_item_2 = {'guid': 'image_2'}
 
@@ -604,6 +608,9 @@ class CreatePackageMethodTestCase(RssIngestServiceTest):
 
         expected = {
             'type': 'composite',
+            'guid': 'package:main_text',
+            'firstcreated': datetime(2015, 1, 27, 16, 0, 0),
+            'versioncreated': datetime(2015, 1, 27, 16, 0, 0),
             'groups': [
                 {
                     'id': 'root',

--- a/server/superdesk/io/rss_test.py
+++ b/server/superdesk/io/rss_test.py
@@ -13,7 +13,7 @@ from datetime import datetime
 from superdesk.tests import TestCase
 from time import struct_time
 from unittest import mock
-from unittest.mock import MagicMock
+from unittest.mock import call, MagicMock
 
 
 feed_parse = MagicMock()
@@ -551,7 +551,9 @@ class CreateItemMethodTestCase(RssIngestServiceTest):
 class CreateImageItemsMethodTestCase(RssIngestServiceTest):
     """Tests for the _create_image_items() method."""
 
-    def test_creates_image_items_from_given_urls(self):
+    @mock.patch('superdesk.io.rss.generate_guid')
+    @mock.patch('superdesk.io.rss.GUID_TAG', 'guid_type_tag')
+    def test_creates_image_items_from_given_urls(self, fake_generate_guid):
         links = [
             'http://foo.bar/image_1.jpg',
             'http://baz.ban/image_2.jpg',
@@ -560,12 +562,18 @@ class CreateImageItemsMethodTestCase(RssIngestServiceTest):
             'firstcreated': datetime(2015, 1, 27, 15, 56, 59),
             'versioncreated': datetime(2015, 3, 19, 17, 20, 45)
         }
+        fake_generate_guid.side_effect = ('image:guid:1', 'image:guid:2')
 
         result = self.instance._create_image_items(links, text_item)
 
-        expected = [
+        self.assertEqual(
+            fake_generate_guid.mock_calls,
+            [call(type='guid_type_tag')] * 2
+        )
+
+        expected_result = [
             {
-                'guid': 'http://foo.bar/image_1.jpg',
+                'guid': 'image:guid:1',
                 'type': 'picture',
                 'firstcreated': datetime(2015, 1, 27, 15, 56, 59),
                 'versioncreated': datetime(2015, 3, 19, 17, 20, 45),
@@ -575,7 +583,7 @@ class CreateImageItemsMethodTestCase(RssIngestServiceTest):
                     }
                 }
             }, {
-                'guid': 'http://baz.ban/image_2.jpg',
+                'guid': 'image:guid:2',
                 'type': 'picture',
                 'firstcreated': datetime(2015, 1, 27, 15, 56, 59),
                 'versioncreated': datetime(2015, 3, 19, 17, 20, 45),
@@ -586,13 +594,17 @@ class CreateImageItemsMethodTestCase(RssIngestServiceTest):
                 }
             }
         ]
-        self.assertCountEqual(result, expected)
+        self.assertCountEqual(result, expected_result)
 
 
 class CreatePackageMethodTestCase(RssIngestServiceTest):
     """Tests for the _create_package() method."""
 
-    def test_creates_package_from_given_text_and_image_items(self):
+    @mock.patch('superdesk.io.rss.generate_guid')
+    @mock.patch('superdesk.io.rss.GUID_TAG', 'guid_type_tag')
+    def test_creates_package_from_given_text_and_image_items(
+        self, fake_generate_guid
+    ):
         text_item = {
             'guid': 'main_text',
             'firstcreated': datetime(2015, 1, 27, 16, 0, 0),
@@ -601,14 +613,18 @@ class CreatePackageMethodTestCase(RssIngestServiceTest):
         img_item_1 = {'guid': 'image_1'}
         img_item_2 = {'guid': 'image_2'}
 
+        fake_generate_guid.return_value = 'package:guid:abcd123'
+
         package = self.instance._create_package(
             text_item,
             [img_item_1, img_item_2]
         )
 
+        fake_generate_guid.assert_called_with(type='guid_type_tag')
+
         expected = {
             'type': 'composite',
-            'guid': 'package:main_text',
+            'guid': 'package:guid:abcd123',
             'firstcreated': datetime(2015, 1, 27, 16, 0, 0),
             'versioncreated': datetime(2015, 1, 27, 16, 0, 0),
             'groups': [


### PR DESCRIPTION
It turned out that RSS packages lacked metadata and were filtered out because they were recognized as expired, and they also lacked the `guid` attribute. This PR fixes that.