### PR TITLE
[SD-3031] Removal of images when expiring from ingest

### DIFF
--- a/server/superdesk/commands/clean_images.py
+++ b/server/superdesk/commands/clean_images.py
@@ -35,7 +35,7 @@ class CleanImages(superdesk.Command):
             self.__add_existing_files(used_images, upload_items)
 
             print('Number of used files: ', len(used_images))
-            current_files = superdesk.app.media.fs().find({'_id': {'$nin': list(used_images)}})
+            current_files = superdesk.app.media.fs('upload').find({'_id': {'$nin': list(used_images)}})
 
             for file_id in (file._id for file in current_files if str(file._id) not in used_images):
                 print('Removing unused file: ', file_id)

--- a/server/superdesk/io/commands/remove_expired_content.py
+++ b/server/superdesk/io/commands/remove_expired_content.py
@@ -57,6 +57,7 @@ def remove_expired_data(provider):
     items = get_expired_items(provider, expiration_date)
 
     ids = [item['_id'] for item in items]
+    items.rewind()
     file_ids = [rend.get('media')
                 for item in items
                 for rend in item.get('renditions', {}).values()


### PR DESCRIPTION
It seems that the clean images routine was broken.

Also the images are not getting purged as the cursor had been traversed already when attempting to construct the list of file id's