### PR TITLE
fix(lock): fix unlocking of auto generated items

### DIFF
--- a/client/spec/highlights_spec.js
+++ b/client/spec/highlights_spec.js
@@ -220,7 +220,7 @@ describe('HIGHLIGHTS', function() {
 
             workspace.switchToDesk('SPORTS');
             content.setListView();
-            expect(content.getCount()).toBe(4);
+            expect(content.getCount()).toBe(3);
         });
     });
 

--- a/server/apps/common/models/io/base_proxy.py
+++ b/server/apps/common/models/io/base_proxy.py
@@ -49,11 +49,10 @@ class BaseProxy(DataLayer):
         return self.data_layer.delete(resource, filter)
 
     def _update(self, resource, filter, doc, method='update'):
-        _id = doc.get(ID_FIELD, None)
-        if ID_FIELD in doc:
-            del doc[ID_FIELD]
+        _id = doc.pop(ID_FIELD, None)
         original = self.find_one(resource, filter, None)
-        res = getattr(self.data_layer, method)(resource, filter[ID_FIELD], doc, original)
-        if _id is not None:
-            doc[ID_FIELD] = _id
+        filter[ID_FIELD] = original[ID_FIELD]  # make sure it's correct type
+        updates = doc.copy()
+        res = getattr(self.data_layer, method)(resource, filter[ID_FIELD], updates, original)
+        doc.setdefault(ID_FIELD, _id)
         return res

--- a/server/apps/common/models/io/base_proxy_tests.py
+++ b/server/apps/common/models/io/base_proxy_tests.py
@@ -1,0 +1,23 @@
+
+import unittest
+import unittest.mock
+import bson
+from .base_proxy import BaseProxy
+
+
+class MockDatalayer():
+    find_one = None
+    update = None
+
+
+class BaseProxyTestCase(unittest.TestCase):
+
+    def test_update_will_use_db_id(self):
+        original = {'_id': bson.ObjectId()}
+        updates = {'name': 'foo', '_id': original['_id']}
+        datalayer = MockDatalayer()
+        datalayer.find_one = unittest.mock.MagicMock(return_value=original)
+        datalayer.update = unittest.mock.MagicMock(return_value=original)
+        proxy = BaseProxy(datalayer)
+        proxy.update('test', {'_id': str(original['_id'])}, updates)
+        datalayer.update.assert_called_with('test', original['_id'], {'name': 'foo'}, original)

--- a/server/apps/item_lock/components/item_lock.py
+++ b/server/apps/item_lock/components/item_lock.py
@@ -81,7 +81,7 @@ class ItemLock(BaseComponent):
 
             # delete the item if nothing is saved so far
             # version 0 created on lock item
-            if item[config.VERSION] == 0 and item['state'] == 'draft':
+            if item.get(config.VERSION, 0) == 0 and item['state'] == 'draft':
                 superdesk.get_resource_service('archive').delete(lookup={'_id': item['_id']})
                 return
 


### PR DESCRIPTION
when item is saved it gets populated, but before it's not set
and unlocking it fails with KeyError. there is also some bc fix
for items using objectId and not uuid