### PR TITLE
Do not show Fetch buttons in search results if current desk is 'personal'

### DIFF
--- a/client/.jshintrc
+++ b/client/.jshintrc
@@ -30,6 +30,7 @@
     "afterEach": false,
     "inject": false,
     "expect": false,
+    "fail": false,
     "describe": false,
     "xdescribe": false,
     "requirejs": false,

--- a/client/app/scripts/superdesk-ingest/ingest.spec.js
+++ b/client/app/scripts/superdesk-ingest/ingest.spec.js
@@ -56,4 +56,47 @@ describe('ingest', function() {
             expect(api.save.calls.count()).toBe(2);
         }));
     });
+
+    describe('registering activities in superdesk.ingest module', function () {
+
+        beforeEach(module('superdesk.ingest'));
+
+        describe('the "archive" activity', function () {
+            var activity;
+
+            beforeEach(inject(function (superdesk) {
+                activity = superdesk.activities.archive;
+                if (angular.isUndefined(activity)) {
+                    fail('Activity "archive" is not registered.');
+                }
+            }));
+
+            it('is allowed if the current desk is not "personal"', function () {
+                var extra_condition = activity.additionalCondition,
+                    fakeDesks;
+
+                // get the function that checks the additional conditions
+                extra_condition = extra_condition[extra_condition.length - 1];
+                fakeDesks = {
+                    getCurrentDeskId: function () { return '1234'; }
+                };
+
+                expect(extra_condition(fakeDesks)).toBe(true);
+            });
+
+            it('is not allowed if the current desk is "personal"', function () {
+                var extra_condition = activity.additionalCondition,
+                    fakeDesks;
+
+                // get the function that checks the additional conditions
+                extra_condition = extra_condition[extra_condition.length - 1];
+                fakeDesks = {
+                    getCurrentDeskId: function () { return 'personal'; }
+                };
+
+                expect(extra_condition(fakeDesks)).toBe(false);
+            });
+        });
+    });
+
 });

--- a/client/app/scripts/superdesk-ingest/module.js
+++ b/client/app/scripts/superdesk-ingest/module.js
@@ -1358,7 +1358,11 @@ define([
                     {action: 'list', type: 'ingest'}
                 ],
                 privileges: {fetch: 1},
-                key: 'f'
+                key: 'f',
+                additionalCondition: ['desks', function (desks) {
+                    // fetching to 'personal' desk is not allowed
+                    return (desks.getCurrentDeskId() !== 'personal');
+                }]
             })
             .activity('externalsource', {
                 label: gettext('Get from external source'),


### PR DESCRIPTION
As @sivakuna-aap explained in the chat, fetching ingested items to the `'personal'` desk is not allowed. This PR removes the "Fetch" and "Fetch As..." action buttons from the ingested items listed on the search results pane.

Resolves [SD-2601](https://dev.sourcefabric.org/browse/SD-2601).