### PR TITLE
Fix unit tests failing because of the unexpected GET .../workspace.html

### DIFF
--- a/client/app/scripts/superdesk-authoring/tests/authoring_spec.js
+++ b/client/app/scripts/superdesk-authoring/tests/authoring_spec.js
@@ -312,6 +312,7 @@ describe('authoring', function() {
 describe('autosave', function() {
     beforeEach(module('superdesk.authoring'));
     beforeEach(module('superdesk.mocks'));
+    beforeEach(module('templates'));
 
     it('can fetch an autosave for not locked item', inject(function(autosave, api, $q, $rootScope) {
         spyOn(api, 'find').and.returnValue($q.when({}));
@@ -364,6 +365,7 @@ describe('autosave', function() {
 describe('lock service', function() {
     beforeEach(module('superdesk.authoring'));
     beforeEach(module('superdesk.mocks'));
+    beforeEach(module('templates'));
 
     var user = {_id: 'user'};
     var sess = {_id: 'sess'};
@@ -430,6 +432,7 @@ describe('authoring actions', function() {
     beforeEach(module('superdesk.authoring'));
     beforeEach(module('superdesk.mocks'));
     beforeEach(module('superdesk.desks'));
+    beforeEach(module('templates'));
 
     beforeEach(inject(function(desks, $q) {
         spyOn(desks, 'fetchCurrentUserDesks').and.returnValue($q.when({_items: userDesks}));

--- a/client/app/scripts/superdesk-authoring/workqueue/tests/workqueue_spec.js
+++ b/client/app/scripts/superdesk-authoring/workqueue/tests/workqueue_spec.js
@@ -13,6 +13,7 @@ describe('workqueue', function() {
 
     beforeEach(module('mock.route'));
     beforeEach(module('superdesk.authoring.workqueue'));
+    beforeEach(module('templates'));
 
     beforeEach(inject(function(session, $q) {
         spyOn(session, 'getIdentity').and.returnValue($q.when({_id: USER_ID}));

--- a/client/app/scripts/superdesk-desks/tests/desks-spec.js
+++ b/client/app/scripts/superdesk-desks/tests/desks-spec.js
@@ -6,6 +6,7 @@ describe('desks service', function() {
     var USER_URL = 'users/1';
 
     beforeEach(module('superdesk.desks'));
+    beforeEach(module('templates'));
 
     it('can fetch current user desks',
     inject(function(desks, session, api, preferencesService, $rootScope, $q) {

--- a/client/app/scripts/superdesk-ingest/ingest.spec.js
+++ b/client/app/scripts/superdesk-ingest/ingest.spec.js
@@ -5,6 +5,7 @@ describe('ingest', function() {
     describe('send service', function() {
 
         beforeEach(module('superdesk.ingest.send'));
+        beforeEach(module('templates'));
 
         it('can send an item', inject(function(send, api, $q, $rootScope) {
             spyOn(api, 'save').and.returnValue($q.when({_created: 'now'}));

--- a/client/app/scripts/superdesk-publish/tests/publish_spec.js
+++ b/client/app/scripts/superdesk-publish/tests/publish_spec.js
@@ -108,6 +108,7 @@ describe('publish queue', function() {
     beforeEach(module('superdesk.publish.filters'));
     beforeEach(module('superdesk.publish'));
     beforeEach(module('superdesk.mocks'));
+    beforeEach(module('templates'));
 
     beforeEach(inject(function($rootScope, $controller, adminPublishSettingsService, $q, api) {
         spyOn(adminPublishSettingsService, 'fetchSubscribers').and.returnValue($q.when(subscribers));

--- a/client/app/scripts/superdesk-search/tests/tags_spec.js
+++ b/client/app/scripts/superdesk-search/tests/tags_spec.js
@@ -9,6 +9,7 @@ describe('Tag Service', function() {
 
     beforeEach(module('superdesk.search'));
     beforeEach(module('superdesk.desks'));
+    beforeEach(module('templates'));
 
     it('can populate keywords from location', inject(function($location, tags, $rootScope, desks, $q) {
         var members = null;

--- a/client/app/scripts/superdesk-templates/templates.spec.js
+++ b/client/app/scripts/superdesk-templates/templates.spec.js
@@ -2,6 +2,7 @@ describe('templates', function() {
     'use strict';
 
     beforeEach(module('superdesk.templates'));
+    beforeEach(module('templates'));
 
     describe('templates widget', function() {
         it('should create a template', inject(function($controller, api, desks, $q, $rootScope) {

--- a/client/app/scripts/superdesk/itemList/itemList_spec.js
+++ b/client/app/scripts/superdesk/itemList/itemList_spec.js
@@ -2,6 +2,7 @@
 
 describe('itemListService', function() {
     beforeEach(module('superdesk.mocks'));
+    beforeEach(module('templates'));
     beforeEach(module('superdesk.itemList'));
     beforeEach(module(function($provide) {
         $provide.service('api', function($q) {

--- a/client/app/scripts/superdesk/notification/tests/notification_spec.js
+++ b/client/app/scripts/superdesk/notification/tests/notification_spec.js
@@ -1,6 +1,8 @@
 'use strict';
 describe('Reload Service', function() {
     beforeEach(module('superdesk.notification'));
+    beforeEach(module('templates'));
+
     var USER_URL = '/users/1';
     var USER = {
         _links: {self: {href: USER_URL}},


### PR DESCRIPTION
Not sure if loading the `'templates'` module could be done at a single central place, suggestions welcome, but at least this fixes the tests in builds, allowing us to merge the PRs again.