### PR TITLE
Fix (multiedit disabled for spiked items)

### DIFF
--- a/client/app/scripts/superdesk-desks/aggregate.js
+++ b/client/app/scripts/superdesk-desks/aggregate.js
@@ -11,8 +11,8 @@
  (function() {
     'use strict';
 
-    AggregateCtrl.$inject = ['$scope', 'api', 'desks', 'workspaces', 'preferencesService', 'storage', 'gettext'];
-    function AggregateCtrl($scope, api, desks, workspaces, preferencesService, storage, gettext) {
+    AggregateCtrl.$inject = ['$scope', 'api', 'desks', 'workspaces', 'preferencesService', 'storage', 'gettext', 'multi'];
+    function AggregateCtrl($scope, api, desks, workspaces, preferencesService, storage, gettext, multi) {
         var PREFERENCES_KEY = 'agg:view';
         var defaultMaxItems = 10;
         var self = this;
@@ -235,6 +235,7 @@
          * param {string} fileType
          */
         this.setFileType = function(fileType) {
+            multi.reset();
             if (fileType === 'all') {
                 this.selectedFileType = [];
             } else {

--- a/client/app/scripts/superdesk-monitoring/styles/monitoring.less
+++ b/client/app/scripts/superdesk-monitoring/styles/monitoring.less
@@ -11,6 +11,9 @@
 
     .subnav {
         top: 0;
+        .sortbar {
+            padding: 3px 10px;
+        }
     }
 
     .monitoring-preview-layout{

--- a/client/app/scripts/superdesk-monitoring/views/monitoring-view.html
+++ b/client/app/scripts/superdesk-monitoring/views/monitoring-view.html
@@ -27,17 +27,15 @@
 
         <div class="button-stack right-stack">
             <div class="pull-left-10x" ng-if="type === 'highlights'" sd-create-highlights-button data-highlight="monitoring.queryParam.highlight"></div>
-            <div class="dropdown navbtn strict" dropdown>
+            <div class="dropdown navbtn strict" ng-if="type === 'monitoring'" dropdown>
                 <button class="dropdown-toggle" dropdown-toggle><i class="icon-dots-vertical"></i></button>
-                <div class="dropdown-menu pull-right">
-                    <ul>
-                        <li ng-if="type === 'monitoring'">
-                            <button ng-click="aggregate.edit()">
-                                <i class="icon-settings"></i> {{ :: 'Settings' | translate }}
-                            </button>
-                        </li>
-                    </ul>
-                </div>
+                <ul class="dropdown-menu pull-right">
+                    <li>
+                        <button ng-click="aggregate.edit()">
+                            <i class="icon-settings"></i> {{ :: 'Settings' | translate }}
+                        </button>
+                    </li>
+                </ul>
             </div>
 
             <div class="dropdown navbtn strict" ng-if="!state.opened" title="{{ :: 'Create' | translate }}" dropdown>

--- a/client/app/scripts/superdesk-search/views/multi-action-bar.html
+++ b/client/app/scripts/superdesk-search/views/multi-action-bar.html
@@ -5,7 +5,7 @@
 		translate-n="multi.count"
 		translate-plural="{{ multi.count }} Items selected">{{ multi.count }} Item selected</span>
 
-    <div class="pull-right" ng-if="type === 'archive'">
+    <div class="pull-right" ng-if="type === 'archive' && state !== 'spiked'">
         <button class="navbtn strict" ng-click="action.createPackage()" title="{{ :: 'Create Package' | translate }}">
             <i class="big-icon-package-create"></i>
         </button>
@@ -14,7 +14,7 @@
         </button>
     </div>
     
-    <div class="dropdown strict highlights-dropdown pull-right" ng-if="type === 'archive'" title="{{ :: 'Mark item' | translate }}" dropdown>
+    <div class="dropdown strict highlights-dropdown pull-right" ng-if="type === 'archive' && state !== 'spiked'" title="{{ :: 'Mark item' | translate }}" dropdown>
          <button class="dropdown-toggle navbtn" dropdown-toggle>
             <i class="big-icon-marked-star"></i>
          </button>
@@ -22,7 +22,7 @@
     </div>
 
 	<div class="pull-right" ng-if="type === 'archive'">
-		<button class="navbtn strict" ng-click="action.multiedit()" title="{{ :: 'Multiedit' | translate }}">
+		<button class="navbtn strict" ng-click="action.multiedit()" ng-if="state !== 'spiked'" title="{{ :: 'Multiedit' | translate }}">
     		<i class="big-icon-multiedit"></i>
         </button>
         <button class="navbtn strict" ng-click="action.spikeItems()" title="{{ :: 'Spike' | translate }}"

--- a/client/app/styles/less/layouts.less
+++ b/client/app/styles/less/layouts.less
@@ -269,6 +269,9 @@ a:hover {
 				right: 0 !important;
 			}
 		}
+		.preview-pane {
+			right: -@sidepreview-width;
+		}
 	}
 
     .content-item-preview {

--- a/client/app/styles/less/sf-additional.less
+++ b/client/app/styles/less/sf-additional.less
@@ -185,9 +185,8 @@
 	float: left;
 	&.monitoring-flat-searchbar{
 		margin-top: -9px;
-		margin-left: -20px;
 		.search-handler{
-			padding-left:15px;
+			padding-left:5px;
 		}
 	}
 	.search-handler {


### PR DESCRIPTION
SD-2094

And couple of small fixes that I saw and there is no issue for that:
- On monitoring sorting with searching looks is fixed
- User management looks fixed
- Settings dropdown shown only on monitoring, on other pages not visible (3 dots)
- On monitoring on filtering by filetype checked items are unchecked