### PR TITLE
(fix) [SD-2542]

### DIFF
--- a/client/app/scripts/superdesk-desks/desks.js
+++ b/client/app/scripts/superdesk-desks/desks.js
@@ -410,6 +410,8 @@
                         function(response) {
                             if (angular.isDefined(response.data._message)) {
                                 notify.error(gettext('Error: ' + response.data._message));
+                            } else {
+                                notify.error(gettext('Unknown Error: There was a problem, desk was not deleted.'));
                             }
                         }
                     );
@@ -847,6 +849,8 @@
                                 var origDesk = _.find(scope.desks._items, {_id: scope.desk.edit._id});
                                 _.extend(origDesk, scope.desk.edit);
                             }
+
+                            desks.deskLookup[scope.desk.edit._id] = scope.desk.edit;
                             WizardHandler.wizard('desks').next();
                         }, errorMessage);
                     };
@@ -909,10 +913,11 @@
 
                     scope.getstages = function(previous) {
                         if (scope.desk.edit && scope.desk.edit._id) {
-                            scope.message = null;
+                            scope.message = 'loading...';
                             api('stages').query({where: {desk: scope.desk.edit._id}})
                                 .then(function(result) {
                                     scope.stages = result._items;
+                                    scope.message = null;
                                 });
                         } else {
                             WizardHandler.wizard('desks').goTo(previous);
@@ -1147,12 +1152,13 @@
                         if (step === 'people') {
                             scope.search = null;
                             scope.deskMembers = [];
-                            scope.message = null;
+                            scope.message = 'loading...';
 
                             if (scope.desk.edit && scope.desk.edit._id) {
                                 desks.fetchUsers().then(function(result) {
                                     scope.users = desks.users._items;
                                     scope.deskMembers = desks.deskMembers[scope.desk.edit._id] || [];
+                                    scope.message = null;
                                 });
                             } else {
                                 WizardHandler.wizard('desks').goTo(previous);

--- a/client/app/scripts/superdesk-desks/views/desk-config-modal.html
+++ b/client/app/scripts/superdesk-desks/views/desk-config-modal.html
@@ -159,7 +159,7 @@
 				</div>
 				<div class="modal-footer">
 				  	<button class="btn pull-left" ng-click="previous()" translate>Previous</button>
-				  	<button class="btn btn-primary" ng-click="next()" translate>Next</button>
+				  	<button class="btn btn-primary" ng-disabled="message != null" ng-click="next()" translate>Next</button>
 				</div>
 			</div>
 		</div>
@@ -183,7 +183,7 @@
 				</div>
 				<div class="modal-footer">
 				  	<button class="btn pull-left" ng-click="previous()" translate>Previous</button>
-				  	<button class="btn btn-primary" ng-click="save()" translate>Next</button>
+				  	<button class="btn btn-primary" ng-click="save()" ng-disabled="message != null" translate>Next</button>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
Issues fixed:

1. No message is shown indicating why the desk containing sages has not been deleted. There can be no desk without a stage as incoming stage is mandatory. Originally, as per the requirement user should be able to delete if the desk doesn't have any content.
2. When there are more users in the system and desk as well the system takes time in loading the list. While loading if user clicks on Next the system will send request payload as members: [] resulting in 0 members in the desk although there were users in the desk initially. Same case can occur in case of stages as well.