### PR TITLE
[SD-3236] - Scheduled items stay in "scheduled" state if they don't get queued

### DIFF
--- a/server/apps/archive/__init__.py
+++ b/server/apps/archive/__init__.py
@@ -16,7 +16,8 @@ import logging
 
 from .archive import ArchiveResource, ArchiveService, ArchiveVersionsResource, AutoSaveResource, \
     ArchiveSaveService
-from .commands import RemoveExpiredSpikeContent
+from .commands import RemoveExpiredSpikeContent, UpdateOverdueScheduledContent
+from apps.publish.commands import UpdateOverdueScheduledPublishedContent
 from .ingest import IngestResource, AppIngestService
 from .item_comments import ItemCommentsResource, ItemCommentsSubResource, ItemCommentsService, ItemCommentsSubService
 from .user_content import UserContentResource, UserContentService
@@ -134,3 +135,9 @@ def init_app(app):
 @celery.task
 def content_purge():
     RemoveExpiredSpikeContent().run()
+
+
+@celery.task
+def remove_scheduled():
+    UpdateOverdueScheduledContent().run()
+    UpdateOverdueScheduledPublishedContent().run()

--- a/server/apps/archive/archive.py
+++ b/server/apps/archive/archive.py
@@ -489,7 +489,7 @@ class ArchiveService(BaseService):
 
         doc_id = str(doc[config.ID_FIELD])
         super().delete_action({config.ID_FIELD: doc_id})
-        resource_def = self.app.config['DOMAIN']['archive_versions']
+        resource_def = app.config['DOMAIN']['archive_versions']
         get_resource_service('archive_versions').delete(lookup={versioned_id_field(resource_def): doc_id})
 
     def __is_req_for_save(self, doc):

--- a/server/apps/archive/commands.py
+++ b/server/apps/archive/commands.py
@@ -8,14 +8,18 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 
-
-from eve.utils import ParsedRequest, date_to_str
 import superdesk
+import logging
+from eve.utils import ParsedRequest, date_to_str, config
+from superdesk.celery_task_utils import is_task_running, mark_task_as_not_running
 from superdesk.utc import utcnow
 from .archive import SOURCE as ARCHIVE
-import logging
+from superdesk.metadata.item import ITEM_STATE, CONTENT_STATE
 
 logger = logging.getLogger(__name__)
+
+REMOVE_SPIKE_DEFAULT = {'minutes': 30}
+UPDATE_OVERDUE_SCHEDULED_DEFAULT = {'minutes': 10}
 
 
 class RemoveExpiredSpikeContent(superdesk.Command):
@@ -29,15 +33,22 @@ class RemoveExpiredSpikeContent(superdesk.Command):
     def remove_expired_content(self):
         logger.info('Removing expired content if spiked')
 
-        now = date_to_str(utcnow())
-        items = self.get_expired_items(now)
+        if is_task_running("archive", "remove_expired_content", REMOVE_SPIKE_DEFAULT):
+            return
 
-        while items.count() > 0:
-            for item in items:
-                logger.info('deleting {} expiry: {} now:{}'.format(item['_id'], item['expiry'], now))
-                superdesk.get_resource_service(ARCHIVE).remove_expired(item)
-
+        try:
+            now = date_to_str(utcnow())
             items = self.get_expired_items(now)
+
+            while items.count() > 0:
+                for item in items:
+                    logger.info('deleting {} expiry: {} now:{}'.format(item[config.ID_FIELD], item['expiry'], now))
+                    superdesk.get_resource_service(ARCHIVE).remove_expired(item)
+
+                items = self.get_expired_items(now)
+
+        finally:
+            mark_task_as_not_running("archive", "remove_expired_content")
 
     def get_expired_items(self, now):
         query_filter = self._get_query_for_expired_items(now)
@@ -50,11 +61,68 @@ class RemoveExpiredSpikeContent(superdesk.Command):
         query = {
             '$and': [
                 {'expiry': {'$lte': now}},
-                {'state': 'spiked'}
+                {ITEM_STATE: CONTENT_STATE.SPIKED}
             ]
         }
 
         return query
 
 
+class UpdateOverdueScheduledContent(superdesk.Command):
+    """
+    Updates the overdue scheduled stories
+    """
+
+    def run(self):
+        self.update_overdue_scheduled()
+
+    def update_overdue_scheduled(self):
+        """
+        Updates the overdue scheduled content on archive collection.
+        """
+
+        logger.info('Updating overdue scheduled content')
+
+        if is_task_running("archive", "update_overdue_scheduled", UPDATE_OVERDUE_SCHEDULED_DEFAULT):
+            return
+
+        try:
+            now = date_to_str(utcnow())
+            items = get_overdue_scheduled_items(now, ARCHIVE)
+            item_update = {ITEM_STATE: CONTENT_STATE.PUBLISHED}
+
+            for item in items:
+                logger.info('updating overdue scheduled article with id {} and headline {} -- expired on: {} now: {}'.
+                            format(item[config.ID_FIELD], item['headline'], item['publish_schedule'], now))
+
+                superdesk.get_resource_service(ARCHIVE).patch(item['item_id'], item_update)
+        finally:
+            mark_task_as_not_running("archive", "update_overdue_scheduled")
+
+
+def get_overdue_scheduled_items(expired_date_time, resource, limit=100):
+    """
+    Fetches the overdue scheduled articles from given collection. Overdue Conditions:
+        1.  it should be in 'scheduled' state
+        2.  publish_schedule is less than or equal to expired_date_time
+
+    :param expired_date_time: DateTime that scheduled tate will be checked against
+    :param resource: Name of the resource to check the data from
+    :param limit: Number of return items
+    :return: overdue scheduled articles from published collection
+    """
+
+    logger.info('Get overdue scheduled content from {}'.format(resource))
+    query = {'$and': [
+        {'publish_schedule': {'$lte': expired_date_time}},
+        {ITEM_STATE: CONTENT_STATE.SCHEDULED}
+    ]}
+
+    req = ParsedRequest()
+    req.sort = '_modified'
+    req.max_results = limit
+
+    return superdesk.get_resource_service(resource).get_from_mongo(req=req, lookup=query)
+
 superdesk.command('archive:remove_spiked_if_expired', RemoveExpiredSpikeContent())
+superdesk.command('archive:remove_overdue_scheduled', UpdateOverdueScheduledContent())

--- a/server/settings.py
+++ b/server/settings.py
@@ -114,6 +114,10 @@ CELERYBEAT_SCHEDULE = {
         'task': 'apps.publish.content_purge',
         'schedule': crontab(minute=30)
     },
+    'publish:remove_overdue_scheduled': {
+        'task': 'apps.archive.remove_scheduled',
+        'schedule': crontab(minute=10)
+    },
     'content:schedule': {
         'task': 'apps.templates.content_templates.create_scheduled_content',
         'schedule': crontab(minute='*/5'),


### PR DESCRIPTION
This issue happens when:
- There is no queue entries for an scheduled item so a transmission never takes place so the item always stays in "scheduled" state.
- A text story is scheduled but wire clients didn't get the text but digital clients did get the take pckg. So text version of the story always stays in "scheduled" state.

This is a clean-up task to update the scheduled stories to "Published" once the "publish_schedule" field is overdue and the story is still in scheduled state. Even if there are problems in transmitting the story the state needs to change to "Published" as per users publish queue state doesn't matter much. 