### PR TITLE
[SD-3031] Test for updates of images from Reuters causes media entrie…

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -6,4 +6,4 @@ wooper==0.4.2
 boto3==1.0.0
 
 git+git://github.com/superdesk/eve@sync-develop-24-june#egg=Eve==0.6.0-dev
--e git+git://github.com/superdesk/superdesk-core@c76de058e9#egg=Superdesk-Core==0.0.1-dev
+-e git+git://github.com/superdesk/superdesk-core@29cc286bc2#egg=Superdesk-Core==0.0.1-dev


### PR DESCRIPTION
…s to become orphaned

This is dependent on the corresponding pull request against superdesk-core! 