### PR TITLE
fix(bamboo): use environment for db config

### DIFF
--- a/server/superdesk/tests.py
+++ b/server/superdesk/tests.py
@@ -47,11 +47,8 @@ def get_test_settings():
     test_settings['ELASTICSEARCH_URL'] = ELASTICSEARCH_URL
     test_settings['ELASTICSEARCH_INDEX'] = 'sptest'
     test_settings['MONGO_DBNAME'] = 'sptests'
-    test_settings['MONGO_URI'] = 'mongodb://localhost/sptests'
     test_settings['LEGAL_ARCHIVE_DBNAME'] = 'sptests_legal'
-    test_settings['LEGAL_ARCHIVE_URI'] = 'mongodb://localhost/sptests_legal'
     test_settings['PUBLICAPI_DBNAME'] = 'sptests_publicapi'
-    test_settings['PUBLICAPI_URI'] = 'mongodb://localhost/sptests_publicapi'
     test_settings['DEBUG'] = True
     test_settings['TESTING'] = True
     test_settings['SUPERDESK_TESTING'] = True


### PR DESCRIPTION
on bamboo there is no db on localhost, it's configured via environment.