### PR TITLE
(fix) Dateline

### DIFF
--- a/client/app/scripts/superdesk-authoring/metadata/metadata.js
+++ b/client/app/scripts/superdesk-authoring/metadata/metadata.js
@@ -431,8 +431,15 @@ function MetadataLocatorsDirective($timeout) {
                 var updates = {};
 
                 if (!locator && scope.selectedTerm) {
-                    locator = {'city': scope.selectedTerm, 'city_code': scope.selectedTerm, 'tz': 'UTC',
-                        'dateline': 'city', 'country': '', 'country_code': '', 'state_code': '', 'state': ''};
+                    var previousLocator = scope.fieldprefix ? scope.item[scope.fieldprefix][scope.field] :
+                                            scope.item[scope.field];
+
+                    if (scope.selectedTerm === previousLocator.city) {
+                        locator = previousLocator;
+                    } else {
+                        locator = {'city': scope.selectedTerm, 'city_code': scope.selectedTerm, 'tz': 'UTC',
+                            'dateline': 'city', 'country': '', 'country_code': '', 'state_code': '', 'state': ''};
+                    }
                 }
 
                 if (locator) {

--- a/client/app/scripts/superdesk-authoring/views/article-edit.html
+++ b/client/app/scripts/superdesk-authoring/views/article-edit.html
@@ -60,7 +60,7 @@
                 <option value=""></option>
             </select>
             <select id="datelineDay"
-                    ng-options="datelineDay as day for day in daysInMonth"
+                    ng-options="day for day in daysInMonth"
                     ng-disabled="!item.dateline.located || !_editable"
                     ng-change="modifyDatelineDate()"
                     ng-model="datelineDay">

--- a/client/app/scripts/superdesk/filters.js
+++ b/client/app/scripts/superdesk/filters.js
@@ -164,7 +164,7 @@ define([
                     momentizedTimestamp = momentizedTimestamp.tz(located.tz);
                 }
 
-                return {'month': momentizedTimestamp.month().toString(), 'day': momentizedTimestamp.date().toString()};
+                return {'month': momentizedTimestamp.month().toString(), 'day': momentizedTimestamp.format('DD')};
             };
         })
         .filter('formatDatelineToLocMMMDDSrc', function() {


### PR DESCRIPTION
1. Values for all the options in Dateline Day are same. Because of this, the selected day is always the last day in the month although the current date is before last day of the month.

2. Timezone of a city selected from locators vocabulary is overwritten by UTC timezone by onblur event of the directive.