### PR TITLE
Fix: unable to deselect a macro in routing scheme rule w/o reloading th page

### DIFF
--- a/client/.eslintrc
+++ b/client/.eslintrc
@@ -7,6 +7,7 @@
     },
     "globals": {
         "$": false,
+        "$$": false,
         "_": false,
         "angular": false,
         "browser": false,

--- a/client/.jshintrc
+++ b/client/.jshintrc
@@ -18,6 +18,7 @@
   "trailing": true,
   "globals": {
     "$": false,
+    "$$": false,
     "_": false,
     "angular": false,
     "define": false,

--- a/client/app/scripts/superdesk-desks/views/actionpicker.html
+++ b/client/app/scripts/superdesk-desks/views/actionpicker.html
@@ -1,20 +1,33 @@
 <div class="multiple">
-	<div class="field">
-		<label for="desk">Desk</label>
-		<select id="desk" ng-model="desk" name="desk">
-		    <option ng-repeat="d in desks" value="{{d._id}}" ng-selected="d._id === desk">{{d.name}}</option>
-		</select>
-	</div>
-	<div class="field">
-		<label for="stage">Stage</label>
-		<select id="stage" ng-model="stage" name="stage">
-		    <option ng-repeat="s in deskStages[desk]" value="{{s._id}}" ng-selected="s._id === stage">{{s.name}}</option>
-		</select>
-	</div>
-	<div class="field">
-		<label for="macro">Macro</label>
-		<select id="macro" ng-model="macro" name="macro">
-		    <option ng-repeat="m in deskMacros" value="{{m.name}}" ng-selected="m.name === macro">{{m.label}}</option>
-		</select>
-	</div>
+
+    <div class="field">
+        <label for="desk" translate>Desk</label>
+        <select
+            id="desk" name="desk"
+            ng-options="d._id as d.name for d in desks"
+            ng-model="desk">
+            <option value=""></option>
+        </select>
+    </div>
+
+    <div class="field">
+        <label for="stage" translate>Stage</label>
+        <select
+            id="stage" name="stage"
+            ng-options="s._id as s.name for s in deskStages[desk]"
+            ng-model="stage">
+            <option value=""></option>
+        </select>
+    </div>
+
+    <div class="field">
+        <label for="macro" translate>Macro</label>
+        <select
+            id="macro" name="macro"
+            ng-options="m.name as m.label for m in deskMacros"
+            ng-model="macro">
+            <option value=""></option>
+        </select>
+    </div>
+
 </div>

--- a/client/spec/helpers/pages.js
+++ b/client/spec/helpers/pages.js
@@ -6,6 +6,7 @@ exports.content = require('./content');
 exports.authoring = require('./authoring');
 exports.ingestProvider = new IngestProvider();
 exports.ingestDashboard = new IngestDashboard();
+exports.ingestSettings = new IngestSettings();
 
 require('./waitReady');
 
@@ -81,5 +82,41 @@ function IngestDashboard() {
 
     this.getDashboardIngestCount = function(dashboard) {
         return dashboard.element(by.css('.ingested-count'));
+    };
+}
+
+/**
+ * Constructor for the "class" representing the ingest settings page.
+ *
+ * Contains pre-defined ElementLocator objects, representing the varios UI
+ * elements on the page used in tests.
+ *
+ */
+function IngestSettings() {
+    // the main navigation tabs on the ingest settings page
+    this.tabs = {
+        routingTab: element(by.buttonText('Routing'))
+    };
+
+    this.newSchemeBtn = element(by.partialButtonText('New Routing Scheme'));
+
+    this.newRoutingRuleBtn = element(by.partialButtonText('New Rule'));
+
+    // the settings pane for routing rule (in a modal)
+    this.routingRuleSettings = {
+        tabAction: element(by.buttonText('Action')),
+
+        // NOTE: several elements appear twice - under the FETCH settings
+        // and under the PUBLISH settings, hence the need to locate them all
+        // and select them by index, e.g. .get(0)
+        showFetchBtn: $$('.icon-plus-small').get(0),
+        fetchDeskList: element.all(by.name('desk')).get(0),
+        fetchStageList: element.all(by.name('stage')).get(0),
+        fetchMacroList: element.all(by.name('macro')).get(0),
+
+        showPublishBtn: $$('.icon-plus-small').get(1),
+        publishDeskList: element.all(by.name('desk')).get(1),
+        publishStageList: element.all(by.name('stage')).get(1),
+        publishMacroList: element.all(by.name('macro')).get(1)
     };
 }

--- a/client/spec/helpers/utils.js
+++ b/client/spec/helpers/utils.js
@@ -7,6 +7,7 @@ module.exports.changeUrl = changeUrl;
 module.exports.printLogs = printLogs;
 module.exports.waitForSuperdesk = waitForSuperdesk;
 module.exports.nav = nav;
+module.exports.getListOption = getListOption;
 
 // construct url from uri and base url
 exports.constructUrl = function(base, uri) {
@@ -151,4 +152,18 @@ function route(location) {
     return function() {
         nav(location);
     };
+}
+
+/**
+ * Finds and returns the n-th <option> element of the given dropdown list
+ *
+ * @param {ElementFinder} dropdown - the <select> element to pick the option from
+ * @param {number} n - the option's position in the dropdown's list of options,
+ *   must be an integer (NOTE: list positions start with 1!)
+ *
+ * @return {ElementFinder} the option element itself (NOTE: might not exist)
+ */
+function getListOption(dropdown, n) {
+    var cssSelector = 'option:nth-child(' + n + ')';
+    return dropdown.$(cssSelector);
 }

--- a/client/spec/ingest_settings_spec.js
+++ b/client/spec/ingest_settings_spec.js
@@ -1,0 +1,71 @@
+'use strict';
+var openUrl = require('./helpers/utils').open,
+    ingestSettings = require('./helpers/pages').ingestSettings,
+    utils = require('./helpers/utils');
+
+describe('Ingest Settings: routing scheme', function() {
+
+    beforeEach(function(done) {
+        openUrl('/#/settings/ingest').then(done);
+    });
+
+    it('unselecting options in dropdown lists on the Actions pane', function () {
+        var deskList,   // dropdown list for choosing a desk
+            macroList,  // dropdown list for choosing a macro
+            stageList,  // dropdown list for choosing a desk stage
+            ruleSettings;
+
+        // open the routing scheme edit modal under the  Routing tab, add a new
+        // routing rule and open its Action settings pane
+        ingestSettings.tabs.routingTab.click();
+        ingestSettings.newSchemeBtn.click();
+        ingestSettings.newRoutingRuleBtn.click();
+        ruleSettings = ingestSettings.routingRuleSettings;
+        ruleSettings.tabAction.click();
+
+        // Select values in the three dropdown lists under the FETCH section,
+        // then try to deselect them, i.e. select an empty option. If the
+        // latter exists, the value of the selected options in all lists should
+        // be empty.
+        ruleSettings.showFetchBtn.click();
+
+        deskList = ruleSettings.fetchDeskList;
+        utils.getListOption(deskList, 2).click();
+
+        stageList = ruleSettings.fetchStageList;
+        utils.getListOption(stageList, 2).click();
+
+        macroList = ruleSettings.fetchMacroList;
+        utils.getListOption(macroList, 2).click();
+
+        // now select first options and then check that they are all blank
+        utils.getListOption(deskList, 1).click();
+        utils.getListOption(stageList, 1).click();
+        utils.getListOption(macroList, 1).click();
+
+        expect(deskList.$('option:checked').getAttribute('value')).toEqual('');
+        expect(stageList.$('option:checked').getAttribute('value')).toEqual('');
+        expect(macroList.$('option:checked').getAttribute('value')).toEqual('');
+
+        // We now perform the same check for the dropdown menus under the
+        // PUBLISH section
+        ruleSettings.showPublishBtn.click();
+
+        deskList = ruleSettings.publishDeskList;
+        utils.getListOption(deskList, 2).click();
+
+        stageList = ruleSettings.publishStageList;
+        utils.getListOption(stageList, 2).click();
+
+        macroList = ruleSettings.publishMacroList;
+        utils.getListOption(macroList, 2).click();
+
+        utils.getListOption(deskList, 1).click();
+        utils.getListOption(stageList, 1).click();
+        utils.getListOption(macroList, 1).click();
+
+        expect(deskList.$('option:checked').getAttribute('value')).toEqual('');
+        expect(stageList.$('option:checked').getAttribute('value')).toEqual('');
+        expect(macroList.$('option:checked').getAttribute('value')).toEqual('');
+    });
+});


### PR DESCRIPTION
Resolves [SD-2348](https://dev.sourcefabric.org/browse/SD-2348).

This fix simply adds a blank option to all relevant dropdown lists. On top of that, it uses `ng-options` instead of `ng-repeat` to create their options, improving the speed and reducing the memory usage (because `ng-repeat` creates a new scope for every element in the collection, but `ng-options` does not).