### PR TITLE
(fix) [SD-2573] 

### DIFF
--- a/server/apps/publish/archive_publish.py
+++ b/server/apps/publish/archive_publish.py
@@ -466,15 +466,18 @@ class BasePublishService(BaseService):
                     continue
 
             if doc.get('targeted_for'):
-                matching_target = [t for t in doc.get('targeted_for')
-                                   if t['name'] == subscriber.get('subscriber_type', '') or
-                                   t['name'] == subscriber.get('geo_restrictions', '')]
+                found_match = [t for t in doc['targeted_for'] if t['name'] == subscriber.get('subscriber_type', '')]
 
-                if len(matching_target) > 0 and matching_target[0]['allow'] is False:
+                if len(found_match) == 0 and subscriber.get('geo_restrictions'):
+                    found_match = [t for t in doc['targeted_for'] if t['name'] == subscriber['geo_restrictions']]
+                    if len(found_match) == 0 or (len(found_match) > 0 and found_match[0]['allow'] is False):
+                        continue
+                elif len(found_match) > 0 and found_match[0]['allow'] is False:
                     continue
 
             if not self.conforms_global_filter(subscriber, global_filters, doc):
                 continue
+
             if not self.conforms_publish_filter(subscriber, doc):
                 continue
 

--- a/server/apps/publish/archive_publish.py
+++ b/server/apps/publish/archive_publish.py
@@ -470,7 +470,7 @@ class BasePublishService(BaseService):
 
                 if len(found_match) == 0 and subscriber.get('geo_restrictions'):
                     found_match = [t for t in doc['targeted_for'] if t['name'] == subscriber['geo_restrictions']]
-                    if len(found_match) == 0 or (len(found_match) > 0 and found_match[0]['allow'] is False):
+                    if len(found_match) == 0 or found_match[0]['allow'] is False:
                         continue
                 elif len(found_match) > 0 and found_match[0]['allow'] is False:
                     continue

--- a/server/apps/publish/archive_publish_tests.py
+++ b/server/apps/publish/archive_publish_tests.py
@@ -790,10 +790,10 @@ class ArchivePublishTestCase(TestCase):
         with self.app.app_context():
             ValidatorsPopulateCommand().run(self.filename)
             updates = {'targeted_for': [{'name': 'New South Wales', 'allow': True}]}
-            get_resource_service('archive').patch(id=self.articles[9][config.ID_FIELD], updates=updates)
+            doc_id = self.articles[9][config.ID_FIELD]
+            get_resource_service('archive').patch(id=doc_id, updates=updates)
 
-            doc = get_resource_service('archive').find_one(req=None, _id=self.articles[9][config.ID_FIELD])
-            get_resource_service('archive_publish').patch(id=doc['_id'], updates={'state': 'published'})
+            get_resource_service('archive_publish').patch(id=doc_id, updates={'state': 'published'})
 
             queue_items = self.app.data.find('publish_queue', None, None)
             self.assertEqual(4, queue_items.count())


### PR DESCRIPTION
Fails to filter Subscribers when "Geographical Restrictions" and "Target For" values are different. For ex, a article which has "Victoria" as "Targeted For" is being transmitted to Subscribers with Geographical Restrictions as "Queensland", which shouldn't be case as the article is targeted for Victoria Subscribers only.