### PR TITLE
(imp) (fix) Embargo Related

### DIFF
--- a/client/app/scripts/superdesk-archive/views/metadata-view.html
+++ b/client/app/scripts/superdesk-archive/views/metadata-view.html
@@ -17,9 +17,9 @@
             <dt translate>Word Count</dt>
             <dd>{{ item.word_count }}</dd>
         </dl>
-        <dl>
+        <dl ng-if="item.keywords && item.keywords.length > 0">
             <dt translate>Keywords</dt>
-            <dd ng-if="item.keywords && item.keywords.length > 0">{{ item.keywords | mergeWords}}</dd>
+            <dd>{{ item.keywords | mergeWords}}</dd>
         </dl>
        
         <dl ng-if="item.original_source">
@@ -34,9 +34,9 @@
             <dt translate>Take key</dt>
             <dd>{{ item.anpa_take_key }}</dd>
         </dl>
-        <dl>
+        <dl ng-if="item.signal">
             <dt translate>Signal</dt>
-            <dd ng-if="item.signal">{{ item.signal }}</dd>
+            <dd>{{ item.signal }}</dd>
         </dl>
         <dl>
             <dt translate>ANPA category</dt>
@@ -46,21 +46,25 @@
             <dt translate>Subject</dt>
             <dd ng-if="item.subject && item.subject.length > 0">{{ item.subject | mergeWords:'name'}}</dd>
         </dl>
-         <dl>
-            <dt translate>Editorial Note</dt>
-            <dd ng-if="item.editorial_note">{{ item.editorial_note }}</dd>
+         <dl ng-if="item.embargo">
+            <dt translate>Embargo Timestamp</dt>
+            <dd sd-reldate-complex ng-model="item.embargo"></dd>
         </dl>
-        <dl>
+         <dl ng-if="item.ednote">
+            <dt translate>Editorial Note</dt>
+            <dd>{{ item.ednote }}</dd>
+        </dl>
+        <dl ng-if="item.genre  && item.genre.length > 0">
             <dt translate>Genre</dt>
-            <dd ng-if="item.genre  && item.genre.length > 0">{{ item.genre | mergeWords:'name'}}</dd>
+            <dd>{{ item.genre | mergeWords:'name'}}</dd>
         </dl>
         <dl>
             <dt translate>Dateline</dt>
             <dd>{{ item.dateline.text }}</dd>
         </dl>
-        <dl>
+        <dl ng-if="item.place && item.place.length > 0">
             <dt translate>Place</dt>
-            <dd ng-if="item.place && item.place.length > 0">{{ item.place | mergeWords:'name'}}</dd>
+            <dd>{{ item.place | mergeWords:'name'}}</dd>
         </dl>
         <dl>
             <dt translate>Byline</dt>
@@ -117,14 +121,14 @@
         </dl>
 
         <!-- publish schedule data -->
-        <dl>
+        <dl ng-if="item.publish_schedule">
             <dt translate>Publish Schedule</dt>
-            <dd ng-if="item.publish_schedule" sd-reldate-complex ng-model="item.publish_schedule"></dd>
+            <dd sd-reldate-complex ng-model="item.publish_schedule"></dd>
         </dl>
 
-        <dl>
+        <dl ng-if="item.targeted_for">
             <dt translate>Targeted For</dt>
-            <dd ng-if="item.targeted_for">{{item.targeted_for | mergeTargets}}</dd>
+            <dd>{{item.targeted_for | mergeTargets}}</dd>
         </dl>
 
         <!-- file specific data -->

--- a/client/app/scripts/superdesk-authoring/authoring.js
+++ b/client/app/scripts/superdesk-authoring/authoring.js
@@ -271,6 +271,10 @@
                 delete diff.publish_schedule;
             }
 
+            if (diff.embargo && this.isPublished(orig)) {
+                delete diff.embargo;
+            }
+
             //check if rendition is dirty for real
             if (_.isEqual(orig.renditions, diff.renditions)) {
                 delete diff.renditions;

--- a/client/app/scripts/superdesk-authoring/authoring.js
+++ b/client/app/scripts/superdesk-authoring/authoring.js
@@ -1546,8 +1546,15 @@
                  * Returns true if Embargo needs to be displayed, false otherwise.
                  */
                 scope.showEmbargo = function() {
-                    return scope.mode !== 'ingest' && scope.item && scope.item.type !== 'composite' &&
-                        !scope.item.publish_schedule_date && !scope.item.publish_schedule_time;
+                    var prePublishCondition = scope.mode !== 'ingest' && scope.item &&
+                        scope.item.type !== 'composite' && !scope.item.publish_schedule_date &&
+                        !scope.item.publish_schedule_time;
+
+                    if (prePublishCondition && authoring.isPublished(scope.item)) {
+                        return scope.item.embargo;
+                    }
+
+                    return prePublishCondition;
                 };
 
                 /**

--- a/client/app/scripts/superdesk-authoring/authoring.js
+++ b/client/app/scripts/superdesk-authoring/authoring.js
@@ -967,10 +967,12 @@
 
                         if (!_.isDate(schedule)) {
                             errorMessage = gettext(fieldName + ' is not a valid date!');
-                        } else if (schedule < _.now()) {
-                            errorMessage = gettext(fieldName + ' cannot be earlier than now!');
                         } else if (!schedule.getTime()) {
                             errorMessage = gettext(fieldName + ' time is invalid!');
+                        } else if (schedule < _.now()) {
+                            if (fieldName !== 'Embargo' || $scope._isInProductionStates) {
+                                errorMessage = gettext(fieldName + ' cannot be earlier than now!');
+                            }
                         }
                     }
 

--- a/client/app/scripts/superdesk-packaging/packaging.js
+++ b/client/app/scripts/superdesk-packaging/packaging.js
@@ -198,6 +198,8 @@
             params.ignoreScheduled = true;
 
             var query = search.query(params);
+
+            query.filter({'not': {'exists': {'field': 'embargo'}}});
             query.size(25);
             if ($scope.highlight) {
                 query.filter({term: {'highlights': $scope.highlight.toString()}});

--- a/client/spec/content_spec.js
+++ b/client/spec/content_spec.js
@@ -32,6 +32,22 @@ describe('Content', function() {
         browser.sleep(50);
     }
 
+    function setEmbargo() {
+        var embargoTS = new Date();
+        embargoTS.setDate(embargoTS.getDate() + 2);
+        var embargoDate = embargoTS.getDate() + '/' + (embargoTS.getMonth() + 1) + '/' +
+            embargoTS.getFullYear();
+        var embargoTime = embargoTS.toTimeString().slice(0, 8);
+
+        workspace.editItem('item3', 'SPORTS');
+        element(by.id('send-to-btn')).click();
+        element(by.model('item.embargo_date')).element(by.tagName('input')).sendKeys(embargoDate);
+        element(by.model('item.embargo_time')).element(by.tagName('input')).sendKeys(embargoTime);
+
+        element(by.css('[ng-click="save(item)"]')).click();
+        element(by.id('closeAuthoringBtn')).click();
+    }
+
     it('can navigate with keyboard', function() {
         pressKey(protractor.Key.UP);
         expect(selectedHeadline()).toBe('package1');
@@ -176,6 +192,25 @@ describe('Content', function() {
         expect(element(by.className('navigation-tabs')).all(by.repeater('widget in widgets')).count()).toBe(6);
 
         element(by.id('closeAuthoringBtn')).click();
+    });
+
+    it('can display embargo in metadata when set', function() {
+        setEmbargo();
+
+        content.previewItem('item3');
+        element(by.css('[ng-click="tab = \'metadata\'"]')).click();
+        expect(element(by.model('item.embargo')).isDisplayed()).toBe(true);
+    });
+
+    it('cannot display embargo items in search widget of the package', function() {
+        setEmbargo();
+
+        element(by.className('sd-create-btn')).click();
+        element(by.id('create_package')).click();
+
+        element(by.id('Search')).click();
+        element(by.className('search-box')).element(by.model('query')).sendKeys('item3');
+        expect(element.all(by.repeater('pitem in contentItems')).count()).toBe(0);
     });
 
 });

--- a/client/spec/helpers/content.js
+++ b/client/spec/helpers/content.js
@@ -83,6 +83,13 @@ function Content() {
         return menu;
     };
 
+    this.previewItem = function(item) {
+        this.getItem(item).click();
+
+        var preview = element(by.id('item-preview'));
+        waitFor(preview);
+    };
+
     this.checkMarkedForHighlight = function(highlight, item) {
         var crtItem = this.getItem(item);
         expect(crtItem.element(by.className('icon-star-color')).isDisplayed()).toBeTruthy();

--- a/server/apps/archive/archive.py
+++ b/server/apps/archive/archive.py
@@ -392,6 +392,7 @@ class ArchiveService(BaseService):
         del new_doc[config.ID_FIELD]
         del new_doc['guid']
         new_doc.pop(LINKED_IN_PACKAGES, None)
+        new_doc.pop(EMBARGO, None)
 
         new_doc[ITEM_OPERATION] = ITEM_DUPLICATE
         item_model = get_model(ItemModel)

--- a/server/apps/archive/archive.py
+++ b/server/apps/archive/archive.py
@@ -26,7 +26,7 @@ from eve.utils import parse_request, config
 from superdesk.services import BaseService
 from superdesk.users.services import current_user_has_privilege, is_admin
 from superdesk.metadata.item import metadata_schema, ITEM_STATE, CONTENT_STATE, \
-    CONTENT_TYPE, ITEM_TYPE, EMBARGO, LINKED_IN_PACKAGES
+    CONTENT_TYPE, ITEM_TYPE, EMBARGO, LINKED_IN_PACKAGES, PUBLISH_STATES
 from apps.common.components.utils import get_component
 from apps.item_autosave.components.item_autosave import ItemAutosave
 from apps.common.models.base_model import InvalidEtag
@@ -535,7 +535,7 @@ class ArchiveService(BaseService):
                 if not isinstance(embargo, datetime.date) or not embargo.time():
                     raise SuperdeskApiError.badRequestError("Invalid Embargo")
 
-                if item[ITEM_STATE] not in [CONTENT_STATE.CORRECTED, CONTENT_STATE.KILLED] and embargo <= utcnow():
+                if item[ITEM_STATE] not in PUBLISH_STATES and embargo <= utcnow():
                     raise SuperdeskApiError.badRequestError("Embargo cannot be earlier than now")
         elif item[ITEM_TYPE] == CONTENT_TYPE.COMPOSITE and not self.takesService.is_takes_package(item):
             if item.get(EMBARGO):

--- a/server/apps/publish/archive_publish.py
+++ b/server/apps/publish/archive_publish.py
@@ -373,7 +373,7 @@ class BasePublishService(BaseService):
 
         if updates.get(EMBARGO, original.get(EMBARGO)) \
                 and updates.get('ednote', original.get('ednote', '')).find('Embargo') == -1:
-            updates['ednote'] = '{}{}'.format(original.get('ednote', ''), ' Embargoed.')
+            updates['ednote'] = '{} {}'.format(original.get('ednote', ''), 'Embargoed.').strip()
 
     def _update_archive(self, original, updates, versioned_doc=None, should_insert_into_versions=True):
         """

--- a/server/features/embargo.feature
+++ b/server/features/embargo.feature
@@ -342,3 +342,30 @@ Feature: Embargo Date and Time on an Article (User Story: https://dev.sourcefabr
     """
     {"_message": "Rewrite of an Item having embargo isn't possible"}
     """
+
+  @auth
+  Scenario: Embargo shouldn't be copied while Duplicating an Embargoed Article
+    When we patch "/archive/123"
+    """
+    {"embargo": "#DATE+2#", "headline": "here comes the embargo"}
+    """
+    Then we get response code 200
+    When we post to "/archive/123/duplicate" with success
+    """
+    {"desk": "#desks._id#"}
+    """
+    And we get "/archive/#duplicate._id#"
+    Then there is no "embargo" in response
+
+  @auth
+  Scenario: Embargo shouldn't be copied while Copying an Embargoed Article
+    When we post to "/archive" with success
+    """
+    [{"type":"text", "headline": "test1", "state": "draft", "guid": "text-article-with-embargo", "embargo": "#DATE+2#"}]
+    """
+    When we post to "/archive/text-article-with-embargo/copy" with success
+    """
+    {}
+    """
+    And we get "/archive/#copy._id#"
+    Then there is no "embargo" in response


### PR DESCRIPTION
1. [SD-3252](https://dev.sourcefabric.org/browse/SD-3252) - Correct and kill are ineffective in embargo
2. [SD-3247](https://dev.sourcefabric.org/browse/SD-3247) - Add embargo values to metadata info
3. [SD-3254](https://dev.sourcefabric.org/browse/SD-3254) - A duplicate of an embargo carries the same state color
4. [SD-3255](https://dev.sourcefabric.org/browse/SD-3255) - Inconsistency in color when choosing items for a package [embargo]