### PR TITLE
Automate the registration of the ingest classes as providers

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -26,6 +26,7 @@ from superdesk.storage.desk_media_storage import SuperdeskGridFSMediaStorage
 from superdesk.validator import SuperdeskValidator
 from raven.contrib.flask import Sentry
 from superdesk.errors import SuperdeskError, SuperdeskApiError
+from superdesk.io import providers
 from logging.handlers import SysLogHandler
 from settings import LOG_SERVER_ADDRESS, LOG_SERVER_PORT
 
@@ -117,6 +118,11 @@ def get_app(config=None):
 
     app.sentry = sentry
     sentry.init_app(app)
+
+    # instantiate registered provider classes (leave non-classes intact)
+    for key, provider in providers.items():
+        providers[key] = provider() if isinstance(provider, type) else provider
+
     return app
 
 if __name__ == '__main__':

--- a/server/superdesk/io/aap.py
+++ b/server/superdesk/io/aap.py
@@ -16,21 +16,22 @@ from .nitf import NITFParser
 from superdesk.io.file_ingest_service import FileIngestService
 from superdesk.utc import utc, timezone
 from superdesk.notification import push_notification
-from superdesk.io import register_provider
 from ..etree import etree, ParseError as etreeParserError
 from superdesk.utils import get_sorted_files, FileSortAttributes
 from superdesk.errors import ParserError, ProviderError
 
 
 logger = logging.getLogger(__name__)
-PROVIDER = 'aap'
-errors = [ParserError.nitfParserError().get_error_description(),
-          ProviderError.ingestError().get_error_description(),
-          ParserError.parseFileError().get_error_description()]
 
 
 class AAPIngestService(FileIngestService):
     """AAP Ingest Service"""
+
+    PROVIDER = 'aap'
+
+    ERRORS = [ParserError.nitfParserError().get_error_description(),
+              ProviderError.ingestError().get_error_description(),
+              ParserError.parseFileError().get_error_description()]
 
     def __init__(self):
         self.tz = timezone('Australia/Sydney')
@@ -85,5 +86,3 @@ class AAPIngestService(FileIngestService):
         except Exception as ex:
             self.move_file(self.path, filename, provider=provider, success=False)
             raise ParserError.parseFileError('AAP', filename, ex, provider)
-
-register_provider(PROVIDER, AAPIngestService(), errors)

--- a/server/superdesk/io/afp.py
+++ b/server/superdesk/io/afp.py
@@ -19,18 +19,19 @@ from superdesk.utils import get_sorted_files, FileSortAttributes
 from ..utc import utc
 from ..etree import etree, ParseError as etreeParserError
 from superdesk.notification import push_notification
-from superdesk.io import register_provider
 from superdesk.errors import ParserError, ProviderError
 
 
 logger = logging.getLogger(__name__)
-PROVIDER = 'afp'
-errors = [ParserError.newsmlOneParserError().get_error_description(),
-          ProviderError.ingestError().get_error_description()]
 
 
 class AFPIngestService(FileIngestService):
     """AFP Ingest Service"""
+
+    PROVIDER = 'afp'
+
+    ERRORS = [ParserError.newsmlOneParserError().get_error_description(),
+              ProviderError.ingestError().get_error_description()]
 
     def __init__(self):
         self.parser = NewsMLOneParser()
@@ -67,6 +68,3 @@ class AFPIngestService(FileIngestService):
                 raise ProviderError.ingestError(ex, provider)
 
         push_notification('ingest:update')
-
-
-register_provider(PROVIDER, AFPIngestService(), errors)

--- a/server/superdesk/io/dpa.py
+++ b/server/superdesk/io/dpa.py
@@ -14,18 +14,19 @@ import logging
 from datetime import datetime
 from superdesk.io.file_ingest_service import FileIngestService
 from superdesk.utc import utc
-from superdesk.io import register_provider
 from superdesk.utils import get_sorted_files, FileSortAttributes
 from superdesk.errors import ParserError, ProviderError
 from superdesk.io.iptc7901 import Iptc7901FileParser
 
 logger = logging.getLogger(__name__)
-PROVIDER = 'dpa'
-errors = [ParserError.IPTC7901ParserError().get_error_description(),
-          ProviderError.ingestError().get_error_description()]
 
 
 class DPAIngestService(FileIngestService):
+
+    PROVIDER = 'dpa'
+
+    ERRORS = [ParserError.IPTC7901ParserError().get_error_description(),
+              ProviderError.ingestError().get_error_description()]
 
     def __init__(self):
         self.parser = Iptc7901FileParser()
@@ -60,5 +61,3 @@ class DPAIngestService(FileIngestService):
             except Exception as ex:
                 self.move_file(self.path, filename, provider=provider, success=False)
                 raise ProviderError.ingestError(ex, provider)
-
-register_provider(PROVIDER, DPAIngestService(), errors)

--- a/server/superdesk/io/email.py
+++ b/server/superdesk/io/email.py
@@ -10,18 +10,18 @@
 
 import imaplib
 from .ingest_service import IngestService
-from superdesk.io import register_provider
 from superdesk.upload import url_for_media
 from superdesk.errors import IngestEmailError
 
 from superdesk.io.rfc822 import rfc822Parser
 
-PROVIDER = 'email'
-errors = [IngestEmailError.emailError().get_error_description(),
-          IngestEmailError.emailLoginError().get_error_description()]
-
 
 class EmailReaderService(IngestService):
+
+    PROVIDER = 'email'
+
+    ERRORS = [IngestEmailError.emailError().get_error_description(),
+              IngestEmailError.emailLoginError().get_error_description()]
 
     def __init__(self):
         self.parser = rfc822Parser()
@@ -60,5 +60,3 @@ class EmailReaderService(IngestService):
 
     def prepare_href(self, href):
         return url_for_media(href)
-
-register_provider(PROVIDER, EmailReaderService(), errors)

--- a/server/superdesk/io/ftp.py
+++ b/server/superdesk/io/ftp.py
@@ -15,11 +15,9 @@ import tempfile
 from datetime import datetime
 from superdesk.utc import utc
 from superdesk.etree import etree
-from superdesk.io import get_xml_parser, register_provider
+from superdesk.io import get_xml_parser
 from .ingest_service import IngestService
 from superdesk.errors import IngestFtpError
-errors = [IngestFtpError.ftpUnknownParserError().get_error_description(),
-          IngestFtpError.ftpError().get_error_description()]
 
 try:
     from urllib.parse import urlparse
@@ -32,6 +30,11 @@ class FTPService(IngestService):
 
     DATE_FORMAT = '%Y%m%d%H%M%S'
     FILE_SUFFIX = '.xml'
+
+    PROVIDER = 'ftp'
+
+    ERRORS = [IngestFtpError.ftpUnknownParserError().get_error_description(),
+              IngestFtpError.ftpError().get_error_description()]
 
     def config_from_url(self, url):
         """Parse given url into ftp config.
@@ -96,5 +99,3 @@ class FTPService(IngestService):
             raise
         except Exception as ex:
             raise IngestFtpError.ftpError(ex, provider)
-
-register_provider('ftp', FTPService(), errors)

--- a/server/superdesk/io/ingest_service.py
+++ b/server/superdesk/io/ingest_service.py
@@ -14,12 +14,62 @@ import superdesk
 from datetime import datetime
 from superdesk.utc import utc, utcnow
 from superdesk.errors import SuperdeskApiError, SuperdeskIngestError
+from superdesk.io import register_provider
 
 
 logger = logging.getLogger(__name__)
 
 
-class IngestService():
+class AutoRegisteredMeta(type):
+    """Metaclass for automatically registering the ingest service instances.
+
+    An instance of an ingest class is registered as a provider when the class
+    is instantiated - but only if the class defines a `PROVIDER` attribute
+    containing the name under which to register the class instances.
+
+    Every ingest provider class needs to define an `ERRORS` attribute
+    representing a list of <error_number, error_message> pairs that might be
+    raised by the class instances' methods.
+
+    If another provider class with the same `PROVIDER` name has already been
+    defined, a TypeError is raised.
+    """
+    _providers = {}  # keep track of all PROVIDER names defined in classes
+
+    def __new__(metacls, name, bases, attrs):
+        provider_name = attrs.get('PROVIDER')
+
+        if provider_name is not None:
+            if 'ERRORS' not in attrs:
+                raise AttributeError(
+                    "Provider class {} must define "
+                    "the ERRORS list attribute.".format(name))
+
+            if provider_name in metacls._providers:
+                raise TypeError(
+                    "PROVIDER {} already exists (class {}).".format(
+                        provider_name, metacls._providers[provider_name])
+                )
+
+            metacls._providers[provider_name] = name
+
+        return super().__new__(metacls, name, bases, attrs)
+
+    def __call__(cls, *args, **kwargs):
+        # NOTE: Registration cannot be done in __new__ or __init__, because the
+        # class cannot be instantiated there yet (a RuntimeError occurs), thus
+        # we need to perform the registration here in __call__ (when a new
+        # class instance is going to be created).
+
+        new_instance = super().__call__(*args, **kwargs)
+
+        if hasattr(cls, 'PROVIDER'):
+            register_provider(cls.PROVIDER, new_instance, cls.ERRORS)
+
+        return new_instance
+
+
+class IngestService(metaclass=AutoRegisteredMeta):
     """Base ingest service class."""
 
     def get_items(self, guid):

--- a/server/superdesk/io/ingest_service_tests.py
+++ b/server/superdesk/io/ingest_service_tests.py
@@ -1,0 +1,131 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013, 2014, 2015 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+
+from superdesk.tests import TestCase
+from unittest import mock
+
+
+class AutoRegisteredMetaTest(TestCase):
+    """Base class for AutoRegisteredMeta metaclass tests."""
+
+    def _get_target_metacls(self):
+        """Return the metaclass under test.
+
+        Make the test fail immediately if the metaclass cannot be imported.
+        """
+        try:
+            from superdesk.io.ingest_service import AutoRegisteredMeta
+        except ImportError:
+            self.fail(
+                "Could not import metaclass under test "
+                "(AutoRegisteredMeta).")
+        else:
+            return AutoRegisteredMeta
+
+
+@mock.patch('superdesk.io.ingest_service.register_provider')
+class CreatingNewClassTestCase(AutoRegisteredMetaTest):
+    """Tests for the new class creation process."""
+
+    def test_creates_new_class_on_invocation(self, fake_register):
+        metacls = self._get_target_metacls()
+
+        BaseCls = type('BaseCls', (), {})
+        new_class = metacls('NewClass', (BaseCls,), {'foo': 'bar', 'baz': 42})
+
+        self.assertEqual(new_class.__name__, 'NewClass')
+        self.assertTrue(issubclass(new_class, BaseCls))
+
+        self.assertTrue(hasattr(new_class, 'foo'))
+        self.assertEqual(new_class.foo, 'bar')
+        self.assertTrue(hasattr(new_class, 'baz'))
+        self.assertEqual(new_class.baz, 42)
+
+    def test_registers_new_provider_instances(self, fake_register):
+        metacls = self._get_target_metacls()
+
+        new_class_errors = [(1234, 'Error 1234')]
+
+        new_class = metacls(
+            'NewClass',
+            (),
+            dict(ERRORS=new_class_errors, PROVIDER='provider_name')
+        )
+
+        new_class()  # create an instance to see if it gets registered
+
+        self.assertTrue(fake_register.called)
+        args, _ = fake_register.call_args
+        self.assertEqual(len(args), 3)
+
+        self.assertEqual(args[0], 'provider_name')
+        self.assertIsInstance(args[1], new_class)
+        self.assertEqual(args[2], new_class_errors)
+
+    def test_does_not_register_instances_of_non_provider_classes(
+        self, fake_register
+    ):
+        metacls = self._get_target_metacls()
+        new_class = metacls('NewClass', (), {})  # NOTE: no PROVIDER attribute
+        new_class()
+        self.assertFalse(fake_register.called)
+
+    def test_raises_error_on_duplicate_provider_name(self, fake_register):
+        metacls = self._get_target_metacls()
+        metacls._providers = {'provider_x': 'ClassX'}
+
+        try:
+            with self.assertRaises(TypeError) as exc_context:
+                metacls('NewClass', (), dict(ERRORS=[], PROVIDER='provider_x'))
+        except:
+            self.fail('Expected exception type was not raised.')
+
+        ex = exc_context.exception
+        self.assertEqual(
+            str(ex),
+            "PROVIDER provider_x already exists (class ClassX).")
+
+    def test_raises_error_if_provider_class_lacks_errors_attribute(
+        self, fake_register
+    ):
+        metacls = self._get_target_metacls()
+        try:
+            with self.assertRaises(AttributeError) as exc_context:
+                # NOTE: no ERRROS attribute
+                metacls('NewClass', (), {'PROVIDER': 'foo'})
+        except:
+            self.fail("Expected exception type was not raised.")
+
+        ex = exc_context.exception
+        self.assertEqual(
+            str(ex),
+            "Provider class NewClass must define the ERRORS list attribute.")
+
+
+class IngestServiceTest(TestCase):
+    """Tests for the base IngestService class."""
+
+    def _get_target_class(self):
+        """Return the class under test.
+
+        Make the test fail immediately if the class cannot be imported.
+        """
+        try:
+            from superdesk.io.ingest_service import IngestService
+        except ImportError:
+            self.fail("Could not import class under test (IngestService).")
+        else:
+            return IngestService
+
+    def test_has_correct_metaclass(self):
+        from superdesk.io.ingest_service import AutoRegisteredMeta
+        klass = self._get_target_class()
+        self.assertIsInstance(klass, AutoRegisteredMeta)

--- a/server/superdesk/io/reuters.py
+++ b/server/superdesk/io/reuters.py
@@ -20,24 +20,23 @@ from superdesk.io.ingest_service import IngestService
 
 from superdesk.utc import utcnow
 from superdesk.etree import etree, ParseError
-from superdesk.io import register_provider
 from .newsml_2_0 import NewsMLTwoParser
 from .reuters_token import get_token
 from superdesk.errors import IngestApiError
 from flask import current_app as app
 
 
-PROVIDER = 'reuters'
-errors = [IngestApiError.apiTimeoutError().get_error_description(),
-          IngestApiError.apiRedirectError().get_error_description(),
-          IngestApiError.apiRequestError().get_error_description(),
-          IngestApiError.apiUnicodeError().get_error_description(),
-          IngestApiError.apiParseError().get_error_description(),
-          IngestApiError.apiGeneralError().get_error_description()]
-
-
 class ReutersIngestService(IngestService):
     """Reuters ingest service."""
+
+    PROVIDER = 'reuters'
+
+    ERRORS = [IngestApiError.apiTimeoutError().get_error_description(),
+              IngestApiError.apiRedirectError().get_error_description(),
+              IngestApiError.apiRequestError().get_error_description(),
+              IngestApiError.apiUnicodeError().get_error_description(),
+              IngestApiError.apiParseError().get_error_description(),
+              IngestApiError.apiGeneralError().get_error_description()]
 
     DATE_FORMAT = '%Y.%m.%d.%H.%M'
     URL = 'http://rmb.reuters.com/rmd/rest/xml'
@@ -167,6 +166,3 @@ class ReutersIngestService(IngestService):
         (scheme, netloc, path, params, query, fragment) = urlparse(href)
         new_href = urlunparse((scheme, netloc, path, '', '', ''))
         return '%s?auth_token=%s' % (new_href, self.get_token())
-
-
-register_provider(PROVIDER, ReutersIngestService(), errors)

--- a/server/superdesk/io/reuters_tests.py
+++ b/server/superdesk/io/reuters_tests.py
@@ -15,15 +15,15 @@ from superdesk.tests import TestCase
 import superdesk
 from superdesk.utc import utcnow
 from .reuters_token import get_token
-from .reuters import PROVIDER
+from .reuters import ReutersIngestService
 from settings import URL_PREFIX
 
 
 def setup_provider(token, hours):
     return {
-        'name': PROVIDER,
-        'type': PROVIDER,
-        'source': PROVIDER,
+        'name': ReutersIngestService.PROVIDER,
+        'type': ReutersIngestService.PROVIDER,
+        'source': ReutersIngestService.PROVIDER,
         'content_expiry': 2880,
         'token': {
             'token': token,
@@ -60,5 +60,6 @@ class GetTokenTestCase(TestCase):
                 self.assertNotEquals('', token)
                 self.assertEquals(token, provider['token']['token'])
 
-                dbprovider = superdesk.get_resource_service('ingest_providers').find_one(type=PROVIDER, req=None)
+                dbprovider = superdesk.get_resource_service('ingest_providers').find_one(
+                    type=ReutersIngestService.PROVIDER, req=None)
                 self.assertEquals(token, dbprovider['token']['token'])

--- a/server/superdesk/io/rss.py
+++ b/server/superdesk/io/rss.py
@@ -20,21 +20,13 @@ from collections import namedtuple
 from datetime import datetime
 
 from superdesk.errors import IngestApiError, ParserError
-from superdesk.io import register_provider
 from superdesk.io.ingest_service import IngestService
 from superdesk.utils import merge_dicts
 
 from urllib.parse import quote as urlquote, urlsplit, urlunsplit
 
 
-PROVIDER = 'rss'
-
 utcfromtimestamp = datetime.utcfromtimestamp
-
-errors = [IngestApiError.apiAuthError().get_error_description(),
-          IngestApiError.apiNotFoundError().get_error_description(),
-          IngestApiError.apiGeneralError().get_error_description(),
-          ParserError.parseMessageError().get_error_description()]
 
 
 class RssIngestService(IngestService):
@@ -43,6 +35,13 @@ class RssIngestService(IngestService):
     (NOTE: it should also work with other syndicated feeds formats, too, since
     the underlying parser supports them, but for our needs RSS 2.0 is assumed)
     """
+
+    PROVIDER = 'rss'
+
+    ERRORS = [IngestApiError.apiAuthError().get_error_description(),
+              IngestApiError.apiNotFoundError().get_error_description(),
+              IngestApiError.apiGeneralError().get_error_description(),
+              ParserError.parseMessageError().get_error_description()]
 
     ItemField = namedtuple('ItemField', ['name', 'name_in_data', 'type'])
 
@@ -336,6 +335,3 @@ class RssIngestService(IngestService):
             item_references.append({'residRef': image['guid']})
 
         return package
-
-
-register_provider(PROVIDER, RssIngestService(), errors)

--- a/server/superdesk/io/teletype.py
+++ b/server/superdesk/io/teletype.py
@@ -14,19 +14,20 @@ import logging
 from datetime import datetime
 from superdesk.io.file_ingest_service import FileIngestService
 from superdesk.utc import utc
-from superdesk.io import register_provider
 from superdesk.utils import get_sorted_files, FileSortAttributes
 from superdesk.errors import ParserError, ProviderError
 from superdesk.io.zczc import ZCZCParser
 
 logger = logging.getLogger(__name__)
-PROVIDER = 'teletype'
-errors = [ParserError.ZCZCParserError().get_error_description(),
-          ProviderError.ingestError().get_error_description(),
-          ParserError.parseFileError().get_error_description()]
 
 
 class TeletypeIngestService(FileIngestService):
+
+    PROVIDER = 'teletype'
+
+    ERRORS = [ParserError.ZCZCParserError().get_error_description(),
+              ProviderError.ingestError().get_error_description(),
+              ParserError.parseFileError().get_error_description()]
 
     def __init__(self):
         self.parser = ZCZCParser()
@@ -88,6 +89,3 @@ class TeletypeIngestService(FileIngestService):
             return [item]
         except Exception as ex:
             raise ParserError.parseFileError('Teletype', filename, ex, provider)
-
-
-register_provider(PROVIDER, TeletypeIngestService(), errors)


### PR DESCRIPTION
This is now handled by a metaclass, which also checks across all ingest classes for any duplicate `PROVIDER˙ names defined. The behavior of this metaclass is described in more details in its docstring.

Resolves [SD 2535](https://dev.sourcefabric.org/browse/SD-2535).