### PR TITLE
(imp) Extracted item state to namedtuple and constant

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -47,7 +47,6 @@ def get_app(config=None):
         config = {}
 
     config['APP_ABSPATH'] = os.path.abspath(os.path.dirname(__file__))
-    config['CONTENT_STATE'] = 'state'
 
     for key in dir(settings):
         if key.isupper():

--- a/server/apps/aap_mm/service.py
+++ b/server/apps/aap_mm/service.py
@@ -9,23 +9,22 @@
 # at https://www.sourcefabric.org/superdesk/license
 
 
-import superdesk
 import logging
+
 from eve.utils import config
 from flask import json
+
+import superdesk
 from superdesk.errors import SuperdeskApiError, ProviderError
 from apps.archive.common import generate_unique_id_and_name
-
 from superdesk.metadata.utils import generate_guid
-from superdesk.metadata.item import GUID_TAG, FAMILY_ID, INGEST_ID
+from superdesk.metadata.item import GUID_TAG, FAMILY_ID, INGEST_ID, ITEM_STATE, CONTENT_STATE
 from apps.archive.common import insert_into_versions, remove_unwanted, set_original_creator
 from apps.tasks import send_to
 from apps.archive.archive import SOURCE as ARCHIVE
 from superdesk import get_resource_service
 
 logger = logging.getLogger(__name__)
-
-STATE_FETCHED = 'fetched'
 
 
 class AapMMService(superdesk.Service):
@@ -55,7 +54,7 @@ class AapMMService(superdesk.Service):
 
             dest_doc[config.VERSION] = 1
             send_to(doc=dest_doc, update=None, desk_id=doc.get('desk'), stage_id=doc.get('stage'))
-            dest_doc[config.CONTENT_STATE] = doc.get('state', STATE_FETCHED)
+            dest_doc[ITEM_STATE] = doc.get(ITEM_STATE, CONTENT_STATE.FETCHED)
             dest_doc[INGEST_ID] = archived_doc['_id']
             dest_doc[FAMILY_ID] = archived_doc['_id']
             remove_unwanted(dest_doc)

--- a/server/apps/archive/archive.py
+++ b/server/apps/archive/archive.py
@@ -27,7 +27,7 @@ from superdesk.activity import add_activity, ACTIVITY_CREATE, ACTIVITY_UPDATE, A
 from eve.utils import parse_request, config
 from superdesk.services import BaseService
 from apps.users.services import is_admin
-from superdesk.metadata.item import metadata_schema
+from superdesk.metadata.item import metadata_schema, ITEM_STATE, CONTENT_STATE
 from apps.common.components.utils import get_component
 from apps.item_autosave.components.item_autosave import ItemAutosave
 from apps.common.models.base_model import InvalidEtag
@@ -379,7 +379,7 @@ class ArchiveService(BaseService):
         on_duplicate_item(new_doc)
         resolve_document_version(new_doc, 'archive', 'PATCH', new_doc)
         if original_doc.get('task', {}).get('desk') is not None and new_doc.get('state') != 'submitted':
-            new_doc[config.CONTENT_STATE] = 'submitted'
+            new_doc[ITEM_STATE] = CONTENT_STATE.SUBMITTED
         item_model.create([new_doc])
         self._duplicate_versions(original_doc['guid'], new_doc)
 
@@ -466,8 +466,8 @@ class ArchiveService(BaseService):
         Removes the article from production if the state is spiked
         """
 
-        assert doc[config.CONTENT_STATE] == 'spiked', \
-            "Article state is %s. Only Spiked Articles can be removed" % doc[config.CONTENT_STATE]
+        assert doc[ITEM_STATE] == CONTENT_STATE.SPIKED, \
+            "Article state is %s. Only Spiked Articles can be removed" % doc[ITEM_STATE]
 
         doc_id = str(doc[config.ID_FIELD])
         super().delete_action({config.ID_FIELD: doc_id})

--- a/server/apps/archive/archive_media.py
+++ b/server/apps/archive/archive_media.py
@@ -15,6 +15,7 @@ from eve.utils import config
 from settings import DEFAULT_SOURCE_VALUE_FOR_MANUAL_ARTICLES
 from superdesk.media.media_operations import process_file_from_stream, decode_metadata
 from superdesk.media.renditions import generate_renditions, delete_file_on_error
+from superdesk.metadata.item import ITEM_STATE, CONTENT_STATE
 from superdesk.upload import url_for_media
 from superdesk.utc import utcnow
 from .common import update_dates_for, generate_guid, GUID_TAG, set_original_creator, \
@@ -61,7 +62,7 @@ class ArchiveMediaService():
                 if not doc.get('_import', None):
                     set_original_creator(doc)
 
-                doc.setdefault(config.CONTENT_STATE, 'draft')
+                doc.setdefault(ITEM_STATE, CONTENT_STATE.DRAFT)
 
                 if not doc.get('ingest_provider'):
                     doc['source'] = DEFAULT_SOURCE_VALUE_FOR_MANUAL_ARTICLES

--- a/server/apps/archive/archive_rewrite.py
+++ b/server/apps/archive/archive_rewrite.py
@@ -8,17 +8,18 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 
+import logging
+
 from flask import request
 
 from superdesk import get_resource_service, Service
+from superdesk.metadata.item import ITEM_STATE
 from superdesk.resource import Resource, build_custom_hateoas
 from apps.archive.common import item_url, CUSTOM_HATEOAS
 from superdesk.workflow import is_workflow_state_transition_valid
 from superdesk.errors import SuperdeskApiError, InvalidStateTransitionError
 from apps.packages.takes_package_service import TakesPackageService
 from apps.tasks import send_to
-from eve.utils import config
-import logging
 
 logger = logging.getLogger(__name__)
 
@@ -64,7 +65,7 @@ class ArchiveRewriteService(Service):
         if get_resource_service('published').is_rewritten_before(original['_id']):
             raise SuperdeskApiError.badRequestError(message='Article has been rewritten before !')
 
-        if not is_workflow_state_transition_valid('rewrite', original[config.CONTENT_STATE]):
+        if not is_workflow_state_transition_valid('rewrite', original[ITEM_STATE]):
             raise InvalidStateTransitionError()
 
         if not TakesPackageService().is_last_takes_package_item(original):

--- a/server/apps/archive/archive_spike.py
+++ b/server/apps/archive/archive_spike.py
@@ -10,25 +10,23 @@
 
 
 import logging
-import superdesk
 
 from flask import current_app as app
 
-
+import superdesk
 from superdesk import get_resource_service
 from superdesk.errors import SuperdeskApiError, InvalidStateTransitionError
+from superdesk.metadata.item import ITEM_STATE
 from superdesk.notification import push_notification
 from superdesk.services import BaseService
 from superdesk.utc import get_expiry_date
 from .common import get_user, item_url, is_assigned_to_a_desk
-from eve.utils import config
 from superdesk.workflow import is_workflow_state_transition_valid
 from apps.archive.archive import ArchiveResource, SOURCE as ARCHIVE
 from apps.tasks import get_expiry
 from apps.packages import PackageService, TakesPackageService
 from apps.archive.archive_rewrite import ArchiveRewriteService
 from apps.archive.common import item_operations, ITEM_OPERATION
-
 
 logger = logging.getLogger(__name__)
 
@@ -86,7 +84,7 @@ class ArchiveSpikeService(BaseService):
             rewrite_service._clear_rewritten_flag(original.get('event_id'), original['_id'])
 
     def update(self, id, updates, original):
-        original_state = original[config.CONTENT_STATE]
+        original_state = original[ITEM_STATE]
         if not is_workflow_state_transition_valid('spike', original_state):
             raise InvalidStateTransitionError()
 
@@ -102,7 +100,7 @@ class ArchiveSpikeService(BaseService):
             expiry_minutes = desk.get('spike_expiry', expiry_minutes)
 
         updates[EXPIRY] = get_expiry_date(expiry_minutes)
-        updates[REVERT_STATE] = item.get(app.config['CONTENT_STATE'], None)
+        updates[REVERT_STATE] = item.get(ITEM_STATE, None)
 
         if original.get('rewrite_of'):
             updates['rewrite_of'] = None
@@ -139,7 +137,7 @@ class ArchiveUnspikeService(BaseService):
         updates[ITEM_OPERATION] = ITEM_UNSPIKE
 
     def update(self, id, updates, original):
-        original_state = original[config.CONTENT_STATE]
+        original_state = original[ITEM_STATE]
         if not is_workflow_state_transition_valid('unspike', original_state):
             raise InvalidStateTransitionError()
         user = get_user(required=True)

--- a/server/apps/duplication/archive_move.py
+++ b/server/apps/duplication/archive_move.py
@@ -8,22 +8,19 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 from eve.versioning import resolve_document_version
+from flask import request
 
 import superdesk
-
-from flask import request
 from apps.tasks import send_to
-
 from superdesk import get_resource_service
 from superdesk.errors import SuperdeskApiError, InvalidStateTransitionError
+from superdesk.metadata.item import ITEM_STATE, CONTENT_STATE
 from superdesk.resource import Resource
 from superdesk.services import BaseService
 from apps.archive.common import item_url, insert_into_versions, item_operations,\
     ITEM_OPERATION
 from apps.archive.archive import SOURCE as ARCHIVE
 from superdesk.workflow import is_workflow_state_transition_valid
-from eve.utils import config
-
 
 ITEM_MOVE = 'move'
 item_operations.append(ITEM_MOVE)
@@ -73,15 +70,15 @@ class MoveService(BaseService):
         if current_stage_of_item and str(current_stage_of_item) == str(doc.get('task', {}).get('stage')):
             raise SuperdeskApiError.preconditionFailedError(message='Move is not allowed within the same stage.')
 
-        if not is_workflow_state_transition_valid('submit_to_desk', archived_doc[config.CONTENT_STATE]):
+        if not is_workflow_state_transition_valid('submit_to_desk', archived_doc[ITEM_STATE]):
             raise InvalidStateTransitionError()
 
         original = dict(archived_doc)
 
         send_to(doc=archived_doc, desk_id=doc.get('task', {}).get('desc'), stage_id=doc.get('task', {}).get('stage'))
 
-        if archived_doc[config.CONTENT_STATE] not in ['published', 'scheduled', 'killed']:
-            archived_doc[config.CONTENT_STATE] = 'submitted'
+        if archived_doc[ITEM_STATE] not in {CONTENT_STATE.PUBLISHED, CONTENT_STATE.SCHEDULED, CONTENT_STATE.KILLED}:
+            archived_doc[ITEM_STATE] = CONTENT_STATE.SUBMITTED
         archived_doc[ITEM_OPERATION] = ITEM_MOVE
 
         resolve_document_version(archived_doc, ARCHIVE, 'PATCH', original)

--- a/server/superdesk/metadata/item.py
+++ b/server/superdesk/metadata/item.py
@@ -10,24 +10,32 @@
 
 from collections import namedtuple
 
-import superdesk
 from superdesk.resource import Resource
 from .packages import PACKAGE_TYPE, TAKES_PACKAGE, LINKED_IN_PACKAGES, PACKAGE
 
 not_analyzed = {'type': 'string', 'index': 'not_analyzed'}
-ITEM_TYPE = 'type'
 GUID_TAG = 'tag'
 GUID_FIELD = 'guid'
 GUID_NEWSML = 'newsml'
 INGEST_ID = 'ingest_id'
 FAMILY_ID = 'family_id'
 PUBLISH_STATES = ['published', 'killed', 'corrected', 'scheduled']
+
 pub_status = ['usable', 'withhold', 'canceled']
 PUB_STATUS = namedtuple('PUBSTATUS', ['USABLE', 'HOLD', 'CANCELED'])(*pub_status)
+
+ITEM_TYPE = 'type'
 content_type = ['text', 'preformatted', 'audio', 'video', 'picture', 'graphic', 'composite']
 CONTENT_TYPE = namedtuple('CONTENT_TYPE',
                           ['TEXT', 'PREFORMATTED', 'AUDIO', 'VIDEO',
                            'PICTURE', 'GRAPHIC', 'COMPOSITE'])(*content_type)
+
+ITEM_STATE = 'state'
+content_state = ['draft', 'ingested', 'routed', 'fetched', 'submitted', 'in_progress', 'spiked',
+                 'published', 'killed', 'corrected', 'scheduled', 'on_hold']
+CONTENT_STATE = namedtuple('CONTENT_STATE', ['DRAFT', 'INGESTED', 'ROUTED', 'FETCHED', 'SUBMITTED', 'PROGRESS',
+                                             'SPIKED', 'PUBLISHED', 'KILLED', 'CORRECTED',
+                                             'SCHEDULED', 'HOLD'])(*content_state)
 
 metadata_schema = {
     # Identifiers
@@ -174,16 +182,15 @@ metadata_schema = {
     },
 
     # Related to state of an article
-
-    'state': {
+    ITEM_STATE: {
         'type': 'string',
-        'allowed': superdesk.allowed_workflow_states,
+        'allowed': content_state,
         'mapping': not_analyzed,
     },
     # The previous state the item was in before for example being spiked, when un-spiked it will revert to this state
     'revert_state': {
         'type': 'string',
-        'allowed': superdesk.allowed_workflow_states,
+        'allowed': content_state,
         'mapping': not_analyzed,
     },
     'pubstatus': {

--- a/server/superdesk/workflow.py
+++ b/server/superdesk/workflow.py
@@ -9,7 +9,7 @@
 # at https://www.sourcefabric.org/superdesk/license
 
 
-from eve.utils import config
+from superdesk.metadata.item import ITEM_STATE
 
 states = []
 actions = []
@@ -110,4 +110,4 @@ def set_default_state(doc, state):
     :param doc: item
     :param state: state to be set as default
     """
-    doc.setdefault(config.CONTENT_STATE, state)
+    doc.setdefault(ITEM_STATE, state)


### PR DESCRIPTION
This improvement extracts the values of item state to a Named Tuple and moves `config.CONTENT_STATE` to `ITEM_STATE`.

Reason for moving `config.CONTENT_STATE` is, few modules doesn't need context and those modules fail to get the key from config.

This improvement doesn't replaces the string literals across all the modules. At the project level it will be implemented as part of [SD-2856](https://dev.sourcefabric.org/browse/SD-2856).