### PR TITLE
Fix an error in console on "Search" page if a desk in not found in lookup

### DIFF
--- a/client/app/scripts/superdesk-authoring/metadata/metadata.js
+++ b/client/app/scripts/superdesk-authoring/metadata/metadata.js
@@ -196,7 +196,10 @@ function MetadataListEditingDirective() {
         templateUrl: 'scripts/superdesk-authoring/metadata/views/metadata-terms.html',
         link: function(scope) {
             scope.$watch('list', function(items) {
-                if (!items || !items[0].hasOwnProperty('parent')) {
+                if (
+                    !items || items.length === 0 ||
+                    !items[0].hasOwnProperty('parent')
+                ) {
                     return;
                 }
 

--- a/client/app/scripts/superdesk-search/search.js
+++ b/client/app/scripts/superdesk-search/search.js
@@ -453,8 +453,10 @@
 
             };
         })
+
         /**
-         * Item filters sidebar
+         * A directive that generates the sidebar containing search results
+         * filters (so-called "aggregations" in Elastic's terms).
          */
         .directive('sdSearchFacets', ['$location', 'desks', 'privileges', 'tags', 'asset',
             function($location, desks, privileges, tags, asset) {
@@ -490,65 +492,79 @@
                     scope.$watch('items', function() {
 
                         initAggregations();
+
                         tags.initSelectedFacets().then(function(currentTags) {
 
                             scope.tags = currentTags;
 
-                            if (scope.items && scope.items._aggregations !== undefined) {
-
-                                _.forEach(scope.items._aggregations.type.buckets, function(type) {
-                                    scope.aggregations.type[type.key] = type.doc_count;
-                                });
-
-                                _.forEach(scope.items._aggregations.category.buckets, function(cat) {
-                                    if (cat.key !== '') {
-                                        scope.aggregations.category[cat.key] = cat.doc_count;
-                                    }
-                                });
-
-                                _.forEach(scope.items._aggregations.urgency.buckets, function(urgency) {
-                                    scope.aggregations.urgency[urgency.key] = urgency.doc_count;
-                                });
-
-                                _.forEach(scope.items._aggregations.source.buckets, function(source) {
-                                    scope.aggregations.source[source.key] = source.doc_count;
-                                });
-
-                                _.forEach(scope.items._aggregations.state.buckets, function(state) {
-                                    scope.aggregations.state[state.key] = state.doc_count;
-                                });
-
-                                _.forEach(scope.items._aggregations.day.buckets, function(day) {
-                                    scope.aggregations.date['Last Day'] = day.doc_count;
-                                });
-
-                                _.forEach(scope.items._aggregations.week.buckets, function(week) {
-                                    scope.aggregations.date['Last Week'] = week.doc_count;
-                                });
-
-                                _.forEach(scope.items._aggregations.month.buckets, function(month) {
-                                    scope.aggregations.date['Last Month'] = month.doc_count;
-                                });
-
-                                if (!scope.desk) {
-                                    _.forEach(scope.items._aggregations.desk.buckets, function(desk) {
-                                        scope.aggregations.desk[desks.deskLookup[desk.key].name] = {
-                                                count: desk.doc_count,
-                                                id: desk.key
-                                            };
-                                    }) ;
-                                }
-
-                                if (scope.desk) {
-                                    _.forEach(scope.items._aggregations.stage.buckets, function(stage) {
-                                        _.forEach(desks.deskStages[scope.desk._id], function(deskStage) {
-                                            if (deskStage._id === stage.key) {
-                                                scope.aggregations.stage[deskStage.name] = {count: stage.doc_count, id: stage.key};
-                                            }
-                                        });
-                                    });
-                                }
+                            if (!scope.items || scope.items._aggregations === undefined) {
+                                return;
                             }
+
+                            _.forEach(scope.items._aggregations.type.buckets, function(type) {
+                                scope.aggregations.type[type.key] = type.doc_count;
+                            });
+
+                            _.forEach(scope.items._aggregations.category.buckets, function(cat) {
+                                if (cat.key !== '') {
+                                    scope.aggregations.category[cat.key] = cat.doc_count;
+                                }
+                            });
+
+                            _.forEach(scope.items._aggregations.urgency.buckets, function(urgency) {
+                                scope.aggregations.urgency[urgency.key] = urgency.doc_count;
+                            });
+
+                            _.forEach(scope.items._aggregations.source.buckets, function(source) {
+                                scope.aggregations.source[source.key] = source.doc_count;
+                            });
+
+                            _.forEach(scope.items._aggregations.state.buckets, function(state) {
+                                scope.aggregations.state[state.key] = state.doc_count;
+                            });
+
+                            _.forEach(scope.items._aggregations.day.buckets, function(day) {
+                                scope.aggregations.date['Last Day'] = day.doc_count;
+                            });
+
+                            _.forEach(scope.items._aggregations.week.buckets, function(week) {
+                                scope.aggregations.date['Last Week'] = week.doc_count;
+                            });
+
+                            _.forEach(scope.items._aggregations.month.buckets, function(month) {
+                                scope.aggregations.date['Last Month'] = month.doc_count;
+                            });
+
+                            if (!scope.desk) {
+                                _.forEach(scope.items._aggregations.desk.buckets, function(desk) {
+                                    var lookedUpDesk = desks.deskLookup[desk.key];
+
+                                    if (typeof lookedUpDesk === 'undefined') {
+                                        var msg =  [
+                                            'Desk (key: ', desk.key, ') not found in ',
+                                            'deskLookup, probable storage inconsistency.'
+                                        ].join('');
+                                        console.warn(msg);
+                                        return;
+                                    }
+
+                                    scope.aggregations.desk[lookedUpDesk.name] = {
+                                            count: desk.doc_count,
+                                            id: desk.key
+                                        };
+                                });
+                            }
+
+                            if (scope.desk) {
+                                _.forEach(scope.items._aggregations.stage.buckets, function(stage) {
+                                    _.forEach(desks.deskStages[scope.desk._id], function(deskStage) {
+                                        if (deskStage._id === stage.key) {
+                                            scope.aggregations.stage[deskStage.name] = {count: stage.doc_count, id: stage.key};
+                                        }
+                                    });
+                                });
+                            }
+
                         });
                     });
 

--- a/client/app/scripts/superdesk-search/tests/search_spec.js
+++ b/client/app/scripts/superdesk-search/tests/search_spec.js
@@ -81,3 +81,137 @@ describe('search service', function() {
         }));
     });
 });
+
+describe('sdSearchFacets directive', function () {
+    var desks,
+        facetsInit,
+        fakeApi,
+        fakeMetadata,
+        isoScope,
+        $element;  // directive's DOM element
+
+    beforeEach(module(
+        'superdesk.authoring.metadata',
+        'superdesk.search',
+        'templates'  // needed so that directive's template is placed into
+                     // $templateCache, avoiding the "Unexpected request" error
+    ));
+
+    /**
+     * Mock some of the dependencies of the parent directives.
+     */
+    beforeEach(module(function ($provide) {
+        fakeApi = {
+            ingestProviders: {
+                query: jasmine.createSpy()
+            }
+        };
+
+        fakeMetadata = {
+            values: {subjectcodes: []},
+            fetchSubjectcodes: jasmine.createSpy()
+        };
+
+        $provide.value('api', fakeApi);
+        $provide.value('metadata', fakeMetadata);
+    }));
+
+    /**
+     * Mock even more dependencies and compile the directive under test.
+     */
+    beforeEach(inject(function (
+        $templateCache, $compile, $rootScope, $q, _desks_, tags, search
+    ) {
+        var html,
+            scope;
+
+        // more services mocking...
+        spyOn(search, 'getSubjectCodes').and.returnValue([]);
+
+        desks = _desks_;
+        spyOn(desks, 'initialize');
+
+        facetsInit = $q.defer();
+        spyOn(tags, 'initSelectedFacets').and.returnValue(facetsInit.promise);
+
+        fakeApi.ingestProviders.query.and.returnValue(
+            $q.when({_items: [{foo: 'bar'}]})
+        );
+        fakeMetadata.fetchSubjectcodes.and.returnValue($q.when());
+
+        // directive compilation...
+        html = [
+            '<div sd-search-container>',
+            '    <div sd-search-facets></div>',
+            '</div>'
+        ].join('');
+
+        scope = $rootScope.$new();
+
+        $element = $compile(html)(scope).find('div[sd-search-facets]');
+        scope.$digest();
+
+        isoScope = $element.isolateScope();
+    }));
+
+    describe('reacting to changes in the item list', function () {
+        beforeEach(function () {
+            isoScope.items = {
+                _aggregations: {
+                    desk: {buckets: []},
+                    type: {buckets: []},
+                    category: {buckets: []},
+                    urgency: {buckets: []},
+                    source: {buckets: []},
+                    state: {buckets: []},
+                    day: {buckets: []},
+                    week: {buckets: []},
+                    month: {buckets: []},
+                    stage: {buckets: []}
+                }
+            };
+        });
+
+        it('does not throw an error if desk not in deskLookup', function () {
+            isoScope.desk = null;
+
+            isoScope.items._aggregations.desk.buckets = [
+                {doc_count: 123, key: 'abc123'}
+            ];
+
+            desks.deskLookup = {
+                otherDesk: {}  // desk abc123 not present in deskLookup
+            };
+
+            try {
+                facetsInit.resolve();
+                isoScope.$digest();
+            } catch (ex) {
+                fail('A desk not in deskLookup should not cause an error.');
+            }
+        });
+
+        it('outputs a warning if desk not in deskLookup', function () {
+            isoScope.desk = null;
+
+            isoScope.items._aggregations.desk.buckets = [
+                {doc_count: 123, key: 'abc123'}
+            ];
+
+            desks.deskLookup = {
+                otherDesk: {}  // desk abc123 not present in deskLookup
+            };
+
+            spyOn(console, 'warn');
+
+            facetsInit.resolve();
+            isoScope.$digest();
+
+            expect(console.warn).toHaveBeenCalledWith(
+                'Desk (key: abc123) not found in deskLookup, ' +
+                'probable storage inconsistency.'
+            );
+        });
+    });
+
+});


### PR DESCRIPTION
Resolves [SD-2797](https://dev.sourcefabric.org/browse/SD-2797).

This PR includes the following:

* Fix the console error on the Search page if a desk is not found in desk lookup (this can happen if there are inconsistencies between Mongo and Elastic),
* Small fix in the `MetadataListEditingDirective` (potential error if the `items` Array is empty),
* Rewrite an `if` statement in `sdSearchFacets` directive's `items` change handler to outdent the function body for better readability (the indentation level was already pretty high).