### PR TITLE
fix (slider replace): Removed replace from sd slider, because it is deprecated

### DIFF
--- a/client/app/scripts/superdesk/directives/sdSlider.js
+++ b/client/app/scripts/superdesk/directives/sdSlider.js
@@ -20,7 +20,6 @@ define(['angular'], function (angular) {
         directive('sdSlider', function () {
             return {
                 transclude: true,
-                replace: true,
                 templateUrl: 'scripts/superdesk/views/sdSlider.html',
                 scope: {
                     value: '=',

--- a/client/app/styles/less/forms.less
+++ b/client/app/styles/less/forms.less
@@ -738,7 +738,7 @@ form.flat, .form-flat {
 }
 
 // sdSlider
-.sd-slider.ui-slider {
+[sd-slider].ui-slider {
     border-top: 2px solid @sd-blue;
     .ui-slider-range {
         .transition(width .1s);


### PR DESCRIPTION
https://github.com/superdesk/superdesk/pull/877

According to @petrjasek comment, updated sdSlider and removed `replace`.