### PR TITLE
Fix package preview in the sidebar.

### DIFF
--- a/client/app/scripts/superdesk-packaging/packaging.js
+++ b/client/app/scripts/superdesk-packaging/packaging.js
@@ -467,7 +467,7 @@
             link: function(scope) {
                 scope.data = null;
                 scope.error = null;
-                scope.type = scope.item.type || scope.item.itemClass.split(':')[1];
+
                 if (scope.item.location) {
                     api[scope.item.location].getById(scope.item.residRef)
                     .then(function(result) {

--- a/client/app/scripts/superdesk-packaging/views/sd-package-item-preview.html
+++ b/client/app/scripts/superdesk-packaging/views/sd-package-item-preview.html
@@ -1,28 +1,32 @@
-<div class="item {{ :: type }}" ng-class="{locked: isLocked, published: isPublished}">
+<div class="item {{ :: data.type }}" ng-class="{locked: isLocked, published: isPublished}">
 	<div class="info">
-	    <figure class="icons-holder" ng-if=":: type === 'composite' || type === 'text'">
-	    	<i class="filetype-icon-large-{{ :: type }}"></i>
+        <figure class="icons-holder" ng-if="data.type === 'composite' || data.type === 'text'">
+            <i class="filetype-icon-large-{{ :: data.type }}"></i>
 	    </figure>
 
-		<div class="holder" ng-if=":: type !== 'composite' && type !== 'text'">
+		<div class="holder" ng-if="data.type !== 'composite' && data.type !== 'text'">
 			<div class="loading" ng-show="data == null && error == null"></div>
-			<div class="error-icon" ng-show="error != null"><i class="filetype-icon-large-{{ :: type}}"></i></div>
-			<div ng-if=":: type === 'picture'" sd-item-rendition data-item="data" data-rendition="thumbnail"></div>
-			<audio ng-if=":: type === 'audio'" controls="controls" sd-sources data-renditions="data.renditions" ng-show="data"></audio>
-			<div ng-if=":: type === 'video'"><i class="filetype-icon-large-video"></i></div>
+			<div class="error-icon" ng-show="error != null"><i class="filetype-icon-large-{{data.type}}"></i></div>
+			<div ng-if="data.type === 'picture'" sd-item-rendition data-item="data" data-rendition="thumbnail"></div>
+			<audio ng-if="data.type === 'audio'" controls="controls" sd-sources data-renditions="data.renditions" ng-show="data"></audio>
+			<div ng-if="data.type === 'video'"><i class="filetype-icon-large-video"></i></div>
 		</div>
 
         <div class="item-headline">
-            <div ng-show=":: item.headline || item.slugline || item.description">{{ :: item.headline || item.slugline || item.description}}</div>
-            <div ng-hide=":: item.headline || item.slugline || item.description" translate>Blank headline received</div>
+            <div ng-show=":: data.headline || data.slugline || data.description">{{ :: data.headline || data.slugline || data.description}}</div>
+            <div ng-hide=":: data.headline || data.slugline || data.description" translate>Blank headline received</div>
         </div>
 
-        <a ng-href="#/{{ :: type !== 'composite' ? 'authoring' : 'packaging'}}/{{ :: item.residRef }}/view?_id={{ :: item.guid }}" 
-        	title="{{ :: 'Open item' | translate }}" ng-if="item.guid && !error" ng-click="$event.stopPropagation();" class="open-item">
+        <a
+            ng-href="#/{{ data.type !== 'composite' ? 'authoring' : 'packaging'}}/{{ data.residRef }}/view?_id={{ data.guid }}"
+            title="{{ :: 'Open item' | translate }}"
+            ng-if="data.guid && !error"
+            ng-click="$event.stopPropagation();"
+            class="open-item">
             <i class="icon-external"></i>
         </a>
 
-        <div class="package-details" ng-if=":: type === 'composite'"><i class="svg-icon-right"></i></div>
+        <div class="package-details" ng-if="data.type === 'composite'"><i class="svg-icon-right"></i></div>
 
 	    <div class="alert-error" ng-show="error" translate>Problems occurred while fetching data.</div>
 	</div>

--- a/server/superdesk/io/rss.py
+++ b/server/superdesk/io/rss.py
@@ -302,7 +302,7 @@ class RssIngestService(IngestService):
         the text item preceeds the references to image items.
 
         Package's `firstcreated` and `versioncreated` fields are set to values
-        of these fields in `text_item`.
+        of these fields in `text_item`, and the `headline` is copied as well.
 
         :param dict text_item: item representing the text content
         :param list image_items: list of items (dicts) representing the images
@@ -315,6 +315,7 @@ class RssIngestService(IngestService):
             'guid': generate_guid(type=GUID_TAG),
             'firstcreated': text_item['firstcreated'],
             'versioncreated': text_item['versioncreated'],
+            'headline': text_item.get('headline', ''),
             'groups': [
                 {
                     'id': 'root',

--- a/server/superdesk/io/rss_test.py
+++ b/server/superdesk/io/rss_test.py
@@ -609,6 +609,7 @@ class CreatePackageMethodTestCase(RssIngestServiceTest):
             'guid': 'main_text',
             'firstcreated': datetime(2015, 1, 27, 16, 0, 0),
             'versioncreated': datetime(2015, 1, 27, 16, 0, 0),
+            'headline': 'Headline of the text item'
         }
         img_item_1 = {'guid': 'image_1'}
         img_item_2 = {'guid': 'image_2'}
@@ -627,6 +628,7 @@ class CreatePackageMethodTestCase(RssIngestServiceTest):
             'guid': 'package:guid:abcd123',
             'firstcreated': datetime(2015, 1, 27, 16, 0, 0),
             'versioncreated': datetime(2015, 1, 27, 16, 0, 0),
+            'headline': 'Headline of the text item',
             'groups': [
                 {
                     'id': 'root',


### PR DESCRIPTION
Resolves [SD-2581](https://dev.sourcefabric.org/browse/SD-2581).

The preview template seemed to display an incorrect object - some `item` way up the scope hierarchy, instead of `data`, the actual item contained in a package fetched from the server.

I also removed one-time bindings at a few places that were causing incorrect behavior, e.g. picture preview not shown etc.