### PR TITLE
[SD-2472] - Error handling in fetching empty package

### DIFF
--- a/client/app/scripts/superdesk-ingest/module.js
+++ b/client/app/scripts/superdesk-ingest/module.js
@@ -1407,8 +1407,8 @@ define([
         });
     }]);
 
-    SendService.$inject = ['desks', 'api', '$q'];
-    function SendService(desks, api, $q) {
+    SendService.$inject = ['desks', 'api', '$q', 'notify'];
+    function SendService(desks, api, $q, notify) {
         this.one = sendOne;
         this.all = sendAll;
 
@@ -1435,6 +1435,11 @@ define([
                         item.archived = archiveItem._created;
                         return archiveItem;
                     }, function(response) {
+                        var message = 'Failed to fetch the item';
+                        if (angular.isDefined(response.data._message)) {
+                            message = message + ': ' + response.data._message;
+                        }
+                        notify.error(gettext(message));
                         item.error = response;
                     })
                 ['finally'](function() {

--- a/server/apps/archive/archive.py
+++ b/server/apps/archive/archive.py
@@ -42,7 +42,7 @@ from .archive_media import ArchiveMediaService
 from superdesk.utc import utcnow
 import datetime
 from settings import DEFAULT_SOURCE_VALUE_FOR_MANUAL_ARTICLES, VERSION
-from superdesk.metadata.packages import ITEM_REF, SEQUENCE
+from superdesk.metadata.packages import RESIDREF, SEQUENCE
 
 
 logger = logging.getLogger(__name__)
@@ -370,9 +370,9 @@ class ArchiveService(BaseService):
                 if groups.get('id') != 'root':
                     associations = groups.get('refs', [])
                     for assoc in associations:
-                        if assoc.get(ITEM_REF):
+                        if assoc.get(RESIDREF):
                             item, _item_id, _endpoint = self.packageService.get_associated_item(assoc)
-                            assoc[ITEM_REF] = assoc['guid'] = self.duplicate_content(item)
+                            assoc[RESIDREF] = assoc['guid'] = self.duplicate_content(item)
 
         return self._duplicate_item(original_doc)
 

--- a/server/apps/duplication/archive_fetch.py
+++ b/server/apps/duplication/archive_fetch.py
@@ -111,19 +111,19 @@ class FetchService(BaseService):
 
     def __fetch_items_in_package(self, dest_doc, desk, stage, state):
         for ref in [ref for group in dest_doc.get('groups', [])
-                    for ref in group.get('refs', []) if 'residRef' in ref]:
+                    for ref in group.get('refs', []) if ref.get('residRef')]:
             ref['location'] = ARCHIVE
 
         refs = [{'_id': ref.get('residRef'), 'desk': desk,
                  'stage': stage, 'state': state}
                 for group in dest_doc.get('groups', [])
-                for ref in group.get('refs', []) if 'residRef' in ref]
+                for ref in group.get('refs', []) if ref.get('residRef')]
 
         if refs:
             new_ref_guids = self.fetch(refs, id=None, notify=False)
             count = 0
             for ref in [ref for group in dest_doc.get('groups', [])
-                        for ref in group.get('refs', []) if 'residRef' in ref]:
+                        for ref in group.get('refs', []) if ref.get('residRef')]:
                 ref['residRef'] = ref['guid'] = new_ref_guids[count]
                 count += 1
 

--- a/server/apps/packages/package_service.py
+++ b/server/apps/packages/package_service.py
@@ -158,7 +158,12 @@ class PackageService():
     def get_associated_item(self, assoc, throw_if_not_found=True):
         endpoint = assoc.get('location', 'archive')
         item_id = assoc[ITEM_REF]
+
+        if not item_id:
+            raise SuperdeskApiError.badRequestError("Package contains empty ResidRef!")
+
         item = get_resource_service(endpoint).find_one(req=None, _id=item_id)
+
         if not item and throw_if_not_found:
             message = 'Invalid item reference: ' + assoc[ITEM_REF]
             logger.error(message)

--- a/server/apps/packages/takes_package_service.py
+++ b/server/apps/packages/takes_package_service.py
@@ -16,7 +16,7 @@ from superdesk.errors import SuperdeskApiError, InvalidStateTransitionError
 from superdesk import get_resource_service
 from apps.archive.archive import SOURCE as ARCHIVE
 from superdesk.metadata.packages import LINKED_IN_PACKAGES, PACKAGE_TYPE, TAKES_PACKAGE, PACKAGE, \
-    LAST_TAKE, ASSOCIATIONS, MAIN_GROUP, SEQUENCE, ITEM_REF
+    LAST_TAKE, REFS, MAIN_GROUP, SEQUENCE, RESIDREF
 from superdesk.metadata.item import CONTENT_TYPE, ITEM_TYPE, PUBLISH_STATES, ITEM_STATE, CONTENT_STATE, EMBARGO
 from apps.archive.common import insert_into_versions
 from .package_service import get_item_ref, create_root_group
@@ -62,12 +62,12 @@ class TakesPackageService():
             target_ref[SEQUENCE] = sequence
             takes_package[SEQUENCE] = target_ref[SEQUENCE]
             takes_package[LAST_TAKE] = target[config.ID_FIELD]
-            main_group[ASSOCIATIONS].append(target_ref)
+            main_group[REFS].append(target_ref)
 
         if link is not None:
             link_ref = get_item_ref(link)
             link_ref[SEQUENCE] = self.__next_sequence__(sequence)
-            main_group[ASSOCIATIONS].append(link_ref)
+            main_group[REFS].append(link_ref)
             takes_package[SEQUENCE] = link_ref[SEQUENCE]
             takes_package[LAST_TAKE] = link[config.ID_FIELD]
             link[SEQUENCE] = link_ref[SEQUENCE]
@@ -195,7 +195,7 @@ class TakesPackageService():
                     try:
                         ref = next(ref for ref in refs if ref.get(SEQUENCE) == sequence)
                         updates = {ITEM_STATE: CONTENT_STATE.SPIKED}
-                        spike_service.patch(ref[ITEM_REF], updates)
+                        spike_service.patch(ref[RESIDREF], updates)
                     except InvalidStateTransitionError:
                         # for published items it will InvalidStateTransitionError
                         break
@@ -217,9 +217,9 @@ class TakesPackageService():
             refs = self._get_package_refs(package)
             if refs:
                 ref = next((ref for ref in refs if ref.get(SEQUENCE) == 1
-                            and ref.get(ITEM_REF, '') != item.get(config.ID_FIELD, '')), None)
+                            and ref.get(RESIDREF, '') != item.get(config.ID_FIELD, '')), None)
                 if ref:
-                    return ref.get(ITEM_REF, None)
+                    return ref.get(RESIDREF, None)
 
         return None
 
@@ -246,7 +246,7 @@ class TakesPackageService():
         """
         refs = self._get_package_refs(package)
         if refs:
-            takes = [ref.get(ITEM_REF) for ref in refs if ref.get(SEQUENCE) < sequence]
+            takes = [ref.get(RESIDREF) for ref in refs if ref.get(SEQUENCE) < sequence]
             # elastic filter for the archive resource filters out the published items
             archive_service = get_resource_service(ARCHIVE)
             query = {'query': {'filtered': {'filter': {'terms': {'_id': takes}}}}}
@@ -267,7 +267,7 @@ class TakesPackageService():
         if not refs:
             return []
 
-        takes = [ref.get(ITEM_REF) for ref in refs]
+        takes = [ref.get(RESIDREF) for ref in refs]
 
         query = {'$and':
                  [

--- a/server/apps/publish/archive_publish_tests.py
+++ b/server/apps/publish/archive_publish_tests.py
@@ -22,7 +22,7 @@ from apps.packages.takes_package_service import TakesPackageService
 from apps.publish.archive_publish import ArchivePublishService, DIGITAL, WIRE
 from apps.publish.subscribers import SUBSCRIBER_TYPES
 from apps.validators import ValidatorsPopulateCommand
-from superdesk.metadata.packages import ITEM_REF
+from superdesk.metadata.packages import RESIDREF
 from test_factory import SuperdeskTestCase
 from apps.publish import init_app, publish_queue, RemoveExpiredPublishContent
 from apps.legal_archive import LEGAL_ARCHIVE_NAME, LEGAL_ARCHIVE_VERSIONS_NAME, LEGAL_PUBLISH_QUEUE_NAME
@@ -198,13 +198,13 @@ class ArchivePublishTestCase(SuperdeskTestCase):
                                                  'location': ARCHIVE,
                                                  'guid': '5',
                                                  ITEM_TYPE: CONTENT_TYPE.TEXT,
-                                                 ITEM_REF: '5'
+                                                 RESIDREF: '5'
                                              },
                                              {
                                                  'location': ARCHIVE,
                                                  'guid': '4',
                                                  ITEM_TYPE: CONTENT_TYPE.TEXT,
-                                                 ITEM_REF: '4'
+                                                 RESIDREF: '4'
                                              }
                                          ],
                                          'role': 'grpRole:main'}],
@@ -289,7 +289,7 @@ class ArchivePublishTestCase(SuperdeskTestCase):
                           ITEM_TYPE: CONTENT_TYPE.COMPOSITE,
                           'groups': [{'id': 'root', 'refs': [{'idRef': 'main'}], 'role': 'grpRole:NEP'},
                                      {'id': 'main',
-                                      'refs': [{'location': ARCHIVE, ITEM_TYPE: CONTENT_TYPE.COMPOSITE, ITEM_REF: '6'}],
+                                      'refs': [{'location': ARCHIVE, ITEM_TYPE: CONTENT_TYPE.COMPOSITE, RESIDREF: '6'}],
                                       'role': 'grpRole:main'}],
                           'firstcreated': utcnow(),
                           'expiry': utcnow() + timedelta(minutes=20),

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -5,4 +5,4 @@ behave==1.2.5
 wooper==0.4.2
 
 git+git://github.com/superdesk/eve@75aa97d#egg=Eve==0.6.0-dev
--e git+git://github.com/superdesk/superdesk-core@a39803c#egg=Superdesk-Core==0.0.1-dev
+-e git+git://github.com/superdesk/superdesk-core@7676f6a#egg=Superdesk-Core==0.0.1-dev


### PR DESCRIPTION
This wouldn't happen normally, there are few examples of packages coming from Reuters having Empty ResidRef fields in the groups in ingest collection. Handles this problem gracefully. 