### PR TITLE
fix(monitoring): refresh monitoring on content changes

### DIFF
--- a/client/app/scripts/superdesk-archive/controllers/list.js
+++ b/client/app/scripts/superdesk-archive/controllers/list.js
@@ -124,9 +124,7 @@ define([
         $scope.$on('item:copy', refreshItems);
         $scope.$on('item:take', refreshItems);
         $scope.$on('item:duplicate', refreshItems);
-        $scope.$on('item:created', refreshItems);
-        $scope.$on('item:updated', refreshItems);
-        $scope.$on('item:replaced', refreshItems);
+        $scope.$on('content:update', refreshItems);
         $scope.$on('item:deleted', refreshItems);
         $scope.$on('item:mark', refreshItems);
         $scope.$on('item:spike', reset);

--- a/client/app/scripts/superdesk-desks/desks.js
+++ b/client/app/scripts/superdesk-desks/desks.js
@@ -126,6 +126,12 @@
                     }
                 });
 
+                scope.$on('content:update', function($event, data) {
+                    if (cards.shouldUpdate(scope.stage, data)) {
+                        queryItems();
+                    }
+                });
+
                 var container = elem[0];
                 var offsetY = 0;
                 elem.bind('scroll', function() {

--- a/client/app/scripts/superdesk-monitoring/monitoring.spec.js
+++ b/client/app/scripts/superdesk-monitoring/monitoring.spec.js
@@ -156,18 +156,20 @@ describe('monitoring', function() {
         }));
 
         it('can update items on content:update event',
-        inject(function($rootScope, $compile, $q, api) {
+        inject(function($rootScope, $compile, $q, api, $timeout) {
             var scope = $rootScope.$new();
             $compile('<div sd-monitoring-view></div>')(scope);
             scope.$digest();
 
             spyOn(api, 'query').and.returnValue($q.when({_items: [], _meta: {total: 0}}));
-            scope.$broadcast('content:update', {stage: 'bar'});
+            scope.$broadcast('content:update', {stages: {'bar': 1}});
             scope.$digest();
+            $timeout.flush(500);
             expect(api.query).not.toHaveBeenCalled();
 
-            scope.$broadcast('content:update', {stage: 'foo'});
+            scope.$broadcast('content:update', {stages: {'foo': 1}});
             scope.$digest();
+            $timeout.flush(500);
             expect(api.query).toHaveBeenCalled();
         }));
 

--- a/client/protractor-conf.js
+++ b/client/protractor-conf.js
@@ -24,7 +24,8 @@ exports.config = {
 
     framework: 'jasmine2',
     jasmineNodeOpts: {
-        showColors: true
+        showColors: true,
+        defaultTimeoutInterval: 55000
     },
 
     capabilities: {

--- a/server/apps/archive/common.py
+++ b/server/apps/archive/common.py
@@ -9,14 +9,14 @@
 # at https://www.sourcefabric.org/superdesk/license
 
 
-from datetime import datetime
-
-from eve.utils import config
 import flask
+from eve.utils import config
+from datetime import datetime
 from flask import current_app as app
 from eve.versioning import insert_versioning_documents
 from pytz import timezone
 
+import superdesk
 from superdesk.users.services import get_sign_off
 from superdesk.celery_app import update_key
 from superdesk.utc import utcnow, get_expiry_date
@@ -25,11 +25,12 @@ from superdesk import get_resource_service
 from superdesk.metadata.item import metadata_schema, ITEM_STATE, CONTENT_STATE, \
     LINKED_IN_PACKAGES, BYLINE, SIGN_OFF, EMBARGO
 from superdesk.workflow import set_default_state, is_workflow_state_transition_valid
-import superdesk
 from superdesk.metadata.item import GUID_NEWSML, GUID_FIELD, GUID_TAG, not_analyzed
 from superdesk.metadata.packages import PACKAGE_TYPE, TAKES_PACKAGE, SEQUENCE
 from superdesk.metadata.utils import generate_guid
 from superdesk.errors import SuperdeskApiError, IdentifierGenerationError
+from apps.auth import get_user
+
 
 ARCHIVE = 'archive'
 CUSTOM_HATEOAS = {'self': {'title': 'Archive', 'href': '/archive/{_id}'}}
@@ -138,13 +139,6 @@ def on_duplicate_item(doc):
 def update_dates_for(doc):
     for item in ['firstcreated', 'versioncreated']:
         doc.setdefault(item, utcnow())
-
-
-def get_user(required=False):
-    user = flask.g.get('user', {})
-    if '_id' not in user and required:
-        raise SuperdeskApiError.notFoundError('Invalid user.')
-    return user
 
 
 def get_auth():

--- a/server/apps/auth/__init__.py
+++ b/server/apps/auth/__init__.py
@@ -8,14 +8,17 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 
+import flask
+import logging
+import superdesk
+
 from apps.auth.auth import SuperdeskTokenAuth
 from .auth import AuthUsersResource, AuthResource  # noqa
 from .sessions import SessionsResource
-import superdesk
 from superdesk.services import BaseService
 from superdesk.celery_app import celery
-import logging
 from .session_purge import RemoveExpiredSessions
+from superdesk.errors import SuperdeskApiError
 
 logger = logging.getLogger(__name__)
 
@@ -38,3 +41,14 @@ def session_purge():
         RemoveExpiredSessions().run()
     except Exception as ex:
         logger.error(ex)
+
+
+def get_user(required=False):
+    """Get user authenticated for current request.
+
+    :param boolean required: if True and there is no user it will raise an error
+    """
+    user = flask.g.get('user', {})
+    if '_id' not in user and required:
+        raise SuperdeskApiError.notFoundError('Invalid user.')
+    return user

--- a/server/apps/content/__init__.py
+++ b/server/apps/content/__init__.py
@@ -1,0 +1,33 @@
+"""Content related helpers and utils.
+"""
+
+from superdesk.notification import push_notification
+from apps.auth import get_user
+
+
+def push_content_notification(items):
+    """Push content:update notification for multiple items.
+
+    It can be also 2 versions of same item in updated handler
+    so that we sent event with both old and new desk/stage.
+
+    :param list items: list of items
+    """
+    ids = {}
+    desks = {}
+    stages = {}
+    for item in items:
+        ids[str(item.get('_id', ''))] = 1
+        task = item.get('task', {})
+        if task.get('desk'):
+            desks[str(task.get('desk', ''))] = 1
+        if task.get('stage'):
+            stages[str(task.get('stage', ''))] = 1
+    user = get_user()
+    push_notification(
+        'content:update',
+        user=str(user.get('_id', '')),
+        items=ids,
+        desks=desks,
+        stages=stages
+    )

--- a/server/apps/content/content_tests.py
+++ b/server/apps/content/content_tests.py
@@ -1,0 +1,31 @@
+
+import flask
+import unittest
+import unittest.mock
+from . import push_content_notification
+
+
+class PushContentNotificationTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.app = flask.Flask(__name__)
+        self.ctx = self.app.app_context()
+        self.ctx.push()
+
+    def tearDown(self):
+        self.ctx.pop()
+
+    @unittest.mock.patch('apps.content.push_notification')
+    def test_push_content_notification(self, push_notification):
+        foo1 = {'_id': 'foo', 'task': {'desk': 'sports', 'stage': 'inbox'}}
+        foo2 = {'_id': 'foo', 'task': {'desk': 'news', 'stage': 'todo'}}
+        foo3 = {'_id': 'foo'}
+
+        push_content_notification([foo1, foo2, foo3])
+        push_notification.assert_called_once_with(
+            'content:update',
+            user='',
+            items={'foo': 1},
+            desks={'sports': 1, 'news': 1},
+            stages={'inbox': 1, 'todo': 1}
+        )


### PR DESCRIPTION
there is single event `content:update` with info about item, desk
and stage which client can use to figure out what to update in monitoring.

SD-3204 SD-3213