### PR TITLE
fix(desk dropdown): Added Untitled for workspace where name is not specified

### DIFF
--- a/client/app/scripts/superdesk-workspace/views/workspace-dropdown.html
+++ b/client/app/scripts/superdesk-workspace/views/workspace-dropdown.html
@@ -2,6 +2,7 @@
     <button id="selected-desk" data-toggle="dropdown" class="dropdown-toggle {{workspaceType}} pull-left">
         <span class="name" ng-if="selected.name">{{ selected.name | uppercase }}</span>
         <span class="name" ng-if="!selected" translate>Select Workspace</span>
+        <span class="name" ng-if="!selected.name && workspaceType">{{ :: 'Untitled' | translate }}</span>
         <span class="caret"></span>
     </button>
 
@@ -19,6 +20,7 @@
             <button ng-click="selectWorkspace(workspace)"
                     ng-disabled="workspace._id === selected._id">
                 {{ :: workspace.name }}
+                <span ng-if="!workspace.name">{{ :: 'Untitled' | translate }}</span>
             </button>
         </li>
         <li>


### PR DESCRIPTION
There was some cases when workspace name is empty. This is a fix for it.

![desk drodpown](https://cloud.githubusercontent.com/assets/6507688/10013679/cd67bf82-6113-11e5-9532-b45d1837d2e6.jpg)
