### PR TITLE
Remove the "filter" parameter from Content API

### DIFF
--- a/server/publicapi/items/service.py
+++ b/server/publicapi/items/service.py
@@ -50,7 +50,7 @@ class ItemsService(BaseService):
         if req is None:
             req = ParsedRequest()
 
-        allowed_params = ('include_fields', 'exclude_fields')
+        allowed_params = {'include_fields', 'exclude_fields'}
         self._check_for_unknown_params(
             req, whitelist=allowed_params, allow_filtering=False)
 
@@ -72,10 +72,10 @@ class ItemsService(BaseService):
         if req is None:
             req = ParsedRequest()
 
-        allowed_params = (
-            'q', 'start_date', 'end_date', 'filter',
+        allowed_params = {
+            'q', 'start_date', 'end_date',
             'include_fields', 'exclude_fields'
-        )
+        }
         self._check_for_unknown_params(req, whitelist=allowed_params)
 
         request_params = req.args or {}
@@ -85,11 +85,6 @@ class ItemsService(BaseService):
         if 'q' in request_params:
             req.args['q'] = request_params['q']
             req.args['default_operator'] = 'OR'
-
-        # TODO: add validation for the "filter" parameter when we define its
-        # format and implement the corresponding actions
-        if 'filter' in request_params:
-            req.args['filters'] = [{'term': json.loads(request_params['filter'])}]
 
         # set the date range filter
         start_date, end_date = self._get_date_range(request_params)

--- a/server/publicapi/tests/items_service_test.py
+++ b/server/publicapi/tests/items_service_test.py
@@ -162,8 +162,7 @@ class GetMethodTestCase(ItemsServiceTestCase):
 
         expected_whitelist = sorted([
             'start_date', 'end_date',
-            'exclude_fields', 'include_fields',
-            'q', 'filter'
+            'exclude_fields', 'include_fields', 'q',
         ])
 
         whitelist_arg = kwargs.get('whitelist')
@@ -216,21 +215,6 @@ class GetMethodTestCase(ItemsServiceTestCase):
         args, _ = fake_super_get.call_args
         self.assertEqual(len(args), 2)
         self.assertIsInstance(args[0], ParsedRequest)
-
-    def test_sets_query_filter_on_request_object_if_present(self):
-        request = MagicMock()
-        request.args = MultiDict([('filter', '{"language": "de"}')])
-        lookup = {}
-
-        instance = self._make_one()
-        instance.get(request, lookup)
-
-        self.assertTrue(fake_super_get.called)
-        args, _ = fake_super_get.call_args
-        self.assertGreater(len(args), 0)
-
-        query_filter = args[0].args['filters'][0]
-        self.assertEqual(query_filter.get('term', {}).get('language'), 'de')
 
     def test_raises_correct_error_on_invalid_start_date_parameter(self):
         request = MagicMock()


### PR DESCRIPTION
Although useful, the "filter" parameter is not (yet) ready for a production use - we would need to implement at least the parameter syntax validation, make sure it is not tied to a specific backend and probably also limit its features (we might not want to give users the full filtering power the backend provides).

Since this filtering functionality is not required for the API v1 and would require non-trivial amount of additional work, we removed it for now.

Resolves [SD-2859](https://dev.sourcefabric.org/browse/SD-2859).

P.S.: I also did a minor optimization of checking the allowed parameters along the way (used `set` instead of a `tuple`).