### PR TITLE
fix(menu): fix case when privileges are not in storage

### DIFF
--- a/client/app/scripts/superdesk/auth/session-service_spec.js
+++ b/client/app/scripts/superdesk/auth/session-service_spec.js
@@ -73,6 +73,21 @@ define([
             expect(session.identity.name).toBe('bar');
         }));
 
+        it('can filter blacklisted fields from indentity', inject(function(session) {
+            session.start(SESSION, {
+                name: 'foo',
+                session_preferences: ['session'],
+                user_preferences: ['user'],
+                workspace: ['workspace'],
+                allowed_actions: ['actions']
+            });
+            expect(session.identity.name).not.toBeUndefined();
+            expect(session.identity.session_preferences).toBeUndefined();
+            expect(session.identity.user_preferences).toBeUndefined();
+            expect(session.identity.workspace).toBeUndefined();
+            expect(session.identity.allowed_actions).toBeUndefined();
+        }));
+
         it('can clear session', inject(function (session) {
             session.start(SESSION, {name: 'bar'});
             session.clear();

--- a/client/app/scripts/superdesk/menu/views/superdesk-view.html
+++ b/client/app/scripts/superdesk/menu/views/superdesk-view.html
@@ -3,7 +3,6 @@
 
 <div id="main-container" ng-class="flags" ng-view></div>
 
-<!--<div sd-scratchpad></div>-->
 <div sd-activity-modal></div>
 <div sd-login-modal></div>
 <div sd-notify></div>

--- a/client/app/scripts/superdesk/services/preferences_spec.js
+++ b/client/app/scripts/superdesk/services/preferences_spec.js
@@ -1,161 +1,128 @@
-define([
-    './preferencesService',
-    './storage'
-], function(preferencesServiceSpec, storageSpec) {
-    'use strict';
+'use strict';
 
-    describe('Preferences Service', function() {
+describe('Preferences Service', function() {
 
-        beforeEach(module(preferencesServiceSpec.name));
-        beforeEach(module(storageSpec.name));
-        beforeEach(module('superdesk.api'));
+    beforeEach(module('superdesk.preferences'));
+    beforeEach(module('superdesk.api'));
 
-        var storage,
-            preferencesService,
-            testPreferences = {
-                'active_privileges': {'privilege1': 1, 'privilege2': 0},
-                'user_preferences': {
-                    'archive:view': {
-                        'default': 'mgrid',
-                        'label': 'Users archive view format',
-                        'type': 'string',
-                        'category': 'archive',
-                        'allowed': [
-                            'mgrid',
-                            'compact'
-                        ],
-                        'view': 'mgrid'
-                    },
-                    'feature:preview': {
-                        'default': false,
-                        'type': 'bool',
-                        'category': 'feature',
-                        'enabled': true,
-                        'label': 'test'
-                    },
-                    'email:notification': {
-                        'default': true,
-                        'category': 'notifications',
-                        'enabled': true,
-                        'type': 'bool',
-                        'label': 'Send notifications via email'
-                    }
+    var preferencesService,
+        testPreferences = {
+            'active_privileges': {'privilege1': 1, 'privilege2': 0},
+            'user_preferences': {
+                'archive:view': {
+                    'default': 'mgrid',
+                    'label': 'Users archive view format',
+                    'type': 'string',
+                    'category': 'archive',
+                    'allowed': [
+                        'mgrid',
+                        'compact'
+                    ],
+                    'view': 'mgrid'
                 },
-                'session_preferences': {
-                    'desk:items': [],
-                    'pinned:items': [],
-                    'scratchpad:items': [
-                        '/archive/urn:newsml:a0cca6c9-fe94-46ed-9ce7-aab9361ff6b8',
-                        '/archive/urn:newsml:a0cca6c9-fe94-46ed-9ce7-aab9361ff6b8'
-                    ]
+                'feature:preview': {
+                    'default': false,
+                    'type': 'bool',
+                    'category': 'feature',
+                    'enabled': true,
+                    'label': 'test'
+                },
+                'email:notification': {
+                    'default': true,
+                    'category': 'notifications',
+                    'enabled': true,
+                    'type': 'bool',
+                    'label': 'Send notifications via email'
                 }
-            };
-
-        var update = {
-            'feature:preview': {
-                'default': false,
-                'enabled': false,
-                'label': 'Test Label',
-                'type': 'bool',
-                'category': 'feature'
+            },
+            'session_preferences': {
+                'desk:items': [],
+                'pinned:items': [],
+                'scratchpad:items': [
+                    '/archive/urn:newsml:a0cca6c9-fe94-46ed-9ce7-aab9361ff6b8',
+                    '/archive/urn:newsml:a0cca6c9-fe94-46ed-9ce7-aab9361ff6b8'
+                ]
             }
         };
 
-        beforeEach(inject(function(api, $q) {
-            spyOn(api, 'find').and.returnValue($q.when(testPreferences));
-            spyOn(api, 'save').and.returnValue($q.when({'user_preferences': update}));
-        }));
+    var update = {
+        'feature:preview': {
+            'default': false,
+            'enabled': false,
+            'label': 'Test Label',
+            'type': 'bool',
+            'category': 'feature'
+        }
+    };
 
-        beforeEach(inject(function($injector, $q, session, api) {
-            storage = $injector.get('storage');
-            preferencesService = $injector.get('preferencesService');
-            storage.clear();
+    beforeEach(inject(function(api, $q) {
+        spyOn(api, 'find').and.returnValue($q.when(testPreferences));
+        spyOn(api, 'save').and.returnValue($q.when({'user_preferences': update}));
+    }));
 
-            spyOn(session, 'getIdentity').and.returnValue($q.when({sessionId: 1}));
-        }));
+    beforeEach(inject(function($injector, $q, session) {
+        preferencesService = $injector.get('preferencesService');
+        spyOn(session, 'getIdentity').and.returnValue($q.when({sessionId: 1}));
+        session.sessionId = 1;
+    }));
 
-        it('can get preferences', inject(function(api, $rootScope) {
+    it('can get user preferences', inject(function(api, $rootScope) {
+        preferencesService.get();
+        $rootScope.$digest();
 
-            expect(storage.getItem('preferences')).toBe(null);
-            $rootScope.sessionId = 1;
-            preferencesService.get();
+        var preferences;
+        preferencesService.get().then(function(_preferences) {
+            preferences = _preferences;
+        });
 
-            $rootScope.$digest();
-            var preferences = preferencesService.get();
+        $rootScope.$digest();
 
-            $rootScope.$digest();
+        expect(preferences).not.toBe(null);
+        expect(preferences['archive:view'].view).toBe('mgrid');
+        expect(api.find).toHaveBeenCalledWith('preferences', 1, null, true);
+    }));
 
-            expect(preferences).not.toBe(null);
-            expect(preferences).not.toBe(undefined);
-            expect(storage.getItem('preferences')).not.toBe(null);
-            expect(api.find).toHaveBeenCalledWith('preferences', 1, null, true);
+    it('can get user preferences by key', inject(function(api, $rootScope) {
+        preferencesService.get();
+        $rootScope.$digest();
 
-        }));
+        var preferences;
+        preferencesService.get('archive:view').then(function(_preferences) {
+            preferences = _preferences;
+        });
 
-        it('can get user preferences by key', inject(function(api, $rootScope) {
+        $rootScope.$digest();
+        expect(preferences.view).toBe('mgrid');
+    }));
 
-            expect(storage.getItem('preferences')).toBe(null);
-            $rootScope.sessionId = 1;
-            preferencesService.get();
+    it('update user preferences by key', inject(function(api, $q, $rootScope) {
+        preferencesService.get();
+        $rootScope.$digest();
 
-            $rootScope.$digest();
-            var preferences;
-            preferencesService.get('archive:view').then(function(_preferences) {
-                preferences = _preferences;
-            });
+        preferencesService.update(update, 'feature:preview');
+        preferencesService.update({'workspace:active': {'workspace': ''}}, 'workspace:active');
+        $rootScope.$digest();
+        expect(api.save.calls.count()).toBe(1);
 
-            $rootScope.$digest();
+        var preferences;
+        preferencesService.get('feature:preview').then(function(_preferences) {
+            preferences = _preferences;
+        });
 
-            expect(preferences.view).toBe('mgrid');
-            expect(storage.getItem('preferences')).not.toBe(null);
+        $rootScope.$digest();
+        expect(preferences.enabled).toBe(false);
+    }));
 
-        }));
+    it('can get all active privileges', inject(function(api, $rootScope) {
+        preferencesService.get();
+        $rootScope.$digest();
 
-        it('update user preferences by key', inject(function(api, $q, $rootScope) {
-            expect(storage.getItem('preferences')).toBe(null);
-            $rootScope.sessionId = 1;
-            preferencesService.get();
-            $rootScope.$digest();
+        var privileges;
+        preferencesService.getPrivileges().then(function(_privileges) {
+            privileges = _privileges;
+        });
 
-            preferencesService.update(update, 'feature:preview');
-            preferencesService.update({'workspace:active': {'workspace': ''}}, 'workspace:active');
-            $rootScope.$digest();
-            expect(api.save.calls.count()).toBe(1);
-
-            expect(storage.getItem('preferences').user_preferences['feature:preview'].enabled).toBe(false);
-        }));
-
-        it('can remove preferences', inject(function(api, $rootScope) {
-
-            expect(storage.getItem('preferences')).toBe(null);
-            $rootScope.sessionId = 1;
-            preferencesService.get();
-
-            $rootScope.$digest();
-
-            var preferences = preferencesService.get('archive:view');
-            expect(preferences).not.toBe(null);
-            expect(storage.getItem('preferences')).not.toBe(null);
-
-            preferencesService.remove();
-
-            expect(storage.getItem('preferences')).toBe(null);
-
-        }));
-
-        it('can get all active privileges', inject(function(api, $rootScope) {
-
-            expect(storage.getItem('preferences')).toBe(null);
-            $rootScope.sessionId = 1;
-            preferencesService.get();
-
-            $rootScope.$digest();
-            preferencesService.getPrivileges();
-
-            $rootScope.$digest();
-
-            expect(storage.getItem('preferences').active_privileges.privilege1).toBe(1);
-
-        }));
-    });
+        $rootScope.$digest();
+        expect(privileges.privilege1).toBe(1);
+    }));
 });


### PR DESCRIPTION
it stops using storage as user preferences cache altogether,
because after making a change storage prefs were not complete
and on page reload it would result in empty privileges.