### PR TITLE
Fix fetching packages from public API using demo data

### DIFF
--- a/server/publicapi/demo_data/data.json
+++ b/server/publicapi/demo_data/data.json
@@ -341,7 +341,7 @@
 {
     "_id": "tag:demodata.org,0011:ninjs_XYZ123",
     "type": "composite",
-    "profile": "text-photo",
+    "profile": "rich-interlinked-story",
     "version": "v1",
     "versioncreated": {"$date": "2015-05-03T07:48:51Z"},
     "pubstatus": "usable",
@@ -388,29 +388,13 @@
     "body_text": "Reporter: \"Don Vito Corleone, bongiorno!\", etc.",
     "body_html": "<b>Reporter:</b> &quot;Don Vito Corleone, bongiorno!&quot;, etc.",
     "associations": {
-        "mainpic": {
-            "type": "picture",
-            "versioncreated": {"$date": "2015-04-26T11:50:14Z"},
-            "byline": "Photo Grapher jr.",
-            "headline": "Don Vito Corleone in a restaurant",
-            "description_text": "Mafia boss enjoying red wine at lunch",
-            "description_html": "<p>Mafia boss enjoying red wine at lunch</p>",
-            "renditions": {
-                "main": {
-                    "href": "http://ninjs.example.com/pictures/don_vito.png",
-                    "mimetype": "image/png",
-                    "title": "Original Resolution",
-                    "height": 780,
-                    "width": 965
-                },
-                "small": {
-                    "href": "http://ninjs.example.com/pictures/small/don_vito.png",
-                    "mimetype": "image/png",
-                    "title": "Low Resolution",
-                    "height": 260,
-                    "width": 320
-                }
-            }
+        "videoFootage" : {
+            "_id": "tag:demodata.org,0002:ninjs_XYZ123",
+            "type": "video"
+        },
+        "relatedStory" : {
+            "_id": "tag:demodata.org,0012:ninjs_XYZ123",
+            "type": "composite"
         }
     }
 }
@@ -466,28 +450,12 @@
     "body_html": "<p>Want to try <em>McRide</em> or <em>McGhostHouse</em>?</p>",
     "associations": {
         "mainpic": {
-            "type": "picture",
-            "versioncreated": {"$date": "2014-08-11T09:39:02Z"},
-            "byline": "The Phototaker",
-            "headline": "Spain's first McTheme Park, main entrance",
-            "description_text": "Visitors waiting in a queue to visit McTheme Park",
-            "description_html": "<p>Visitors waiting in a queue to visit McTheme Park</p>",
-            "renditions": {
-                "main": {
-                    "href": "http://ninjs.example.com/pictures/mcthemepark_orig.jpg",
-                    "mimetype": "image/jpg",
-                    "title": "Original Resolution",
-                    "height": 900,
-                    "width": 1500
-                },
-                "thumbnail": {
-                    "href": "http://ninjs.example.com/pictures/small/mcthemepark_thumb.jpg",
-                    "mimetype": "image/jpg",
-                    "title": "Thumbnail Size",
-                    "height": 300,
-                    "width": 500
-                }
-            }
+            "_id": "tag:demodata.org,0001:ninjs_XYZ123",
+            "type": "picture"
+        },
+        "storyText": {
+            "_id": "tag:demodata.org,0003:ninjs_XYZ123",
+            "type": "text"
         }
     }
 }

--- a/server/publicapi/packages/service.py
+++ b/server/publicapi/packages/service.py
@@ -24,16 +24,37 @@ class PackagesService(ItemsService):
     """
 
     def on_fetched_item(self, document):
-        self._set_associations_uri(document)
+        """Event handler when a single package is retrieved from database.
+
+        It sets the `uri` field for all associated (referenced) objects.
+
+        :param dict document: fetched MongoDB document representing the package
+        """
+        self._process_referenced_objects(document)
         super().on_fetched_item(document)
 
-    def on_fetched(self, res):
-        for doc in res['_items']:
-            self._set_associations_uri(doc)
-        super().on_fetched(res)
+    def on_fetched(self, result):
+        """Event handler when a collection of packages is retrieved from
+        database.
 
-    def _set_associations_uri(self, doc):
-        associations = []
-        for doc_id in doc.get('associations', []):
-            associations.append(self._get_uri(doc_id))
-        doc['associations'] = associations
+        For each package in the fetched collection it sets the `uri` field for
+        all objects associated with (referenced by) the package.
+
+        :param dict result: dictionary contaning the list of MongoDB documents
+            (the fetched packages) and some metadata, e.g. pagination info
+        """
+        for document in result['_items']:
+            self._process_referenced_objects(document)
+        super().on_fetched(result)
+
+    def _process_referenced_objects(self, document):
+        """Do some processing on the objects referenced by `document`.
+
+        For all referenced objects their `uri` field is generated and their
+        `_id` field removed.
+
+        :param dict document: MongoDB document representing a package object
+        """
+        for name, target_obj in document.get('associations', {}).items():
+            target_obj['uri'] = self._get_uri(target_obj)
+            del target_obj['_id']

--- a/server/publicapi/tests/items_service_test.py
+++ b/server/publicapi/tests/items_service_test.py
@@ -852,3 +852,46 @@ class OnFetchedMethodTestCase(ItemsServiceTestCase):
 
         self_link = result.get('_links', {}).get('self', {}).get('href')
         self.assertEqual(self_link, 'items?start_date=1975-12-31')
+
+
+class GetUriMethodTestCase(ItemsServiceTestCase):
+    """Tests for the _get_uri() helper method."""
+
+    def setUp(self):
+        super().setUp()
+
+        self.app = Flask(__name__)
+        self.app.config['PUBLICAPI_URL'] = 'http://api.com'
+        self.app.config['URLS'] = {
+            'items': 'items_endpoint',
+            'packages': 'packages_endpoint'
+        }
+
+        self.app_context = self.app.app_context()
+        self.app_context.push()
+
+    def tearDown(self):
+        self.app_context.pop()
+        super().tearDown()
+
+    def test_generates_correct_uri_for_non_composite_items(self):
+        document = {
+            '_id': 'foo:bar',
+            'type': 'picture'
+        }
+
+        instance = self._make_one(datasource='items')
+        result = instance._get_uri(document)
+
+        self.assertEqual(result, 'http://api.com/items_endpoint/foo%3Abar')
+
+    def test_generates_correct_uri_for_composite_items(self):
+        document = {
+            '_id': 'foo:bar',
+            'type': 'composite'
+        }
+
+        instance = self._make_one(datasource='items')
+        result = instance._get_uri(document)
+
+        self.assertEqual(result, 'http://api.com/packages_endpoint/foo%3Abar')

--- a/server/publicapi/tests/packages_service_test.py
+++ b/server/publicapi/tests/packages_service_test.py
@@ -8,7 +8,9 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 
+from flask import Flask
 from publicapi.tests import ApiTestCase
+from unittest import mock
 
 
 class PackagesServiceTestCase(ApiTestCase):
@@ -26,5 +28,145 @@ class PackagesServiceTestCase(ApiTestCase):
         else:
             return PackagesService
 
-    def test_class_exists(self):
-        self._get_target_class()  # fails if the class cannot be obtained
+    def _make_one(self, *args, **kwargs):
+        """Create a new instance of the class under test."""
+        return self._get_target_class()(*args, **kwargs)
+
+
+@mock.patch("publicapi.packages.service.ItemsService.on_fetched_item")
+class OnFetchedItemMethodTestCase(PackagesServiceTestCase):
+    """Tests for the on_fetched_item() method."""
+
+    def setUp(self):
+        super().setUp()
+
+        self.app = Flask(__name__)
+        self.app.config['PUBLICAPI_URL'] = 'http://api.com'
+        self.app.config['URLS'] = {
+            'items': 'items_endpoint',
+            'packages': 'packages_endpoint'
+        }
+
+        self.app_context = self.app.app_context()
+        self.app_context.push()
+
+    def tearDown(self):
+        self.app_context.pop()
+        super().tearDown()
+
+    def test_invokes_superclass_method_with_correct_args(self, super_fetched):
+        document = {'_id': 'item:XYZ'}
+        instance = self._make_one(datasource='packages')
+        instance.on_fetched_item(document)
+        super_fetched.assert_called_with(document)
+
+    def test_sets_uri_field_on_referenced_items(self, super_fetched):
+        document = {
+            '_id': 'item:XYZ',
+            'associations': {
+                'main_picture': {'type': 'picture', '_id': 'img:123'},
+            }
+        }
+
+        instance = self._make_one(datasource='packages')
+        instance.on_fetched_item(document)
+
+        expected_assoc = {
+            'main_picture': {
+                'type': 'picture',
+                'uri': 'http://api.com/items_endpoint/img%3A123'
+            }
+        }
+        self.assertEqual(document.get('associations'), expected_assoc)
+
+    def test_sets_uri_field_on_referenced_packages(self, super_fetched):
+        document = {
+            '_id': 'item:XYZ',
+            'associations': {
+                'story_object': {'type': 'composite', '_id': 'pkg:456'}
+            }
+        }
+
+        instance = self._make_one(datasource='packages')
+        instance.on_fetched_item(document)
+
+        expected_assoc = {
+            'story_object': {
+                'type': 'composite',
+                'uri': 'http://api.com/packages_endpoint/pkg%3A456'
+            }
+        }
+        self.assertEqual(document.get('associations'), expected_assoc)
+
+
+@mock.patch("publicapi.packages.service.ItemsService.on_fetched")
+class OnFetchedMethodTestCase(PackagesServiceTestCase):
+    """Tests for the on_fetched() method."""
+
+    def setUp(self):
+        super().setUp()
+
+        self.app = Flask(__name__)
+        self.app.config['PUBLICAPI_URL'] = 'http://api.com'
+        self.app.config['URLS'] = {
+            'items': 'items_endpoint',
+            'packages': 'packages_endpoint'
+        }
+
+        self.app_context = self.app.app_context()
+        self.app_context.push()
+
+    def tearDown(self):
+        self.app_context.pop()
+        super().tearDown()
+
+    def test_invokes_superclass_method_with_correct_args(self, super_fetched):
+        result = {
+            '_items': []
+        }
+        instance = self._make_one(datasource='packages')
+        instance.on_fetched(result)
+        super_fetched.assert_called_with(result)
+
+    def test_sets_uri_field_on_objects_referenced_by_fetched_packages(
+        self, super_fetched
+    ):
+        result = {
+            '_items': [
+                {
+                    '_id': 'pkg:ABC',
+                    'associations': {
+                        'main_picture': {'type': 'picture', '_id': 'img:123'},
+                    }
+                },
+                {
+                    '_id': 'pkg:DEF',
+                    'associations': {
+                        'main_story': {'type': 'composite', '_id': 'pkg:456'},
+                    }
+                },
+            ]
+        }
+
+        instance = self._make_one(datasource='packages')
+        instance.on_fetched(result)
+
+        # check 1st fetched package's associations
+        expected_assoc = {
+            'main_picture': {
+                'type': 'picture',
+                'uri': 'http://api.com/items_endpoint/img%3A123'
+            }
+        }
+        fetched_package = result['_items'][0]
+        self.assertEqual(fetched_package.get('associations'), expected_assoc)
+
+        # check 2nd fetched package's associations
+        expected_assoc = {
+            'main_story': {
+                'type': 'composite',
+                'uri': 'http://api.com/packages_endpoint/pkg%3A456'
+            }
+        }
+        fetched_package = result['_items'][1]
+        self.assertEqual(fetched_package.get('associations'), expected_assoc)


### PR DESCRIPTION
Resolves [SD-2720](https://dev.sourcefabric.org/browse/SD-2720).

Things changed:
* Change demo data so that composite items only contain references to associated objects and not the objects themselves.
* Fix an issue with `uri` field generation for associated objects.
* Add/update docstrings, add quite a few tests that were missing.
