### PR TITLE
(fix) [SD-2633] [SD-2730]

### DIFF
--- a/client/app/scripts/superdesk-authoring/metadata/metadata.js
+++ b/client/app/scripts/superdesk-authoring/metadata/metadata.js
@@ -318,7 +318,7 @@ function MetadataSliderDirective(desks) {
                 var o = {};
 
                 if (angular.isDefined(item)) {
-                    o[scope.field] = (scope.field === 'anpa-category') ? item : item.name;
+                    o[scope.field] = (scope.field === 'anpa_category') ? item : item.name;
                 } else {
                     o[scope.field] = null;
                 }

--- a/client/app/scripts/superdesk-authoring/metadata/views/metadata-widget.html
+++ b/client/app/scripts/superdesk-authoring/metadata/views/metadata-widget.html
@@ -16,10 +16,6 @@
 				<div class="state-label state-{{item.state}}">{{item.state}}</div>
 			</div>
 		</li>
-		<li>
-			<label translate>Type</label>
-			<div class="data">{{item.type}}</div>
-		</li>
 		<li ng-if="item.original_source">
 			<label translate>Original source</label>
 			<div class="data">{{ item.original_source}}</div>
@@ -56,10 +52,20 @@
 				<div sd-meta-dropdown data-list="metadata.priority" data-item="item" data-field="priority" data-change="autosave(item)" ng-disabled="!_editable" ></div>
 			</div>
 		</li>
-		<li>
-			<label translate>Restrictions</label>
-			<div class="data visible" ng-if="metadata.geographical_restrictions">
-				<div sd-meta-dropdown data-list="metadata.geographical_restrictions" data-item="item" data-field="restrictions" data-change="autosave(item)" ng-disabled="!_editable"></div>
+		<li class="terms-box">
+			<label translate>Targeted For</label>
+			<div ng-if="metadata.targeted_for">
+				<span sd-check ng-model="item.negation" tooltip="Adds Negation" tooltip-placement="right" ng-disabled="!_editable"></span>
+				<select id="targeted_for_list" ng-model="item.targeted_for_value" ng-disabled="!_editable">
+					<option value=""></option>
+					<option value="{{g.value}}" ng-repeat="g in metadata.targeted_for track by g.name">{{:: g.name}}</option>
+				</select>
+				<button class="btn btn-small btn-primary" type="button" ng-click="addTargeted()" ng-disabled="!_editable" translate>Add</button>
+				<div class="terms" ng-if="item['targeted_for'].length">
+					<ul>
+						<li ng-repeat="t in item['targeted_for']" ng-click="removeTargeted(t)">{{ :: t['allow'] == false ? 'Not ' + t.name : t.name}}<i class="icon-close-small"></i></li>
+					</ul>
+				</div>
 			</div>
 		</li>
 		<li>

--- a/client/app/scripts/superdesk-authoring/views/header-info.html
+++ b/client/app/scripts/superdesk-authoring/views/header-info.html
@@ -21,8 +21,8 @@
 
     <li class="full-width general-info">
         <div class="item info-icons">
-            <i class="filetype-icon-{{item.type}}" ng-hide="hover || item.selected"></i>
-            
+            <i class="filetype-icon-{{item.type}}" ng-hide="hover || item.selected" tooltip="Article Type" tooltip-placement="middle"></i>
+
             <div class="slider-icon pull-left">
                 <div class="dropdown dropleft" dropdown>
                     <i class="urgency-icon-{{item.urgency}} dropdown-toggle" dropdown-toggle></i>
@@ -73,9 +73,6 @@
             <label translate>SOURCE</label>
             <div class="data" sd-meta-ingest data-item="item"></div>
         </div>
-        <div class="item" ng-if="metadata.categories">
-            <div class="data" sd-meta-dropdown data-list="metadata.categories" data-item="item" data-field="anpa-category" data-change="autosave(item)" ng-disabled="!_editable"></div>
-        </div>
         <div class="item">
             <label translate>RELATED</label>
             <div class="data">{{relatedItems._items.length}}</div>
@@ -116,6 +113,11 @@
     <li class="terms-box">
         <label translate>GENRE</label>
         <div class="data" sd-meta-terms data-item="item" data-field="genre" data-unique="value" data-list="metadata.genre" ng-disabled="!_editable" data-header="true" data-change="autosave(item)" data-postprocessing="processGenre()"></div>
+    </li>
+
+    <li class="full-width terms-box" ng-if="metadata.categories">
+        <label translate>CATEGORY</label>
+        <div class="data" sd-meta-terms data-item="item" data-field="anpa_category" data-unique="qcode" data-list="metadata.categories" ng-disabled="!_editable" data-header="true" data-change="autosave(item)"></div>
     </li>
 
     <li class="full-width terms-box">

--- a/client/app/scripts/superdesk-publish/filters/view/production-test-view.html
+++ b/client/app/scripts/superdesk-publish/filters/view/production-test-view.html
@@ -39,7 +39,7 @@
                                 </td>
                                 <td>{{ :: result_item.slugline | limitTo: 40}}</td>
                                 <td>{{ :: result_item.source}}</td>
-                                <td>{{ :: result_item['anpa-category'].name }}</td>
+                                <td>{{ :: result_item['anpa_category'] | mergeWords:'name' }}</td>
                                 <td>
                                     <i ng-click="openView(result_item)" class="icon-fullscreen true" title="Open in new tab"></i>
                                 </td>

--- a/server/apps/publish/archive_publish.py
+++ b/server/apps/publish/archive_publish.py
@@ -122,9 +122,10 @@ class BasePublishService(BaseService):
                     queued_digital = self._publish_takes_package(package_id, updates, original, last_updated)
                 else:
                     # if item is going to be sent to digital subscribers, package it as a take
-                    if self.sending_to_digital_subscribers(updates):
-                        updated = copy(original)
-                        updated.update(updates)
+                    updated = copy(original)
+                    updated.update(updates)
+
+                    if self.sending_to_digital_subscribers(updated):
                         # create a takes package
                         package_id = TakesPackageService().package_story_as_a_take(updated, {}, None)
                         original = get_resource_service('archive').find_one(req=None, _id=original['_id'])

--- a/server/apps/publish/archive_publish_tests.py
+++ b/server/apps/publish/archive_publish_tests.py
@@ -786,7 +786,7 @@ class ArchivePublishTestCase(TestCase):
             get_resource_service('archive_publish').patch(id=doc['_id'], updates={'state': 'published'})
 
             queue_items = self.app.data.find('publish_queue', None, None)
-            self.assertEqual(5, queue_items.count())
+            self.assertEqual(4, queue_items.count())
 
     def test_targeted_for(self):
         with self.app.test_request_context(URL_PREFIX):


### PR DESCRIPTION
[SD-2633] ANPA Category and Targeted For was overwritten. ANPA Category should be multiple.
[SD-2730] Problems with correcting published items that have non-empty "Targeted For" field.
production-test-view.html was referring to anpa-category which is renamed to anpa_category