### PR TITLE
fix(loading): reload route in next digest

### DIFF
--- a/client/app/scripts/superdesk/superdesk.js
+++ b/client/app/scripts/superdesk/superdesk.js
@@ -67,7 +67,9 @@ define([
                 stopListener();
                 $http.defaults.headers.common.Authorization = session.token;
                 $rootScope.loading = false;
-                $route.reload();
+                // do this in next $digest so that beta service can setup route redirects
+                // for features that should not be available
+                $rootScope.$applyAsync($route.reload);
             });
 
             // prevent routing when there is no token


### PR DESCRIPTION
once user logs in and preferences promise is resolved we're updating
routes to disable those that should not be available because of
permissions or beta flag. to make sure route reload is triggered only
after it's called via `$applyAsync`.