### PR TITLE
(fix) Fixing the problem of AWS Storage 'Metadata too Large' exception.

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -7,3 +7,4 @@ boto3==1.0.0
 
 git+git://github.com/superdesk/eve@sync-develop-24-june#egg=Eve==0.6.0-dev
 -e git+git://github.com/superdesk/superdesk-core@0e317580007#egg=Superdesk-Core==0.0.1-dev
+


### PR DESCRIPTION
https://github.com/superdesk/superdesk-core/pull/9

This only affects the AWS storage.  

Maybe change the code https://github.com/superdesk/superdesk/blob/master/server/apps/storage/amazon/amazon_media_storage.py#L118

`self.client.put_object(Key=filename, Body=content, Bucket=self.container_name,
                                   ContentType=content_type, Metadata=None)` 

