### PR TITLE
refactor(editor): integrate findreplace and spellcheck

### DIFF
--- a/client/app/scripts/superdesk-authoring/editor/find-replace.js
+++ b/client/app/scripts/superdesk-authoring/editor/find-replace.js
@@ -21,33 +21,49 @@ function FindReplaceDirective($timeout, $rootScope, editor) {
             scope.to = '';
             scope.from = '';
 
+            /**
+             * Highlight next matching string
+             */
             scope.next = function() {
-                editor.command.next();
+                editor.selectNext();
             };
 
+            /**
+             * Highlight previous matching string
+             */
             scope.prev = function() {
-                editor.command.prev();
+                editor.selectPrev();
             };
 
+            /**
+             * Replace currently highlighted matching string with text
+             */
             scope.replace = function() {
-                editor.command.replace(scope.to || '');
+                editor.replace(scope.to || '');
+                editor.selectNext();
             };
 
+            /**
+             * Replace all matching string with text
+             */
             scope.replaceAll = function() {
-                editor.command.replaceAll(scope.to || '');
+                editor.replaceAll(scope.to || '');
             };
 
             scope.$watch('from', function(needle) {
-                var input = document.getElementById('find-replace-what'),
-                    selectionStart = input.selectionStart,
-                    selectionEnd = input.selectionEnd;
-                editor.command.find(needle);
+                var input = document.getElementById('find-replace-what');
+                var selectionStart = input.selectionStart;
+                var selectionEnd = input.selectionEnd;
+
+                editor.setSettings({findreplace: {needle: needle}});
+                editor.render();
+                editor.selectNext();
                 input.setSelectionRange(selectionStart, selectionEnd);
             });
 
-            editor.startCommand();
             scope.$on('$destroy', function() {
-                editor.stopCommand();
+                editor.setSettings({findreplace: null});
+                editor.render();
             });
         }
     };

--- a/client/app/scripts/superdesk-authoring/styles/authoring.less
+++ b/client/app/scripts/superdesk-authoring/styles/authoring.less
@@ -174,6 +174,21 @@
 		border-bottom: 1px dotted #cc0000;
 		background-color: rgba(204, 0, 0, 0.08);
 	}
+
+    .sdfindreplace {
+        background-color: rgba(0, 0, 0, 0.08);
+    }
+
+    .sdfindreplace.sdactive {
+        background-color: rgba(237, 212, 0, 0.55);
+    }
+
+    &.typing {
+        .sderror, .sdfindreplace {
+            border-bottom: none;
+            background-color: transparent;
+        }
+    }
 }
 
 

--- a/client/app/scripts/superdesk/editor/spellcheck/spellcheck.spec.js
+++ b/client/app/scripts/superdesk/editor/spellcheck/spellcheck.spec.js
@@ -17,7 +17,6 @@ describe('spellcheck', function() {
                 baz: 1
             }
         },
-        TEXT = 'wha is foo, f1, 4k and 3d?',
         LANG = 'en',
         errors = [];
 
@@ -43,33 +42,6 @@ describe('spellcheck', function() {
         expect(errors).toContain({word: 'test', index: 0});
         expect(errors).toContain({word: 'if', index: 10});
         expect(dictionaries.getActive).toHaveBeenCalledWith(LANG);
-    }));
-
-    it('can render errors in given node', inject(function(spellcheck, $rootScope) {
-        var p = createParagraph(TEXT);
-
-        spellcheck.render(p);
-        $rootScope.$digest();
-
-        expect(p.innerHTML)
-            .toBe('<span class="sderror">wha</span> is foo, f1, <span class="sderror">4k</span> and 3d?');
-
-        expect(spellcheck.clean(p)).toBe(TEXT);
-    }));
-
-    it('can render errors at the end of text', inject(function(spellcheck, $rootScope) {
-        var p = createParagraph('what is buz');
-
-        spellcheck.render(p);
-        $rootScope.$digest();
-
-        expect(p.innerHTML)
-            .toBe('what is <span class="sderror">buz</span>');
-    }));
-
-    it('can remove errors and keep the marker', inject(function(spellcheck) {
-        var p = createParagraph('what is <span class="sderror">b<span class="mark"></span>uz</span>');
-        expect(spellcheck.clean(p)).toBe('what is b<span class="mark"></span>uz');
     }));
 
     it('can add words to user dictionary', inject(function(spellcheck, api, $rootScope) {
@@ -120,23 +92,16 @@ describe('spellcheck', function() {
             var ctrl = $controller('SpellcheckMenu');
             expect(ctrl.isAuto).toBe(true);
 
-            var scope = $rootScope.$new(),
-                settingsHandle = jasmine.createSpy('handle');
-
-            scope.$on('editor:settings', settingsHandle);
-
             ctrl.pushSettings();
-            expect(settingsHandle).toHaveBeenCalled();
             expect(editor.settings.spellcheck).toBe(true);
 
             ctrl.isAuto = false;
             ctrl.pushSettings();
             expect(editor.settings.spellcheck).toBe(false);
 
-            var spellcheckHandle = jasmine.createSpy('handle');
-            scope.$on('spellcheck:run', spellcheckHandle);
+            spyOn(editor, 'render');
             ctrl.spellcheck();
-            expect(spellcheckHandle).toHaveBeenCalled();
+            expect(editor.render).toHaveBeenCalled();
         }));
     });
 });

--- a/client/spec/authoring_spec.js
+++ b/client/spec/authoring_spec.js
@@ -15,94 +15,33 @@ describe('authoring', function() {
     });
 
     it('Can Undo content', function() {
+        var TIMEOUT = 500;
+
+        var ctrl = function(key) {
+            var Key = protractor.Key;
+            return browser.actions().sendKeys(Key.chord(Key.CONTROL, key)).perform();
+        };
+
         workspace.open();
         workspace.editItem('item4', 'SPORTS');
-        authoring.writeText('Two');
-        browser.driver.switchTo().activeElement().getText().then(function(text) {
-            expect(text).toEqual('Two');
-        });
 
-        browser.sleep(500);
+        authoring.writeText('Two');
+        expect(authoring.getBodyText()).toBe('Two');
+
+        browser.sleep(TIMEOUT);
 
         authoring.writeText('Words');
-        browser.driver.switchTo().activeElement().getText().then(function(text) {
-            expect(text).toEqual('TwoWords');
-        });
+        expect(authoring.getBodyText()).toBe('TwoWords');
 
-        browser.sleep(500);
+        browser.sleep(TIMEOUT);
 
-        var Key = protractor.Key;
-        browser.actions().sendKeys(Key.chord(Key.CONTROL, 'z')).perform();
+        ctrl('z');
+        expect(authoring.getBodyText()).toBe('Two');
 
-        browser.driver.switchTo().activeElement().getText().then(function(text) {
-            expect(text).toEqual('Two');
-        });
-        // headline editor
-        authoring.writeTextToHeadline('headline');
-        browser.driver.switchTo().activeElement().getText().then(function(text) {
-            expect(text).toEqual('headlineitem4');
-        });
+        browser.sleep(TIMEOUT);
 
-        browser.sleep(500);
-
-        browser.actions().sendKeys(Key.chord(Key.CONTROL, 'z')).perform();
-
-        browser.driver.switchTo().activeElement().getText().then(function(text) {
-            expect(text).toEqual('item4');
-        });
-    });
-
-    it('Can Redo content', function () {
-        workspace.open();
-        workspace.editItem('item4', 'SPORTS');
-        authoring.writeText('Undo');
-        browser.driver.switchTo().activeElement().getText().then(function(text) {
-            expect(text).toEqual('Undo');
-        });
-
-        browser.sleep(500);
-
-        authoring.writeText('Redo');
-        browser.driver.switchTo().activeElement().getText().then(function(text) {
-            expect(text).toEqual('UndoRedo');
-        });
-
-        browser.sleep(500);
-
-        var Key = protractor.Key;
-
-        browser.actions().sendKeys(Key.chord(Key.CONTROL, 'z')).perform();
-        browser.driver.switchTo().activeElement().getText().then(function(text) {
-            expect(text).toEqual('Undo');
-        });
-
-        browser.sleep(500);
-
-        browser.actions().sendKeys(Key.chord(Key.CONTROL, 'y')).perform();
-        browser.driver.switchTo().activeElement().getText().then(function(text) {
-            expect(text).toEqual('Undo');
-        });
-
-        // abstract editor
-        authoring.writeTextToAbstract('Redo');
-        browser.driver.switchTo().activeElement().getText().then(function(text) {
-            expect(text).toEqual('Redo');
-        });
-
-        browser.sleep(500);
-
-        browser.actions().sendKeys(Key.chord(Key.CONTROL, 'z')).perform();
-        browser.driver.switchTo().activeElement().getText().then(function(text) {
-            expect(text).toEqual('');
-        });
-
-        browser.sleep(500);
-
-        browser.actions().sendKeys(Key.chord(Key.CONTROL, 'y')).perform();
-        browser.driver.switchTo().activeElement().getText().then(function(text) {
-            expect(text).toEqual('Redo');
-        });
-
+        ctrl('y');
+        expect(authoring.getBodyText()).toBe('TwoWords');
     });
 
     it('view item history create-fetch operation', function() {

--- a/client/spec/helpers/authoring.js
+++ b/client/spec/helpers/authoring.js
@@ -195,14 +195,27 @@ function Authoring() {
             .toContain(highlight);
     };
 
+    var bodyHtml = element(by.model('item.body_html')).all(by.className('editor-type-html')).first();
+    var headline = element(by.model('item.headline')).all(by.className('editor-type-html')).first();
+    var abstract = element(by.model('item.abstract')).all(by.className('editor-type-html')).first();
+
     this.writeText = function (text) {
-        element(by.model('item.body_html')).all(by.className('editor-type-html')).sendKeys(text);
-    };
-    this.writeTextToHeadline = function (text) {
-        element(by.model('item.headline')).all(by.className('editor-type-html')).sendKeys(text);
-    };
-    this.writeTextToAbstract = function (text) {
-        element(by.model('item.abstract')).all(by.className('editor-type-html')).sendKeys(text);
+        bodyHtml.sendKeys(text);
     };
 
+    this.writeTextToHeadline = function (text) {
+        headline.sendKeys(text);
+    };
+
+    this.writeTextToAbstract = function (text) {
+        abstract.sendKeys(text);
+    };
+
+    this.getBodyText = function() {
+        return bodyHtml.getText();
+    };
+
+    this.getHeadlineText = function() {
+        return headline.getText();
+    };
 }


### PR DESCRIPTION
instead of kind of stand alone those functions are now integrated
in the editor, so you can switch between those.
you can trigger those via editor service on all registered scopes.

instead of using input event it's now using keydown/up to detect
changes on items which can be only triggered by user.

SD-2793