### PR TITLE
[SD-2750] Takes Publishing

### DIFF
--- a/server/apps/archive/__init__.py
+++ b/server/apps/archive/__init__.py
@@ -112,8 +112,6 @@ def init_app(app):
     superdesk.privilege(name='saved_searches', label='Manage Saved Searches',
                         description='User can manage Saved Searches')
 
-    superdesk.privilege(name='kill', label='Kill', description='Kill a published content')
-    superdesk.privilege(name='correct', label='Correction', description='Correction to a published content')
     superdesk.privilege(name='hold', label='Hold', description='Hold a content')
     superdesk.privilege(name='restore', label='Restore', description='Restore a hold a content')
 

--- a/server/apps/content.py
+++ b/server/apps/content.py
@@ -18,13 +18,16 @@ PACKAGE = 'package'
 PACKAGE_TYPE = 'package_type'
 TAKES_PACKAGE = 'takes'
 ITEM_TYPE = 'type'
-ITEM_TYPE_COMPOSITE = 'composite'
 LAST_TAKE = 'last_take'
 
 not_analyzed = {'type': 'string', 'index': 'not_analyzed'}
 
 pub_status = ['usable', 'withhold', 'canceled']
 PUB_STATUS = namedtuple('PUBSTATUS', ['USABLE', 'HOLD', 'CANCELED'])(*pub_status)
+content_type = ['text', 'preformatted', 'audio', 'video', 'picture', 'graphic', 'composite']
+CONTENT_TYPE = namedtuple('CONTENT_TYPE',
+                          ['TEXT', 'PREFORMATTED', 'AUDIO', 'VIDEO',
+                           'PICTURE', 'GRAPHIC', 'COMPOSITE'])(*content_type)
 
 metadata_schema = {
     # Identifiers
@@ -129,7 +132,7 @@ metadata_schema = {
     # Story Metadata
     ITEM_TYPE: {
         'type': 'string',
-        'allowed': ['text', 'preformatted', 'audio', 'video', 'picture', 'graphic', ITEM_TYPE_COMPOSITE],
+        'allowed': content_type,
         'default': 'text',
         'mapping': not_analyzed
     },

--- a/server/apps/publish/__init__.py
+++ b/server/apps/publish/__init__.py
@@ -52,6 +52,8 @@ def init_app(app):
 
     superdesk.privilege(name='subscribers', label='Subscribers', description='User can manage subscribers')
     superdesk.privilege(name='publish', label='Publish', description='Publish a content')
+    superdesk.privilege(name='kill', label='Kill', description='Kill a published content')
+    superdesk.privilege(name='correct', label='Correction', description='Correction to a published content')
     superdesk.privilege(name='publish_queue', label='Publish Queue', description='User can update publish queue')
 
 

--- a/server/features/content_publish.feature
+++ b/server/features/content_publish.feature
@@ -1412,7 +1412,7 @@ Feature: Content Publishing
       }
       """
 
-    @auth @vocabulary @test
+    @auth @vocabulary
     Scenario: Publish subsequent takes to same wire clients as published before.
       Given the "validators"
       """

--- a/server/superdesk/publish/publicapi.py
+++ b/server/superdesk/publish/publicapi.py
@@ -10,7 +10,7 @@
 
 import json
 
-from apps.content import ITEM_TYPE, ITEM_TYPE_COMPOSITE
+from apps.content import ITEM_TYPE, CONTENT_TYPE
 from superdesk import get_resource_service, config, app
 from superdesk.errors import PublishPublicAPIError
 from superdesk.publish import register_transmitter
@@ -34,7 +34,7 @@ class PublicAPIPublishService(PublishService):
             self._fix_dates(item)
             self._process_renditions(item)
 
-            if item[ITEM_TYPE] == ITEM_TYPE_COMPOSITE:
+            if item[ITEM_TYPE] == CONTENT_TYPE.COMPOSITE:
                 public_api_service = get_resource_service('publish_packages')
             else:
                 public_api_service = get_resource_service('publish_items')


### PR DESCRIPTION
- [x] Refactor the code for publishing so that subscribers are retrieved based publish action.
- [x] For takes:
      - If wire: the subsequent publishes should go to the same subscribers
      - If digital: the subsequent publishes should go at least to the same subscribers