### PR TITLE
(feat): Allow users to view content send to another desk.

### DIFF
--- a/client/app/scripts/superdesk-desks/desks.js
+++ b/client/app/scripts/superdesk-desks/desks.js
@@ -370,13 +370,14 @@
         });
     }
 
-    DeskConfigController.$inject = ['$scope', 'gettext', 'notify', 'desks', 'WizardHandler', 'modal'];
-    function DeskConfigController ($scope, gettext, notify, desks, WizardHandler, modal) {
+    DeskConfigController.$inject = ['$scope', 'gettext', 'notify', 'desks', 'WizardHandler', 'modal', 'metadata'];
+    function DeskConfigController ($scope, gettext, notify, desks, WizardHandler, modal, metadata) {
 
         //expecting $scope.desks to be defined
 
         $scope.modalActive = false;
         $scope.numberOfUsers = 3;
+        $scope.deskTypes = [];
         $scope.step = {
             current: null
         };
@@ -423,6 +424,15 @@
         $scope.getDeskUsers = function (desk) {
             return desks.deskMembers[desk._id];
         };
+
+        if (metadata.values.desk_types) {
+            $scope.deskTypes = metadata.values.desk_types;
+        } else {
+             metadata.fetchMetadataValues()
+                 .then(function() {
+                     $scope.deskTypes = metadata.values.desk_types;
+                 })
+        }
     }
 
     var app = angular.module('superdesk.desks', [

--- a/client/app/scripts/superdesk-desks/desks.js
+++ b/client/app/scripts/superdesk-desks/desks.js
@@ -370,14 +370,13 @@
         });
     }
 
-    DeskConfigController.$inject = ['$scope', 'gettext', 'notify', 'desks', 'WizardHandler', 'modal', 'metadata'];
-    function DeskConfigController ($scope, gettext, notify, desks, WizardHandler, modal, metadata) {
+    DeskConfigController.$inject = ['$scope', 'gettext', 'notify', 'desks', 'WizardHandler', 'modal'];
+    function DeskConfigController ($scope, gettext, notify, desks, WizardHandler, modal) {
 
         //expecting $scope.desks to be defined
 
         $scope.modalActive = false;
         $scope.numberOfUsers = 3;
-        $scope.deskTypes = [];
         $scope.step = {
             current: null
         };
@@ -424,15 +423,6 @@
         $scope.getDeskUsers = function (desk) {
             return desks.deskMembers[desk._id];
         };
-
-        if (metadata.values.desk_types) {
-            $scope.deskTypes = metadata.values.desk_types;
-        } else {
-             metadata.fetchMetadataValues()
-                 .then(function() {
-                     $scope.deskTypes = metadata.values.desk_types;
-                 })
-        }
     }
 
     var app = angular.module('superdesk.desks', [
@@ -846,12 +836,14 @@
                 }
             };
         }])
-        .directive('sdDeskeditBasic', ['gettext', 'desks', 'WizardHandler', function(gettext, desks, WizardHandler) {
+        .directive('sdDeskeditBasic', ['gettext', 'desks', 'WizardHandler', 'metadata',
+            function(gettext, desks, WizardHandler, metadata) {
             return {
 
                 link: function(scope, elem, attrs) {
 
                     scope.limits = limits;
+                    scope.deskTypes = [];
 
                     scope.$watch('step.current', function(step) {
                         if (step === 'general') {
@@ -907,6 +899,15 @@
                             scope._errorLimits = scope.desk.edit.name.length > scope.limits.desk ? true : null;
                         }
                     };
+
+                    if (metadata.values.desk_types) {
+                        scope.deskTypes = metadata.values.desk_types;
+                    } else {
+                        metadata.fetchMetadataValues()
+                            .then(function() {
+                                scope.deskTypes = metadata.values.desk_types;
+                            });
+                    }
 
                 }
             };

--- a/client/app/scripts/superdesk-desks/styles/desks.less
+++ b/client/app/scripts/superdesk-desks/styles/desks.less
@@ -354,6 +354,19 @@
                 color: #D33C30;
             }
 		}
+	  	.desk-type {
+		  clear: both;
+		}
+	  	.expiry {
+		  list-style: none;
+		  li {
+			float: left;
+			padding-left: 25px;
+		  }
+		  li:first-child {
+			padding-left: 0px;
+		  }
+		}
 	}
 	.modal-footer {
 		position: absolute;

--- a/client/app/scripts/superdesk-desks/views/desk-config-modal.html
+++ b/client/app/scripts/superdesk-desks/views/desk-config-modal.html
@@ -26,9 +26,23 @@
                                 <label translate>Source for User Created Articles</label>
                                 <input type="text" class="fullwidth-input" ng-model="desk.edit.source" ng-keyup="handleEdit($event);" required>
                             </div>
-                            <div sd-content-expiry data-item="desk.edit" data-preview="false" data-expiryfield="spike_expiry" data-header="Spike Expiry"></div>
-                            <div sd-content-expiry data-item="desk.edit" data-preview="false" data-expiryfield="published_item_expiry" data-header="Published Item Expiry"></div>
-                            <div class="field">
+                            <ul class="expiry">
+                                <li>
+                                    <div sd-content-expiry
+                                         data-item="desk.edit"
+                                         data-preview="false"
+                                         data-expiryfield="spike_expiry"
+                                         data-header="Spike Expiry"></div>
+                                </li>
+                                <li>
+                                    <div sd-content-expiry
+                                         data-item="desk.edit"
+                                         data-preview="false"
+                                         data-expiryfield="published_item_expiry"
+                                         data-header="Published Item Expiry"></div>
+                                </li>
+                            </ul>
+                            <div class="field desk-type">
                                 <label translate>Desk Type</label>
                                 <select id="deskType" ng-model="desk.edit.desk_type"
                                         ng-options="deskType.value as deskType.name for deskType in deskTypes"
@@ -37,13 +51,12 @@
                                 </select>
                             </div>
                         </fieldset>
-                        <p ng-if="message">{{ message }}</p>
                         <span ng-show="_errorUniqueness" translate>Desk with name "{{ desk.edit.name }}" already exists.</span>
                         <p ng-show="_errorLimits" translate>Character limit exceeded, desk can not be created/updated.</p>
                         <span ng-show="_error" translate>There was a problem, desk not created/updated.</span>
                     </div>
                     <div class="modal-footer">
-                        <button class="btn btn-primary" ng-click="save(desk.edit)" ng-disabled="!generalStep.$valid || _errorLimits" translate>Next</button>
+                        <button id="next-general" class="btn btn-primary" ng-click="save(desk.edit)" ng-disabled="!generalStep.$valid || _errorLimits" translate>Next</button>
                     </div>
                 </form>
             </div>
@@ -154,7 +167,7 @@
                 </div>
                 <div class="modal-footer">
                     <button class="btn pull-left" ng-click="previous()" translate>Previous</button>
-                    <button class="btn btn-primary" ng-disabled="message != null" ng-click="next()" translate>Next</button>
+                    <button id="next-stages" class="btn btn-primary" ng-disabled="message != null" ng-click="next()" translate>Next</button>
                 </div>
             </div>
         </div>
@@ -178,7 +191,7 @@
                 </div>
                 <div class="modal-footer">
                     <button class="btn pull-left" ng-click="previous()" translate>Previous</button>
-                    <button class="btn btn-primary" ng-click="save()" ng-disabled="message != null" translate>Next</button>
+                    <button id="next-people" class="btn btn-primary" ng-click="save()" ng-disabled="message != null" translate>Next</button>
                 </div>
             </div>
         </div>

--- a/client/app/scripts/superdesk-desks/views/desk-config-modal.html
+++ b/client/app/scripts/superdesk-desks/views/desk-config-modal.html
@@ -28,6 +28,14 @@
                             </div>
                             <div sd-content-expiry data-item="desk.edit" data-preview="false" data-expiryfield="spike_expiry" data-header="Spike Expiry"></div>
                             <div sd-content-expiry data-item="desk.edit" data-preview="false" data-expiryfield="published_item_expiry" data-header="Published Item Expiry"></div>
+                            <div class="field">
+                                <label translate>Desk Type</label>
+                                <select id="deskType" ng-model="desk.edit.desk_type"
+                                        ng-options="deskType.value as deskType.name for deskType in deskTypes"
+                                        required>
+                                    <option value=""></option>
+                                </select>
+                            </div>
                         </fieldset>
                         <p ng-if="message">{{ message }}</p>
                         <span ng-show="_errorUniqueness" translate>Desk with name "{{ desk.edit.name }}" already exists.</span>

--- a/client/app/scripts/superdesk-desks/views/settings.html
+++ b/client/app/scripts/superdesk-desks/views/settings.html
@@ -3,7 +3,7 @@
 
         <div class="header">
             <h2 translate>Desk management</h2>
-            <button class="btn btn-info pull-right" ng-click="openDesk('general')">
+            <button id="add-new-desk" class="btn btn-info pull-right" ng-click="openDesk('general')">
                 <i class="icon-plus-sign icon-white"></i> {{ :: 'Add New Desk' | translate }}
             </button>
         </div>
@@ -43,6 +43,9 @@
                                             ... {{ :: 'view all' | translate }}
                                         </span>
                                     </span>
+                                </li>
+                                <li>
+                                    <h4>{{ :: 'Desk Type' | translate }}<span class="label">{{ desk.desk_type }}</span></h4>
                                 </li>
                             </ul>							
                         </div>

--- a/client/app/scripts/superdesk-search/search.js
+++ b/client/app/scripts/superdesk-search/search.js
@@ -36,9 +36,9 @@
         /*
          * Sets the from-to desk filters.
          */
-        function setFromToDeskFilters(filters) {
-            var from_desk = $location.search().from_desk,
-                to_desk = $location.search().to_desk,
+        function setFromToDeskFilters(filters, params) {
+            var from_desk = params.from_desk,
+                to_desk = params.to_desk,
                 desk;
 
             if (from_desk) {
@@ -185,7 +185,7 @@
             this.getCriteria = function getCriteria(withSource) {
                 var search = params;
                 var sort = getSort();
-                setFromToDeskFilters(filters);
+                setFromToDeskFilters(filters, params);
                 var criteria = {
                     query: {filtered: {filter: {and: filters}}},
                     sort: [_.zipObject([sort.field], [sort.dir])]

--- a/client/app/scripts/superdesk-search/search.js
+++ b/client/app/scripts/superdesk-search/search.js
@@ -1261,10 +1261,7 @@
                         if (param) {
                             var deskParams = param.split('-');
                             if (deskParams.length === 2) {
-                                var desk = _.find(scope.desks._items, function(item) {
-                                    return item._id === deskParams[0];
-                                });
-                                scope.selectedDesk[field] = desk ? desk : null;
+                                scope.selectedDesk[field] = deskParams[0];
                             }
                         }
                     }
@@ -1393,14 +1390,7 @@
                     function getDeskParam(field) {
                         var deskId = '';
                         if (scope.selectedDesk[field]) {
-                            if (typeof(scope.selectedDesk[field]) === 'string') {
-                                deskId = scope.selectedDesk[field];
-                            } else {
-                                if (_.isObject(scope.selectedDesk[field])) {
-                                    deskId = scope.selectedDesk[field]._id;
-                                }
-                            }
-
+                            deskId = scope.selectedDesk[field];
                             var desk_type = _.result(_.find(scope.desks._items, function (item) {
                                 return item._id === deskId;
                             }), 'desk_type');

--- a/client/app/scripts/superdesk-search/tests/search_spec.js
+++ b/client/app/scripts/superdesk-search/tests/search_spec.js
@@ -21,7 +21,7 @@ describe('search service', function() {
         expect(criteria.query.filtered.query.query_string.query).toBe('test');
     }));
 
-    it('can create query for from_desk and to_desk', inject(function($rootScope, search) {
+    it('can create query for from_desk', inject(function($rootScope, search) {
         // only from desk is specified
         var criteria = search.query({from_desk: 'test-authoring'}).getCriteria();
         var filters = criteria.query.filtered.filter.and;
@@ -29,49 +29,26 @@ describe('search service', function() {
         criteria = search.query({from_desk: 'test-production'}).getCriteria();
         filters = criteria.query.filtered.filter.and;
         expect(filters).toContain({term: {'task.last_production_desk': 'test'}});
+    }));
 
+    it('can create query for to_desk', inject(function($rootScope, search) {
         // only to desk is specified
-        criteria = search.query({to_desk: '456-authoring'}).getCriteria();
-        filters = criteria.query.filtered.filter.and;
+        var criteria = search.query({to_desk: '456-authoring'}).getCriteria();
+        var filters = criteria.query.filtered.filter.and;
         expect(filters).toContain({term: {'task.desk': '456'}});
         expect(filters).toContain({exists: {field: 'task.last_production_desk'}});
         criteria = search.query({to_desk: '456-production'}).getCriteria();
         filters = criteria.query.filtered.filter.and;
         expect(filters).toContain({term: {'task.desk': '456'}});
         expect(filters).toContain({exists: {field: 'task.last_authoring_desk'}});
-
-        // both from desk and to desk are specified
-        criteria = search.query({from_desk: '123-authoring', to_desk: '456-production'}).getCriteria();
-        filters = criteria.query.filtered.filter.and;
-        expect(filters).toContain({term: {'task.last_authoring_desk': '123'}});
-        expect(filters).toContain({term: {'task.desk': '456'}});
     }));
 
-    it('create tags for from desk', inject(function ($location, $rootScope, $q, tags, _desks_) {
-        var desks = _desks_;
-        spyOn(desks, 'initialize').and.returnValue($q.when([]));
-
-        desks.deskLookup = {
-            from: {
-                name: 'National'
-            },
-            to: {
-                name: 'Sport'
-            }
-        };
-
-        $location.search('from_desk', 'from-authoring');
-        $location.search('to_desk', 'to-authoring');
-
-        var tagsList = null;
-        tags.initSelectedFacets().then(function(value) {
-            tagsList = value;
-        });
-
-        $rootScope.$digest();
-        expect(tagsList.selectedParameters.length).toEqual(2);
-        expect(tagsList.selectedParameters[0]).toEqual('From Desk:National');
-        expect(tagsList.selectedParameters[1]).toEqual('To Desk:Sport');
+    it('can create query for from_desk and to_desk', inject(function($rootScope, search) {
+        // both from desk and to desk are specified
+        var criteria = search.query({from_desk: '123-authoring', to_desk: '456-production'}).getCriteria();
+        var filters = criteria.query.filtered.filter.and;
+        expect(filters).toContain({term: {'task.last_authoring_desk': '123'}});
+        expect(filters).toContain({term: {'task.desk': '456'}});
     }));
 
     it('can sort items', inject(function(search, $location, $rootScope) {

--- a/client/app/scripts/superdesk-search/tests/search_spec.js
+++ b/client/app/scripts/superdesk-search/tests/search_spec.js
@@ -21,6 +21,59 @@ describe('search service', function() {
         expect(criteria.query.filtered.query.query_string.query).toBe('test');
     }));
 
+    it('can create query for from_desk and to_desk', inject(function($rootScope, search) {
+        // only from desk is specified
+        var criteria = search.query({from_desk: 'test-authoring'}).getCriteria();
+        var filters = criteria.query.filtered.filter.and;
+        expect(filters).toContain({term: {'task.last_authoring_desk': 'test'}});
+        criteria = search.query({from_desk: 'test-production'}).getCriteria();
+        filters = criteria.query.filtered.filter.and;
+        expect(filters).toContain({term: {'task.last_production_desk': 'test'}});
+
+        // only to desk is specified
+        criteria = search.query({to_desk: '456-authoring'}).getCriteria();
+        filters = criteria.query.filtered.filter.and;
+        expect(filters).toContain({term: {'task.desk': '456'}});
+        expect(filters).toContain({exists: {field: 'task.last_production_desk'}});
+        criteria = search.query({to_desk: '456-production'}).getCriteria();
+        filters = criteria.query.filtered.filter.and;
+        expect(filters).toContain({term: {'task.desk': '456'}});
+        expect(filters).toContain({exists: {field: 'task.last_authoring_desk'}});
+
+        // both from desk and to desk are specified
+        criteria = search.query({from_desk: '123-authoring', to_desk: '456-production'}).getCriteria();
+        filters = criteria.query.filtered.filter.and;
+        expect(filters).toContain({term: {'task.last_authoring_desk': '123'}});
+        expect(filters).toContain({term: {'task.desk': '456'}});
+    }));
+
+    it('create tags for from desk', inject(function ($location, $rootScope, $q, tags, _desks_) {
+        var desks = _desks_;
+        spyOn(desks, 'initialize').and.returnValue($q.when([]));
+
+        desks.deskLookup = {
+            from: {
+                name: 'National'
+            },
+            to: {
+                name: 'Sport'
+            }
+        };
+
+        $location.search('from_desk', 'from-authoring');
+        $location.search('to_desk', 'to-authoring');
+
+        var tagsList = null;
+        tags.initSelectedFacets().then(function(value) {
+            tagsList = value;
+        });
+
+        $rootScope.$digest();
+        expect(tagsList.selectedParameters.length).toEqual(2);
+        expect(tagsList.selectedParameters[0]).toEqual('From Desk:National');
+        expect(tagsList.selectedParameters[1]).toEqual('To Desk:Sport');
+    }));
+
     it('can sort items', inject(function(search, $location, $rootScope) {
         search.setSort('urgency');
         $rootScope.$digest();

--- a/client/app/scripts/superdesk-search/tests/search_spec.js
+++ b/client/app/scripts/superdesk-search/tests/search_spec.js
@@ -123,7 +123,7 @@ describe('sdSearchFacets directive', function () {
         spyOn(search, 'getSubjectCodes').and.returnValue([]);
 
         desks = _desks_;
-        spyOn(desks, 'initialize');
+        spyOn(desks, 'initialize').and.returnValue($q.when([]));
 
         facetsInit = $q.defer();
         spyOn(tags, 'initSelectedFacets').and.returnValue(facetsInit.promise);

--- a/client/app/scripts/superdesk-search/tests/tags_spec.js
+++ b/client/app/scripts/superdesk-search/tests/tags_spec.js
@@ -97,4 +97,32 @@ describe('Tag Service', function() {
         expect(members.selectedParameters.length).toBe(1);
 
     }));
+
+    it('create tags for from desk and to desk', inject(function ($location, $rootScope, $q, tags, _desks_) {
+        var desks = _desks_;
+        desks.deskLookup = {
+            from: {
+                name: 'National'
+            },
+            to: {
+                name: 'Sport'
+            }
+        };
+
+        $location.search('from_desk', 'from-authoring');
+        $location.search('to_desk', 'to-authoring');
+
+        spyOn(desks, 'initialize').and.returnValue($q.when([]));
+
+        var tagsList = null;
+        tags.initSelectedFacets()
+            .then(function(value) {
+                tagsList = value;
+            });
+
+        $rootScope.$digest();
+        expect(tagsList.selectedParameters.length).toEqual(2);
+        expect(tagsList.selectedParameters[0]).toEqual('From Desk:National');
+        expect(tagsList.selectedParameters[1]).toEqual('To Desk:Sport');
+    }));
 });

--- a/client/app/scripts/superdesk-search/views/item-search.html
+++ b/client/app/scripts/superdesk-search/views/item-search.html
@@ -94,7 +94,7 @@
             </label>
             <select
                 id="last-from-desk" name="last-from-desk"
-                ng-options="d._id + '-' + d.desk_type as d.name for d in desks._items track by d._id"
+                ng-options="d._id as d.name for d in desks._items track by d._id"
                 ng-model="selectedDesk.from" ng-change="deskSearch()">
                 <option value=""></option>
             </select>
@@ -106,7 +106,7 @@
             </label>
             <select
                 id="last-to-desk" name="last-to-desk"
-                ng-options="d._id + '-' + d.desk_type as d.name for d in desks._items track by d._id"
+                ng-options="d._id as d.name for d in desks._items track by d._id"
                 ng-model="selectedDesk.to" ng-change="deskSearch()">
                 <option value=""></option>
             </select>

--- a/client/app/scripts/superdesk-search/views/item-search.html
+++ b/client/app/scripts/superdesk-search/views/item-search.html
@@ -94,7 +94,7 @@
             </label>
             <select
                 id="from-desk" name="from-desk"
-                ng-options="d._id as d.name for d in desks._items track by d._id"
+                ng-options="d._id as d.name for d in desks._items"
                 ng-model="selectedDesk.from" ng-change="deskSearch()">
                 <option value="" label=""></option>
             </select>
@@ -106,7 +106,7 @@
             </label>
             <select
                 id="to-desk" name="to-desk"
-                ng-options="d._id as d.name for d in desks._items track by d._id"
+                ng-options="d._id as d.name for d in desks._items"
                 ng-model="selectedDesk.to" ng-change="deskSearch()">
                 <option value="" label=""></option>
             </select>

--- a/client/app/scripts/superdesk-search/views/item-search.html
+++ b/client/app/scripts/superdesk-search/views/item-search.html
@@ -89,26 +89,26 @@
             </div>
         </div>
         <div class="field">
-            <label for="last-from-desk">
+            <label for="from-desk">
                 {{:: 'From Desk' | translate}}
             </label>
             <select
-                id="last-from-desk" name="last-from-desk"
+                id="from-desk" name="from-desk"
                 ng-options="d._id as d.name for d in desks._items track by d._id"
                 ng-model="selectedDesk.from" ng-change="deskSearch()">
-                <option value=""></option>
+                <option value="" label=""></option>
             </select>
         </div>
 
         <div class="field">
-            <label for="last-to-desk">
+            <label for="to-desk">
                 {{:: 'To Desk' | translate}}
             </label>
             <select
-                id="last-to-desk" name="last-to-desk"
+                id="to-desk" name="to-desk"
                 ng-options="d._id as d.name for d in desks._items track by d._id"
                 ng-model="selectedDesk.to" ng-change="deskSearch()">
-                <option value=""></option>
+                <option value="" label=""></option>
             </select>
         </div>
 

--- a/client/app/scripts/superdesk-search/views/item-search.html
+++ b/client/app/scripts/superdesk-search/views/item-search.html
@@ -88,6 +88,30 @@
                 <div sd-meta-terms data-item="subjectitems" data-field="subject" data-unique="qcode" data-list="subjectcodes" data-change="subjectSearch(subjectitems)"></div>
             </div>
         </div>
+        <div class="field">
+            <label for="last-from-desk">
+                {{:: 'From Desk' | translate}}
+            </label>
+            <select
+                id="last-from-desk" name="last-from-desk"
+                ng-options="d._id + '-' + d.desk_type as d.name for d in desks._items track by d._id"
+                ng-model="selectedDesk.from" ng-change="deskSearch()">
+                <option value=""></option>
+            </select>
+        </div>
+
+        <div class="field">
+            <label for="last-to-desk">
+                {{:: 'To Desk' | translate}}
+            </label>
+            <select
+                id="last-to-desk" name="last-to-desk"
+                ng-options="d._id + '-' + d.desk_type as d.name for d in desks._items track by d._id"
+                ng-model="selectedDesk.to" ng-change="deskSearch()">
+                <option value=""></option>
+            </select>
+        </div>
+
     </fieldset>
     <fieldset ng-show="repo.search === 'aapmm'">      
         <div class="field">

--- a/client/app/scripts/superdesk-search/views/search-facets.html
+++ b/client/app/scripts/superdesk-search/views/search-facets.html
@@ -13,7 +13,7 @@
 
         <div sd-search-within></div>
 
-        <div sd-toggle-box data-title="{{ 'Parameters' | translate }}" data-open="false">
+        <div id="search-parameters" sd-toggle-box data-title="{{ 'Parameters' | translate }}" data-open="false">
             <div sd-item-search data-repo="repo" data-context="context"></div>
         </div>
 

--- a/client/app/scripts/superdesk-search/views/search-facets.html
+++ b/client/app/scripts/superdesk-search/views/search-facets.html
@@ -13,7 +13,7 @@
 
         <div sd-search-within></div>
 
-        <div id="search-parameters" sd-toggle-box data-title="{{ 'Parameters' | translate }}" data-open="false">
+        <div id="search-parameters" sd-toggle-box data-title="{{:: 'Parameters' | translate }}" data-open="false">
             <div sd-item-search data-repo="repo" data-context="context"></div>
         </div>
 
@@ -60,7 +60,7 @@
             <ul class="filter-box">
                 <li ng-repeat="(key,value) in aggregations.credit" ng-click="toggleFilter('credit', key)">
                     <span class="sd-checkbox" ng-checked="hasFilter('credit',key)"></span>
-                    <span>{{key | translate}} <i>{{ value.count }}</i></span>
+                    <span>{{:: key | translate}} <i>{{:: value.count }}</i></span>
                 </li>
             </ul>
         </div>

--- a/client/spec/desks_spec.js
+++ b/client/spec/desks_spec.js
@@ -1,0 +1,48 @@
+/**
+ * This file is part of Superdesk.
+ *
+ * Copyright 2013, 2014 Sourcefabric z.u. and contributors.
+ *
+ * For the full copyright and license information, please see the
+ * AUTHORS and LICENSE files distributed with this source code, or
+ * at https://www.sourcefabric.org/superdesk/license
+ */
+'use strict';
+var desks = require('./helpers/desks');
+
+describe('desk maintenance', function() {
+
+    beforeEach(function() {
+        desks.openDesksSettings();
+    });
+
+    it('edit desk', function() {
+        desks.edit('Politic Desk');
+        desks.deskDescriptionElement().sendKeys('New Description');
+        desks.deskSourceElement().sendKeys('Test');
+        desks.setDeskType('production');
+        desks.getNextButtonOnGeneralTab().click();
+        desks.showTab('macros');
+        desks.save();
+        desks.edit('Politic Desk');
+        expect(desks.deskDescriptionElement().getAttribute('value')).toEqual('New Description');
+        expect(desks.deskSourceElement().getAttribute('value')).toEqual('Test');
+        expect(desks.getDeskType().getAttribute('value')).toEqual('string:production');
+    });
+
+    it('add desk', function() {
+        desks.getNewDeskButton().click();
+        desks.deskNameElement().sendKeys('Test Desk');
+        desks.deskDescriptionElement().sendKeys('Test Description');
+        desks.deskSourceElement().sendKeys('Test Source');
+        desks.setDeskType('authoring');
+        desks.getNextButtonOnGeneralTab().click();
+        desks.showTab('macros');
+        desks.save();
+        desks.edit('Test Desk');
+        expect(desks.deskNameElement().getAttribute('value')).toEqual('Test Desk');
+        expect(desks.deskDescriptionElement().getAttribute('value')).toEqual('Test Description');
+        expect(desks.deskSourceElement().getAttribute('value')).toEqual('Test Source');
+        expect(desks.getDeskType().getAttribute('value')).toEqual('string:authoring');
+    });
+});

--- a/client/spec/helpers/desks.js
+++ b/client/spec/helpers/desks.js
@@ -143,4 +143,76 @@ function Desks() {
     this.save = function() {
         element(by.id('save')).click();
     };
+
+    /**
+     * Get the desk name element
+     * @returns {ElementFinder} desk name element
+     **/
+    this.deskNameElement = function() {
+        return element(by.model('desk.edit.name'));
+    };
+
+    /**
+     * Get the desk description element
+     * @returns {ElementFinder} desk description element
+     **/
+    this.deskDescriptionElement = function() {
+        return element(by.model('desk.edit.description'));
+    };
+
+    /**
+     * Get the desk source element
+     * @returns {ElementFinder} desk source element
+     **/
+    this.deskSourceElement = function() {
+        return element(by.model('desk.edit.source'));
+    };
+
+    /**
+     * Get the desk type element
+     * @returns {ElementFinder} desk type element
+     **/
+    this.getDeskType = function() {
+        return element(by.model('desk.edit.desk_type'));
+    };
+
+    /**
+     * Set desk type
+     * @param {string} deskType name
+     **/
+    this.setDeskType = function(deskType) {
+        element(by.model('desk.edit.desk_type')).$('[value="string:' + deskType + '"]').click();
+    };
+
+    /**
+     * next button on general tab
+     * @returns {ElementFinder} next button
+     **/
+    this.getNextButtonOnGeneralTab = function() {
+        return element(by.id('next-general'));
+    };
+
+    /**
+     * next button on stages tab
+     * @returns {ElementFinder} next button
+     **/
+    this.getNextButtonOnStagesTab = function() {
+        return element(by.id('next-stages'));
+    };
+
+    /**
+     * next button on people tab
+     * @returns {ElementFinder} next button
+     **/
+    this.getNextButtonOnPeopleTab = function() {
+        return element(by.id('next-people'));
+    };
+
+    /**
+     * new desk button
+     * @returns {ElementFinder} button
+     **/
+    this.getNewDeskButton = function() {
+        return element(by.id('add-new-desk'));
+    };
 }

--- a/client/spec/helpers/monitoring.js
+++ b/client/spec/helpers/monitoring.js
@@ -413,4 +413,65 @@ function Monitoring() {
             expect(items[1].getText()).toContain(highlight);
         });
     };
+
+    /**
+     * Open a workspace of given name, can be both desk or custom
+     *
+     * @param {string} desk Desk or workspace name.
+     */
+    this.selectDesk = function(desk) {
+        var dropdownBtn = element(by.id('selected-desk')),
+        dropdownMenu = element(by.id('select-desk-menu'));
+
+        // open dropdown
+        dropdownBtn.click();
+
+        function textFilter(elem) {
+            return elem.element(by.tagName('button')).getText()
+            .then(function(text) {
+                return text.toUpperCase().indexOf(desk.toUpperCase()) >= 0;
+            });
+        }
+
+        function clickFiltered(filtered) {
+            if (filtered.length) {
+                return filtered[0].click();
+            }
+        }
+
+        // try to open desk
+        dropdownMenu.all(by.repeater('desk in desks'))
+            .filter(textFilter)
+            .then(clickFiltered);
+
+        // then try to open custom workspace
+        dropdownMenu.all(by.repeater('workspace in wsList'))
+            .filter(textFilter)
+            .then(clickFiltered);
+
+        // close dropdown if opened
+        dropdownMenu.isDisplayed().then(function(shouldClose) {
+            if (shouldClose) {
+                dropdownBtn.click();
+            }
+        });
+    };
+
+    /**
+     * Open a workspace of given name, can be both desk or custom and then navigate
+     * to content view
+     *
+     * @param {string} desk Desk or workspace name.
+     * @return {Promise}
+     */
+    this.switchToDesk = function(desk) {
+        this.selectDesk(desk);
+
+        this.openMonitoring();
+
+        return browser.wait(function() {
+            return element(by.className('list-view')).isPresent();
+        }, 300);
+    };
+
 }

--- a/client/spec/helpers/search.js
+++ b/client/spec/helpers/search.js
@@ -132,7 +132,40 @@ function GlobalSearch() {
      * @param {string} type
      */
     this.toggleByType = function(type) {
-        browser.actions().mouseMove(element(by.className('filetype-icon-' + type))).perform();
-        element(by.id('filetype-icon-' + type)).click();
+            browser.actions().mouseMove(element(by.className('filetype-icon-' + type))).perform();
+            element(by.id('filetype-icon-' + type)).click();
+    };
+
+    /**
+     * Open the filter panel
+     */
+    this.openFilterPanel = function() {
+        element(by.css('.filter-trigger')).click();
+    };
+
+    /**
+     * Open the search Parameters from
+     */
+    this.openParameters = function() {
+        element(by.id('search-parameters')).click();
+    };
+
+    /**
+     * Open the search Parameters from
+     * @param {string} selectId - Id of the <select> element
+     * @param {string} deskName - Name of the desk.
+     */
+    this.selectDesk = function(selectId, deskName) {
+        element(by.id(selectId)).element(by.css('option[label="' + deskName + '"]')).click();
+    };
+
+    /**
+     * Get the Element Heading by index
+     * @param {number} index
+     * @return {promise} headline element
+     */
+    this.getHeadlineElement = function(index) {
+        element(by.id('search-parameters')).click();
+        return this.getItem(index).element(by.className('item-heading'));
     };
 }

--- a/client/spec/helpers/search.js
+++ b/client/spec/helpers/search.js
@@ -132,8 +132,8 @@ function GlobalSearch() {
      * @param {string} type
      */
     this.toggleByType = function(type) {
-            browser.actions().mouseMove(element(by.className('filetype-icon-' + type))).perform();
-            element(by.id('filetype-icon-' + type)).click();
+        browser.actions().mouseMove(element(by.className('filetype-icon-' + type))).perform();
+        element(by.id('filetype-icon-' + type)).click();
     };
 
     /**

--- a/client/spec/search_spec.js
+++ b/client/spec/search_spec.js
@@ -3,7 +3,9 @@
 
 var openUrl = require('./helpers/utils').open,
     workspace = require('./helpers/pages').workspace,
-    content = require('./helpers/pages').content;
+    content = require('./helpers/pages').content,
+    globalSearch = require('./helpers/search'),
+    authoring = require('./helpers/authoring');
 
 describe('Search', function() {
 
@@ -70,5 +72,41 @@ describe('Search', function() {
         var priority3 = element.all(by.repeater('(key,value) in aggregations.priority')).first();
         priority3.click();
         expect(element.all(by.repeater('items._items')).count()).toBe(1);
+    });
+
+    it('can search by from desk field', function() {
+        workspace.switchToDesk('SPORTS DESK').then(content.setListView);
+        expect(element.all(by.repeater('items._items')).count()).toBe(2);
+        authoring.createTextItem();
+        authoring.writeTextToHeadline('From-Sports-To-Politics');
+        authoring.writeText('This is Body');
+        authoring.writeTextToAbstract('This is Abstract');
+        authoring.save();
+        expect(element.all(by.repeater('items._items')).count()).toBe(3);
+        authoring.sendTo('Politic Desk');
+        authoring.confirmSendTo();
+        workspace.switchToDesk('POLITIC DESK').then(content.setListView);
+        expect(element.all(by.repeater('items._items')).count()).toBe(8);
+        globalSearch.openGlobalSearch();
+        globalSearch.setListView();
+        expect(element.all(by.repeater('items._items')).count()).toBe(11);
+        globalSearch.openFilterPanel();
+        globalSearch.openParameters();
+
+        globalSearch.selectDesk('from-desk', 'Sports Desk');
+        expect(element.all(by.repeater('items._items')).count()).toBe(1);
+        expect(globalSearch.getHeadlineElement(0).getText()).toBe('From-Sports-To-Politics');
+
+        globalSearch.selectDesk('to-desk', 'Politic Desk');
+        expect(element.all(by.repeater('items._items')).count()).toBe(1);
+        expect(globalSearch.getHeadlineElement(0).getText()).toBe('From-Sports-To-Politics');
+
+        globalSearch.selectDesk('from-desk', '');
+        expect(element.all(by.repeater('items._items')).count()).toBe(1);
+        expect(globalSearch.getHeadlineElement(0).getText()).toBe('From-Sports-To-Politics');
+
+        globalSearch.selectDesk('to-desk', '');
+        expect(element.all(by.repeater('items._items')).count()).toBe(11);
+
     });
 });

--- a/client/spec/search_spec.js
+++ b/client/spec/search_spec.js
@@ -5,7 +5,8 @@ var openUrl = require('./helpers/utils').open,
     workspace = require('./helpers/pages').workspace,
     content = require('./helpers/pages').content,
     globalSearch = require('./helpers/search'),
-    authoring = require('./helpers/authoring');
+    authoring = require('./helpers/authoring'),
+    monitoring = require('./helpers/monitoring');
 
 describe('Search', function() {
 
@@ -75,38 +76,35 @@ describe('Search', function() {
     });
 
     it('can search by from desk field', function() {
-        workspace.switchToDesk('SPORTS DESK').then(content.setListView);
-        expect(element.all(by.repeater('items._items')).count()).toBe(2);
-        authoring.createTextItem();
+        monitoring.switchToDesk('SPORTS DESK').then(authoring.createTextItem());
         authoring.writeTextToHeadline('From-Sports-To-Politics');
         authoring.writeText('This is Body');
         authoring.writeTextToAbstract('This is Abstract');
         authoring.save();
-        expect(element.all(by.repeater('items._items')).count()).toBe(3);
         authoring.sendTo('Politic Desk');
         authoring.confirmSendTo();
-        workspace.switchToDesk('POLITIC DESK').then(content.setListView);
-        expect(element.all(by.repeater('items._items')).count()).toBe(8);
+        monitoring.switchToDesk('POLITIC DESK');
+        expect(monitoring.getTextItem(0, 0)).toBe('From-Sports-To-Politics');
+
         globalSearch.openGlobalSearch();
         globalSearch.setListView();
-        expect(element.all(by.repeater('items._items')).count()).toBe(11);
+        expect(globalSearch.getItems().count()).toBe(11);
         globalSearch.openFilterPanel();
         globalSearch.openParameters();
 
         globalSearch.selectDesk('from-desk', 'Sports Desk');
-        expect(element.all(by.repeater('items._items')).count()).toBe(1);
+        expect(globalSearch.getItems().count()).toBe(1);
         expect(globalSearch.getHeadlineElement(0).getText()).toBe('From-Sports-To-Politics');
 
         globalSearch.selectDesk('to-desk', 'Politic Desk');
-        expect(element.all(by.repeater('items._items')).count()).toBe(1);
+        expect(globalSearch.getItems().count()).toBe(1);
         expect(globalSearch.getHeadlineElement(0).getText()).toBe('From-Sports-To-Politics');
 
         globalSearch.selectDesk('from-desk', '');
-        expect(element.all(by.repeater('items._items')).count()).toBe(1);
+        expect(globalSearch.getItems().count()).toBe(1);
         expect(globalSearch.getHeadlineElement(0).getText()).toBe('From-Sports-To-Politics');
 
         globalSearch.selectDesk('to-desk', '');
-        expect(element.all(by.repeater('items._items')).count()).toBe(11);
-
+        expect(globalSearch.getItems().count()).toBe(11);
     });
 });

--- a/server/apps/archive/archive_test.py
+++ b/server/apps/archive/archive_test.py
@@ -9,6 +9,7 @@
 # at https://www.sourcefabric.org/superdesk/license
 
 
+from bson import ObjectId
 from test_factory import SuperdeskTestCase
 from eve.utils import date_to_str
 from superdesk.utc import get_expiry_date, utcnow
@@ -17,7 +18,8 @@ from apps.archive.archive import SOURCE as ARCHIVE
 from superdesk.errors import SuperdeskApiError
 from datetime import timedelta, datetime
 from pytz import timezone
-from apps.archive.common import validate_schedule, remove_media_files, format_dateline_to_locmmmddsrc
+from apps.archive.common import validate_schedule, remove_media_files, \
+    format_dateline_to_locmmmddsrc, convert_task_attributes_to_objectId
 from settings import ORGANIZATION_NAME_ABBREVIATION
 
 
@@ -266,3 +268,21 @@ class ArchiveTestCase(SuperdeskTestCase):
         formatted_dateline = format_dateline_to_locmmmddsrc(located, current_ts)
         self.assertEqual(formatted_dateline, 'SYDNEY, NSW, AU %s %s -' % (formatted_date,
                                                                           ORGANIZATION_NAME_ABBREVIATION))
+
+    def test_if_task_attributes_converted_to_objectid(self):
+        doc = {
+            'task': {
+                'user': '562435231d41c835d7b5fb55',
+                'desk': ObjectId("562435241d41c835d7b5fb5d"),
+                'stage': 'test',
+                'last_authoring_desk': 3245,
+                'last_production_desk': None
+            }
+        }
+
+        convert_task_attributes_to_objectId(doc)
+        self.assertIsInstance(doc['task']['user'], ObjectId)
+        self.assertEqual(doc['task']['desk'], ObjectId("562435241d41c835d7b5fb5d"))
+        self.assertEqual(doc['task']['stage'], 'test')
+        self.assertEqual(doc['task']['last_authoring_desk'], 3245)
+        self.assertIsNone(doc['task']['last_production_desk'])

--- a/server/apps/archive/common.py
+++ b/server/apps/archive/common.py
@@ -7,7 +7,7 @@
 # For the full copyright and license information, please see the
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
-
+from bson import ObjectId
 
 import flask
 from eve.utils import config
@@ -41,6 +41,9 @@ ITEM_RESTORE = 'restore'
 ITEM_DUPLICATE = 'duplicate'
 ITEM_DESCHEDULE = 'deschedule'
 item_operations = [ITEM_CREATE, ITEM_UPDATE, ITEM_RESTORE, ITEM_DUPLICATE, ITEM_DESCHEDULE]
+# part the task dict
+LAST_AUTHORING_DESK = 'last_authoring_desk'
+LAST_PRODUCTION_DESK = 'last_production_desk'
 
 
 def update_version(updates, original):
@@ -511,3 +514,24 @@ def is_takes_package(doc):
     """
 
     return doc[ITEM_TYPE] == CONTENT_TYPE.COMPOSITE and doc.get(PACKAGE_TYPE, '') == TAKES_PACKAGE
+
+
+def convert_task_attributes_to_objectId(doc):
+    """
+    set the task attributes desk, stage, user as object id
+    :param doc:
+
+    """
+    task = doc.get('task', {})
+    if ObjectId.is_valid(task.get('desk')) and not isinstance(task.get('desk'), ObjectId):
+        task['desk'] = ObjectId(task.get('desk'))
+    if ObjectId.is_valid(task.get('stage')) and not isinstance(task.get('stage'), ObjectId):
+        task['stage'] = ObjectId(task.get('stage'))
+    if ObjectId.is_valid(task.get('user')) and not isinstance(task.get('user'), ObjectId):
+        task['user'] = ObjectId(task.get('user'))
+    if ObjectId.is_valid(task.get('last_production_desk')) and \
+            not isinstance(task.get('last_production_desk'), ObjectId):
+        task['last_production_desk'] = ObjectId(task.get('last_production_desk'))
+    if ObjectId.is_valid(task.get('last_authoring_desk', None)) and \
+            not isinstance(task.get('last_authoring_desk'), ObjectId):
+        task['last_authoring_desk'] = ObjectId(task.get('last_authoring_desk'))

--- a/server/apps/archive/common.py
+++ b/server/apps/archive/common.py
@@ -529,9 +529,9 @@ def convert_task_attributes_to_objectId(doc):
         task['stage'] = ObjectId(task.get('stage'))
     if ObjectId.is_valid(task.get('user')) and not isinstance(task.get('user'), ObjectId):
         task['user'] = ObjectId(task.get('user'))
-    if ObjectId.is_valid(task.get('last_production_desk')) and \
-            not isinstance(task.get('last_production_desk'), ObjectId):
-        task['last_production_desk'] = ObjectId(task.get('last_production_desk'))
-    if ObjectId.is_valid(task.get('last_authoring_desk', None)) and \
-            not isinstance(task.get('last_authoring_desk'), ObjectId):
-        task['last_authoring_desk'] = ObjectId(task.get('last_authoring_desk'))
+    if ObjectId.is_valid(task.get(LAST_PRODUCTION_DESK)) and \
+            not isinstance(task.get(LAST_PRODUCTION_DESK), ObjectId):
+        task[LAST_PRODUCTION_DESK] = ObjectId(task.get(LAST_PRODUCTION_DESK))
+    if ObjectId.is_valid(task.get(LAST_AUTHORING_DESK, None)) and \
+            not isinstance(task.get(LAST_AUTHORING_DESK), ObjectId):
+        task[LAST_AUTHORING_DESK] = ObjectId(task.get(LAST_AUTHORING_DESK))

--- a/server/apps/archive/common.py
+++ b/server/apps/archive/common.py
@@ -523,6 +523,10 @@ def convert_task_attributes_to_objectId(doc):
 
     """
     task = doc.get('task', {})
+
+    if not task:
+        return
+
     if ObjectId.is_valid(task.get('desk')) and not isinstance(task.get('desk'), ObjectId):
         task['desk'] = ObjectId(task.get('desk'))
     if ObjectId.is_valid(task.get('stage')) and not isinstance(task.get('stage'), ObjectId):

--- a/server/apps/desks.py
+++ b/server/apps/desks.py
@@ -158,6 +158,19 @@ class DesksService(BaseService):
             raise SuperdeskApiError.preconditionFailedError(
                 message='Cannot delete desk as it has article(s) or referenced by versions of the article(s).')
 
+    def on_fetched(self, doc):
+        self._enhance_item(doc[config.ITEMS])
+
+    def on_fetched_item(self, doc):
+        self._enhance_item([doc])
+
+    def _enhance_item(self, docs):
+        """
+        enhance the desk with default desk type as authoring.
+        """
+        for doc in docs:
+            doc.setdefault('desk_type', DeskTypes.authoring.value)
+
     def delete(self, lookup):
         """
         Overriding to delete stages before deleting a desk

--- a/server/apps/desks.py
+++ b/server/apps/desks.py
@@ -156,19 +156,6 @@ class DesksService(BaseService):
             raise SuperdeskApiError.preconditionFailedError(
                 message='Cannot delete desk as it has article(s) or referenced by versions of the article(s).')
 
-    def on_fetched(self, doc):
-        self._enhance_item(doc[config.ITEMS])
-
-    def on_fetched_item(self, doc):
-        self._enhance_item([doc])
-
-    def _enhance_item(self, docs):
-        """
-        enhance the desk with default desk type as authoring.
-        """
-        for doc in docs:
-            doc.setdefault('desk_type', DeskTypes.authoring.value)
-
     def delete(self, lookup):
         """
         Overriding to delete stages before deleting a desk

--- a/server/apps/desks.py
+++ b/server/apps/desks.py
@@ -10,7 +10,8 @@
 from superdesk.errors import SuperdeskApiError
 from collections import namedtuple
 from superdesk.resource import Resource
-from eve.utils import config
+from superdesk import config
+from superdesk.utils import SuperdeskBaseEnum
 from bson.objectid import ObjectId
 from superdesk.services import BaseService
 import superdesk
@@ -18,8 +19,11 @@ from apps.tasks import default_status
 from superdesk.notification import push_notification
 from superdesk.activity import add_activity, ACTIVITY_UPDATE
 
-desk_types = ['authoring', 'production']
-DESK_TYPES = namedtuple('DESK_TYPES', ['AUTHORING', 'PRODUCTION'])(*desk_types)
+
+class DeskTypes(SuperdeskBaseEnum):
+    authoring = 'authoring'
+    production = 'production'
+
 
 desks_schema = {
     'name': {
@@ -72,8 +76,8 @@ desks_schema = {
     },
     'desk_type': {
         'type': 'string',
-        'default': DESK_TYPES.AUTHORING,
-        'allowed': desk_types
+        'default': DeskTypes.authoring.value,
+        'allowed': DeskTypes.values()
     }
 }
 

--- a/server/apps/desks.py
+++ b/server/apps/desks.py
@@ -7,8 +7,6 @@
 # For the full copyright and license information, please see the
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
-import json
-from eve.utils import ParsedRequest
 from superdesk.errors import SuperdeskApiError
 from superdesk.resource import Resource
 from superdesk import config

--- a/server/apps/desks.py
+++ b/server/apps/desks.py
@@ -8,7 +8,6 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 from superdesk.errors import SuperdeskApiError
-from collections import namedtuple
 from superdesk.resource import Resource
 from superdesk import config
 from superdesk.utils import SuperdeskBaseEnum

--- a/server/apps/desks.py
+++ b/server/apps/desks.py
@@ -145,26 +145,6 @@ class DesksService(BaseService):
             raise SuperdeskApiError.preconditionFailedError(
                 message='Cannot delete desk as routing scheme(s) are associated with the desk')
 
-        archive_query = {
-            'query': {
-                'filtered': {
-                    'filter': {
-                        'or': [
-                            {'term': {'task.desk': str(desk[config.ID_FIELD])}},
-                            {'term': {'task.last_authoring_desk': str(desk[config.ID_FIELD])}},
-                            {'term': {'task.last_production_desk': str(desk[config.ID_FIELD])}}
-                        ]
-                    }
-                }
-            }
-        }
-
-        request = ParsedRequest()
-        request.args = {'source': json.dumps(archive_query)}
-        items = superdesk.get_resource_service('archive').get(req=request, lookup=None)
-        if items and items.count():
-            raise SuperdeskApiError.preconditionFailedError(message='Cannot delete desk as it has article(s).')
-
         archive_versions_query = {
             '$or': [
                 {'task.desk': str(desk[config.ID_FIELD])},
@@ -176,7 +156,7 @@ class DesksService(BaseService):
         items = superdesk.get_resource_service('archive_versions').get(req=None, lookup=archive_versions_query)
         if items and items.count():
             raise SuperdeskApiError.preconditionFailedError(
-                message='Cannot delete desk as it referenced by article(s) versions.')
+                message='Cannot delete desk as it has article(s) or referenced by versions of the article(s).')
 
     def delete(self, lookup):
         """

--- a/server/apps/duplication/archive_move.py
+++ b/server/apps/duplication/archive_move.py
@@ -117,7 +117,6 @@ class MoveService(BaseService):
         if old_desk_id and old_desk_id != new_desk_id:
             old_desk = get_resource_service('desks').find_one(req=None, _id=old_desk_id)
             new_desk = get_resource_service('desks').find_one(req=None, _id=new_desk_id)
-            print(old_desk, new_desk, old_desk_id, new_desk_id)
             if old_desk.get('desk_type', '') != new_desk.get('desk_type', ''):
                 if new_desk.get('desk_type') == DeskTypes.authoring.value:
                     updated['task'][LAST_AUTHORING_DESK] = new_desk_id

--- a/server/apps/duplication/archive_move.py
+++ b/server/apps/duplication/archive_move.py
@@ -15,6 +15,7 @@ from copy import deepcopy
 
 import superdesk
 from apps.tasks import send_to
+from apps.desks import DeskTypes
 from superdesk import get_resource_service
 from superdesk.errors import SuperdeskApiError, InvalidStateTransitionError
 from superdesk.metadata.item import ITEM_STATE, CONTENT_STATE
@@ -22,7 +23,8 @@ from superdesk.resource import Resource
 from superdesk.services import BaseService
 from superdesk.metadata.utils import item_url
 from apps.archive.common import insert_into_versions, item_operations,\
-    ITEM_OPERATION, set_sign_off, get_user
+    ITEM_OPERATION, set_sign_off, get_user, LAST_AUTHORING_DESK, LAST_PRODUCTION_DESK,\
+    convert_task_attributes_to_objectId
 from apps.archive.archive import SOURCE as ARCHIVE
 from superdesk.workflow import is_workflow_state_transition_valid
 from apps.content import push_content_notification
@@ -88,7 +90,10 @@ class MoveService(BaseService):
             archived_doc[ITEM_STATE] = CONTENT_STATE.SUBMITTED
         archived_doc[ITEM_OPERATION] = ITEM_MOVE
 
+        # set the change in desk type when content is moved.
+        self.set_change_in_desk_type(archived_doc, original)
         set_sign_off(archived_doc, original=original)
+        convert_task_attributes_to_objectId(archived_doc)
         resolve_document_version(archived_doc, ARCHIVE, 'PATCH', original)
 
         del archived_doc[config.ID_FIELD]
@@ -99,6 +104,27 @@ class MoveService(BaseService):
         push_content_notification([archived_doc, original])
 
         return archived_doc
+
+    def set_change_in_desk_type(self, updated, original):
+        """
+        Detects if the change in the desk is between authoring to production (and vice versa).
+        And sets the field 'last_production_desk' and 'last_authoring_desk'.
+        :param dict updated: document to be saved
+        :param dict original: original document
+        """
+        old_desk_id = str(original.get('task', {}).get('desk', ''))
+        new_desk_id = str(updated.get('task', {}).get('desk', ''))
+        if old_desk_id and old_desk_id != new_desk_id:
+            old_desk = get_resource_service('desks').find_one(req=None, _id=old_desk_id)
+            new_desk = get_resource_service('desks').find_one(req=None, _id=new_desk_id)
+            print(old_desk, new_desk, old_desk_id, new_desk_id)
+            if old_desk.get('desk_type', '') != new_desk.get('desk_type', ''):
+                if new_desk.get('desk_type') == DeskTypes.authoring.value:
+                    updated['task'][LAST_AUTHORING_DESK] = new_desk_id
+                    updated['task'][LAST_PRODUCTION_DESK] = old_desk_id
+                else:
+                    updated['task'][LAST_AUTHORING_DESK] = old_desk_id
+                    updated['task'][LAST_PRODUCTION_DESK] = new_desk_id
 
 
 superdesk.workflow_action(

--- a/server/apps/duplication/archive_move.py
+++ b/server/apps/duplication/archive_move.py
@@ -118,12 +118,10 @@ class MoveService(BaseService):
             old_desk = get_resource_service('desks').find_one(req=None, _id=old_desk_id)
             new_desk = get_resource_service('desks').find_one(req=None, _id=new_desk_id)
             if old_desk.get('desk_type', '') != new_desk.get('desk_type', ''):
-                if new_desk.get('desk_type') == DeskTypes.authoring.value:
-                    updated['task'][LAST_AUTHORING_DESK] = new_desk_id
-                    updated['task'][LAST_PRODUCTION_DESK] = old_desk_id
-                else:
+                if new_desk.get('desk_type') == DeskTypes.production.value:
                     updated['task'][LAST_AUTHORING_DESK] = old_desk_id
-                    updated['task'][LAST_PRODUCTION_DESK] = new_desk_id
+                else:
+                    updated['task'][LAST_PRODUCTION_DESK] = old_desk_id
 
 
 superdesk.workflow_action(

--- a/server/apps/prepopulate/app_prepopulate_data.json
+++ b/server/apps/prepopulate/app_prepopulate_data.json
@@ -115,7 +115,7 @@
     },
 
     {
-        "data": {"members": [{"user": "-id user admin-"}, {"user": "-id user admin4-"}, {"user": "-id user admin1-"}], "name": "Politic Desk", "desk_type": "authoring"},
+        "data": {"members": [{"user": "-id user admin-"}, {"user": "-id user admin4-"}, {"user": "-id user admin1-"}], "name": "Politic Desk", "desk_type": "production"},
         "resource": "desks",
         "username": "admin",
         "id_name": "-id desk Politic Desks-"

--- a/server/apps/prepopulate/app_prepopulate_data.json
+++ b/server/apps/prepopulate/app_prepopulate_data.json
@@ -108,14 +108,14 @@
     },
 
     {
-        "data": {"members": [{"user": "-id user admin-"}, {"user": "-id user admin1-"}, {"user": "-id user admin2-"}, {"user": "-id user admin3-"}], "name": "Sports Desk"},
+        "data": {"members": [{"user": "-id user admin-"}, {"user": "-id user admin1-"}, {"user": "-id user admin2-"}, {"user": "-id user admin3-"}], "name": "Sports Desk", "desk_type": "authoring"},
         "resource": "desks",
         "username": "admin",
         "id_name": "-id desk Sports Desks-"
     },
 
     {
-        "data": {"members": [{"user": "-id user admin-"}, {"user": "-id user admin4-"}, {"user": "-id user admin1-"}], "name": "Politic Desk"},
+        "data": {"members": [{"user": "-id user admin-"}, {"user": "-id user admin4-"}, {"user": "-id user admin1-"}], "name": "Politic Desk", "desk_type": "authoring"},
         "resource": "desks",
         "username": "admin",
         "id_name": "-id desk Politic Desks-"
@@ -310,6 +310,18 @@
         },
 		"resource": "vocabularies",
 		"id_name": "-id vocabularies subscriber_types-"
+    },
+
+    {
+        "data": {
+            "_id": "desk_types",
+            "items": [
+                {"is_active": true, "name": "authoring", "value": "authoring"},
+                {"is_active": true, "name": "production", "value": "production"}
+            ]
+        },
+		"resource": "vocabularies",
+		"id_name": "-id vocabularies desk_types-"
     },
 
     {

--- a/server/apps/prepopulate/data_initialization/desks.json
+++ b/server/apps/prepopulate/data_initialization/desks.json
@@ -63,7 +63,8 @@
             {"user": "54ed94da10245479ccc38410"}
         ],
         "name": "National",
-        "spike_expiry": 1440
+        "spike_expiry": 1440,
+        "desk_type": "production"
     },
     {
         "_id": "54e68fcd1024542de76d6643",
@@ -123,7 +124,8 @@
             {"user": "54ed955910245479d505d296"}
         ],
         "name": "World news",
-        "spike_expiry": 1440
+        "spike_expiry": 1440,
+        "desk_type": "production"
     },
     {
         "_id": "54e691ca1024542de640fef1",
@@ -183,7 +185,8 @@
             {"user": "54ed955910245479d505d2a3"}
         ],
         "name": "Finance",
-        "spike_expiry": 1440
+        "spike_expiry": 1440,
+        "desk_type": "production"
     },
     {
         "_id": "54e692311024542ddeb76af8",
@@ -214,7 +217,8 @@
             {"user": "54ed952410245479ccc38447"}
         ],
         "name": "New Zealand",
-        "spike_expiry": 1440
+        "spike_expiry": 1440,
+        "desk_type": "production"
     },
     {
         "_id": "54e6928d1024542de640fef5",
@@ -291,7 +295,8 @@
             {"user": "54ed952410245479ccc3846c"}
         ],
         "name": "Sport",
-        "spike_expiry": 1440
+        "spike_expiry": 1440,
+        "desk_type": "production"
     },
     {
         "_id": "54e6930f1024542ddeb76afb",
@@ -316,7 +321,8 @@
             {"user": "54ed955910245479d505d295"}
         ],
         "name": "Features",
-        "spike_expiry": 1440
+        "spike_expiry": 1440,
+        "desk_type": "production"
     },
     {
         "_id": "54e698a31024542de76d664a",
@@ -335,7 +341,8 @@
             {"user": "54ed952410245479ccc38477"}
         ],
         "name": "Special",
-        "spike_expiry": 1440
+        "spike_expiry": 1440,
+        "desk_type": "production"
     },
     {
         "_id": "54fe3aee10245412eac572ba",
@@ -351,7 +358,8 @@
             {"user": "54ed955910245479d505d2a2"}
         ],
         "name": "Perth",
-        "spike_expiry": 4320
+        "spike_expiry": 4320,
+        "desk_type": "authoring"
     },
     {
         "_id": "54fe430410245412e8b8f523",
@@ -367,7 +375,8 @@
             {"user": "54ed955910245479d505d2a1"}
         ],
         "name": "Melbourne",
-        "spike_expiry": 4320
+        "spike_expiry": 4320,
+        "desk_type": "authoring"
     },
     {
         "_id": "54fe438b10245412e5608d41",
@@ -383,7 +392,8 @@
             {"user": "54ed955910245479d505d292"}
         ],
         "name": "Darwin",
-        "spike_expiry": 43200
+        "spike_expiry": 43200,
+        "desk_type": "authoring"
     },
     {
         "_id": "54fe43c210245412e8b8f526",
@@ -398,7 +408,8 @@
             {"user": "54ed955910245479d505d299"}
         ],
         "name": "Adelaide",
-        "spike_expiry": 4320
+        "spike_expiry": 4320,
+        "desk_type": "authoring"
     },
     {
         "_id": "54fe44ac10245489df75a266",
@@ -414,7 +425,8 @@
             {"user": "54ed955910245479d505d29f"}
         ],
         "name": "Canberra",
-        "spike_expiry": 4320
+        "spike_expiry": 4320,
+        "desk_type": "authoring"
     },
     {
         "_id": "54fe44df10245489ed5c3a8f",
@@ -430,7 +442,8 @@
             {"user": "54ed955910245479d505d29e"}
         ],
         "name": "Hobart",
-        "spike_expiry": 4320
+        "spike_expiry": 4320,
+        "desk_type": "authoring"
     },
     {
         "_id": "54fe451210245489e2d3b561",
@@ -445,7 +458,8 @@
             {"user": "54ed955910245479d505d29c"}
         ],
         "name": "Brisbane",
-        "spike_expiry": 4320
+        "spike_expiry": 4320,
+        "desk_type": "authoring"
     },
     {
         "_id": "54fe457210245489e2d3b564",
@@ -459,7 +473,8 @@
             {"user": "54ed946e10245479ccc38398"}
         ],
         "name": "Sydney",
-        "spike_expiry": 4320
+        "spike_expiry": 4320,
+        "desk_type": "authoring"
     },
     {
         "_id": "54fe45a910245489df75a26e",
@@ -475,7 +490,8 @@
             {"user": "54ed955910245479d505d28e"}
         ],
         "name": "Jakarta",
-        "spike_expiry": 4320
+        "spike_expiry": 4320,
+        "desk_type": "authoring"
     },
     {
         "_id": "54fe45f210245489ed5c3a95",
@@ -491,7 +507,8 @@
             {"user": "54ed955910245479d505d296"}
         ],
         "name": "London",
-        "spike_expiry": 4320
+        "spike_expiry": 4320,
+        "desk_type": "authoring"
     },
     {
         "_id": "54fe70e310245489e9c69bb5",
@@ -505,6 +522,7 @@
             {"user": "54ed94da10245479ccc383e2"}
         ],
         "name": "Broadcast",
-        "spike_expiry": 1440
+        "spike_expiry": 1440,
+        "desk_type": "production"
     }
 ]

--- a/server/apps/prepopulate/data_initialization/vocabularies.json
+++ b/server/apps/prepopulate/data_initialization/vocabularies.json
@@ -229,12 +229,45 @@
         "display_name": "Keywords for Articles",
         "type": "manageable",
         "items": [
-            {"is_active": true, "name": "Science and Technology",       "value": "SciTech"},
-            {"is_active": true, "name": "International Health Stories", "value": "Medicine"},
-            {"is_active": true, "name": "Health",                       "value": "Health"},
-            {"is_active": true, "name": "Motoring",                     "value": "Motoring"},
-            {"is_active": true, "name": "Soccer",                       "value": "Soccer"},
-            {"is_active": true, "name": "Property",                     "value": "Property"}
+            {
+                "is_active": true,
+                "name": "Science and Technology",
+                "value": "SciTech"
+            },
+            {
+                "is_active": true,
+                "name": "International Health Stories",
+                "value": "Medicine"
+            },
+            {
+                "is_active": true,
+                "name": "Health",
+                "value": "Health"
+            },
+            {
+                "is_active": true,
+                "name": "Motoring",
+                "value": "Motoring"
+            },
+            {
+                "is_active": true,
+                "name": "Soccer",
+                "value": "Soccer"
+            },
+            {
+                "is_active": true,
+                "name": "Property",
+                "value": "Property"
+            }
+        ]
+    },
+    {
+        "_id": "desk_types",
+        "display_name": "Desk Types",
+        "type": "unmanageable",
+        "items": [
+            {"is_active": true, "name": "authoring", "value": "authoring"},
+            {"is_active": true, "name": "production", "value": "production"}
         ]
     }
 ]

--- a/server/apps/publish/content/common.py
+++ b/server/apps/publish/content/common.py
@@ -28,7 +28,7 @@ from superdesk.notification import push_notification
 from superdesk.services import BaseService
 from superdesk import get_resource_service
 from apps.archive.archive import ArchiveResource, SOURCE as ARCHIVE
-from apps.archive.common import validate_schedule, ITEM_OPERATION
+from apps.archive.common import validate_schedule, ITEM_OPERATION, convert_task_attributes_to_objectId
 from superdesk.utc import utcnow
 from superdesk.workflow import is_workflow_state_transition_valid
 from superdesk.publish.formatters import get_formatter
@@ -135,6 +135,7 @@ class BasePublishService(BaseService):
 
         self._set_updates(original, updates, updates.get(config.LAST_UPDATED, utcnow()))
         updates[ITEM_OPERATION] = ITEM_PUBLISH
+        convert_task_attributes_to_objectId(updates)
 
     def on_updated(self, updates, original):
         self.update_published_collection(published_item_id=original[config.ID_FIELD])

--- a/server/apps/stages.py
+++ b/server/apps/stages.py
@@ -10,6 +10,7 @@
 
 import logging
 import superdesk
+from superdesk import config
 from flask import current_app as app
 from superdesk.notification import push_notification
 from superdesk.resource import Resource
@@ -101,7 +102,7 @@ class StagesService(BaseService):
             if 'desk' in doc:
                 push_notification(self.notification_key,
                                   created=1,
-                                  stage_id=str(doc.get('_id')),
+                                  stage_id=str(doc.get(config.ID_FIELD)),
                                   desk_id=str(doc.get('desk')),
                                   is_visible=doc.get('is_visible', True))
             if doc.get('default_incoming', False):
@@ -111,9 +112,9 @@ class StagesService(BaseService):
         """
         Checks if deleting the stage would not violate data integrity, raises an exception if it does.
 
-            1/ Can't delete the default incomming stage
-            2/ The stage must have no unspiked documents
-            3/ The stage can not be refered to by a ingest routing rule
+            1/ Can't delete the default incoming stage
+            2/ The stage must have no documents (spiked or unspiked)
+            3/ The stage can not be referred to by a ingest routing rule
 
         :param doc:
         :return:
@@ -121,24 +122,25 @@ class StagesService(BaseService):
         if doc['default_incoming'] is True:
             desk_id = doc.get('desk', None)
             if desk_id and superdesk.get_resource_service('desks').find_one(req=None, _id=desk_id):
-                raise SuperdeskApiError.forbiddenError(message='Cannot delete a default stage.')
+                raise SuperdeskApiError.preconditionFailedError(message='Cannot delete a default stage.')
 
-        # check if the stage has any documents in it
-        items = self._get_unspiked_stage_documents(str(doc['_id']))
-        if items.count() > 0:  # cannot delete
-            raise SuperdeskApiError.forbiddenError(message='Only empty stages can be deleted.')
+        archive_versions_query = {'task.stage': str(doc[config.ID_FIELD])}
+        items = superdesk.get_resource_service('archive_versions').get(req=None, lookup=archive_versions_query)
+        if items and items.count():
+            raise SuperdeskApiError.preconditionFailedError(
+                message='Cannot delete stage as it has article(s) or referenced by versions of the article(s).')
 
-        # check if the stage is refered to in a ingest routing rule
-        rules = self._stage_in_rule(doc['_id'])
+        # check if the stage is referred to in a ingest routing rule
+        rules = self._stage_in_rule(doc[config.ID_FIELD])
         if rules.count() > 0:
             rule_names = ', '.join(rule.get('name') for rule in rules)
-            raise SuperdeskApiError.forbiddenError(
-                message='Stage is refered to by Ingest Routing Schemes : {}'.format(rule_names))
+            raise SuperdeskApiError.preconditionFailedError(
+                message='Stage is referred by Ingest Routing Schemes : {}'.format(rule_names))
 
     def on_deleted(self, doc):
         push_notification(self.notification_key,
                           deleted=1,
-                          stage_id=str(doc.get('_id')),
+                          stage_id=str(doc.get(config.ID_FIELD)),
                           desk_id=str(doc.get('desk')))
 
     def on_update(self, updates, original):
@@ -146,11 +148,11 @@ class StagesService(BaseService):
             updates['content_expiry'] = app.settings['CONTENT_EXPIRY_MINUTES']
         super().on_update(updates, original)
         if updates.get('content_expiry', None):
-            docs = self.get_stage_documents(str(original['_id']))
+            docs = self.get_stage_documents(str(original[config.ID_FIELD]))
             for doc in docs:
                 expiry = get_expiry_date(updates['content_expiry'], doc['versioncreated'])
                 item_model = get_model(ItemModel)
-                item_model.update({'_id': doc['_id']}, {'expiry': expiry})
+                item_model.update({'_id': doc[config.ID_FIELD]}, {'expiry': expiry})
 
         if updates.get('default_incoming', False):
             if not original.get('default_incoming'):
@@ -164,13 +166,13 @@ class StagesService(BaseService):
         if 'is_visible' in updates and updates['is_visible'] != original.get('is_visible', True):
             push_notification('stage_visibility_updated',
                               updated=1,
-                              stage_id=str(original['_id']),
+                              stage_id=str(original[config.ID_FIELD]),
                               desk_id=str(original['desk']),
                               is_visible=updates.get('is_visible', original.get('is_visible', True)))
         else:
             push_notification(self.notification_key,
                               updated=1,
-                              stage_id=str(original.get('_id')),
+                              stage_id=str(original.get(config.ID_FIELD)),
                               desk_id=str(original.get('desk')))
 
     def _get_unspiked_stage_documents(self, stage_id):

--- a/server/apps/tasks.py
+++ b/server/apps/tasks.py
@@ -15,7 +15,7 @@ from eve.utils import ParsedRequest
 from eve.versioning import resolve_document_version
 
 from apps.archive.common import get_expiry, item_operations, ITEM_OPERATION, update_version
-from apps.archive.common import insert_into_versions, is_assigned_to_a_desk
+from apps.archive.common import insert_into_versions, is_assigned_to_a_desk, convert_task_attributes_to_objectId
 
 from superdesk.resource import Resource
 from superdesk.errors import SuperdeskApiError, InvalidStateTransitionError
@@ -218,6 +218,7 @@ class TasksService(BaseService):
             resolve_document_version(doc, ARCHIVE, 'POST')
             self.update_times(doc)
             self.update_stage(doc)
+            convert_task_attributes_to_objectId(doc)
 
     def on_created(self, docs):
         push_notification(self.datasource, created=1)
@@ -240,6 +241,7 @@ class TasksService(BaseService):
             updates[ITEM_OPERATION] = ITEM_SEND
             send_to(doc=original, update=updates, desk_id=None, stage_id=new_stage_id, user_id=new_user_id)
             resolve_document_version(updates, ARCHIVE, 'PATCH', original)
+        convert_task_attributes_to_objectId(updates)
         update_version(updates, original)
 
     def on_updated(self, updates, original):

--- a/server/features/archive.feature
+++ b/server/features/archive.feature
@@ -340,10 +340,10 @@ Feature: News Items Archive
       And we delete "/desks/#desks._id#"
       Then we get error 412
       """
-      {"_message": "Cannot delete desk as it has article(s)."}
+      {"_message": "Cannot delete desk as it has article(s) or referenced by versions of the article(s)."}
       """
 
-    @auth @test
+    @auth
     Scenario: Cannot delete desk when it is still referenced in archive version
       Given empty "desks"
       And empty "archive"
@@ -368,7 +368,7 @@ Feature: News Items Archive
       When we delete "/desks/#SPORTS_DESK_ID#"
       Then we get error 412
       """
-      {"_message": "Cannot delete desk as it referenced by article(s) versions."}
+      {"_message": "Cannot delete desk as it has article(s) or referenced by versions of the article(s)."}
       """
 
     @auth

--- a/server/features/archive.feature
+++ b/server/features/archive.feature
@@ -343,6 +343,34 @@ Feature: News Items Archive
       {"_message": "Cannot delete desk as it has article(s)."}
       """
 
+    @auth @test
+    Scenario: Cannot delete desk when it is still referenced in archive version
+      Given empty "desks"
+      And empty "archive"
+      When we post to "/desks" with "SPORTS_DESK_ID" and success
+      """
+      {"name": "Sports", "desk_type": "authoring"}
+      """
+      And we post to "/archive"
+      """
+      [{"guid": "123", "type": "text", "body_html": "<p>content</p>", "task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#"}}]
+      """
+      Then we get OK response
+      When we post to "/desks"
+      """
+      {"name": "National", "desk_type": "authoring"}
+      """
+      And we post to "/archive/123/move"
+      """
+      [{"task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#"}}]
+      """
+      Then we get OK response
+      When we delete "/desks/#SPORTS_DESK_ID#"
+      Then we get error 412
+      """
+      {"_message": "Cannot delete desk as it referenced by article(s) versions."}
+      """
+
     @auth
     Scenario: Sign-off is updated when multiple users modify the article
         When we post to "/archive"

--- a/server/features/content_duplication.feature
+++ b/server/features/content_duplication.feature
@@ -18,7 +18,7 @@ Feature: Duplication of Content within Desk
           "task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#", "user": "#CONTEXT_USER_ID#"}}]
       """
 
-    @auth
+    @auth @test
     Scenario: Duplicate a content with history
       When we patch given
       """
@@ -44,6 +44,8 @@ Feature: Duplication of Content within Desk
       """
       {"state": "submitted", "_current_version": 4, "task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#", "user": "#CONTEXT_USER_ID#"}}
       """
+      Then there is no "last_production_desk" in task
+      Then there is no "last_authoring_desk" in task
       When we get "/archive/#duplicate._id#?version=all"
       Then we get list with 4 items
 

--- a/server/features/content_move.feature
+++ b/server/features/content_move.feature
@@ -4,7 +4,7 @@ Feature: Move or Send Content to another desk
     Scenario: Send Content from personal to another desk
         Given "desks"
         """
-        [{"name": "Sports"}]
+        [{"name": "Sports", "desk_type": "production"}]
         """
         When we post to "archive"
         """
@@ -23,12 +23,14 @@ Feature: Move or Send Content to another desk
         { "headline": "test1", "guid": "123", "state": "submitted", "_current_version": 2,
           "task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#", "user": "#CONTEXT_USER_ID#"}}
         """
+        Then there is no "last_production_desk" in task
+        Then there is no "last_authoring_desk" in task
 
     @auth
     Scenario: Send Content from one desk to another desk and validate metadata set by API
-        Given "desks"
+        Given we have "desks" with "SPORTS_DESK_ID" and success
         """
-        [{"name": "Sports"}]
+        [{"name": "Sports", "desk_type": "authoring"}]
         """
         When we post to "archive"
         """
@@ -40,9 +42,9 @@ Feature: Move or Send Content to another desk
         """
         {"headline": "test1", "sign_off": "abc"}
         """
-        When we post to "/desks"
+        When we post to "/desks" with "FINANCE_DESK_ID" and success
         """
-        [{"name": "Finance"}]
+        [{"name": "Finance", "desk_type": "production" }]
         """
         And we switch user
         And we post to "/archive/123/move"
@@ -54,7 +56,94 @@ Feature: Move or Send Content to another desk
         Then we get existing resource
         """
         { "operation": "move", "headline": "test1", "guid": "123", "state": "submitted", "_current_version": 2, "sign_off": "abc/foo",
-          "task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#"}}
+          "task": {
+            "desk": "#desks._id#",
+            "stage": "#desks.incoming_stage#",
+            "last_production_desk": "#FINANCE_DESK_ID#",
+            "last_authoring_desk": "#SPORTS_DESK_ID#"
+            }
+        }
+        """
+
+    @auth @test
+    Scenario: Send Content from one desk to another desk with same desk_type does not change the last_production_desk and last_authoring_desk
+        Given we have "desks" with "SPORTS_DESK_ID" and success
+        """
+        [{"name": "Sports", "desk_type": "authoring"}]
+        """
+        When we post to "archive"
+        """
+        [{  "type":"text", "headline": "test1", "guid": "123", "state": "submitted",
+            "task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#", "user": "#CONTEXT_USER_ID#"}}]
+        """
+        And we get "/archive/123"
+        Then we get existing resource
+        """
+        {"headline": "test1", "sign_off": "abc"}
+        """
+        When we post to "/desks" with "FINANCE_DESK_ID" and success
+        """
+        [{"name": "Finance", "desk_type": "production" }]
+        """
+        And we switch user
+        And we post to "/archive/123/move"
+        """
+        [{"task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#"}}]
+        """
+        Then we get OK response
+        When we get "/archive/123"
+        Then we get existing resource
+        """
+        { "operation": "move", "headline": "test1", "guid": "123", "state": "submitted", "_current_version": 2, "sign_off": "abc/foo",
+          "task": {
+            "desk": "#desks._id#",
+            "stage": "#desks.incoming_stage#",
+            "last_production_desk": "#FINANCE_DESK_ID#",
+            "last_authoring_desk": "#SPORTS_DESK_ID#"
+            }
+        }
+        """
+        When we post to "/desks" with "NATIONAL_DESK_ID" and success
+        """
+        [{"name": "National", "desk_type": "production" }]
+        """
+        And we post to "/archive/123/move"
+        """
+        [{"task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#"}}]
+        """
+        Then we get OK response
+        When we get "/archive/123"
+        Then we get existing resource
+        """
+        { "operation": "move", "headline": "test1", "guid": "123", "state": "submitted", "_current_version": 3, "sign_off": "abc/foo",
+          "task": {
+            "desk": "#desks._id#",
+            "stage": "#desks.incoming_stage#",
+            "last_production_desk": "#FINANCE_DESK_ID#",
+            "last_authoring_desk": "#SPORTS_DESK_ID#"
+            }
+        }
+        """
+        When we post to "/desks" with "ENTERTAINMENT_DESK_ID" and success
+        """
+        [{"name": "Entertainment", "desk_type": "authoring" }]
+        """
+        And we post to "/archive/123/move"
+        """
+        [{"task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#"}}]
+        """
+        Then we get OK response
+        When we get "/archive/123"
+        Then we get existing resource
+        """
+        { "operation": "move", "headline": "test1", "guid": "123", "state": "submitted", "_current_version": 4, "sign_off": "abc/foo",
+          "task": {
+            "desk": "#desks._id#",
+            "stage": "#desks.incoming_stage#",
+            "last_production_desk": "#NATIONAL_DESK_ID#",
+            "last_authoring_desk": "#ENTERTAINMENT_DESK_ID#"
+            }
+        }
         """
 
     @auth

--- a/server/features/content_move.feature
+++ b/server/features/content_move.feature
@@ -24,7 +24,7 @@ Feature: Move or Send Content to another desk
           "task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#", "user": "#CONTEXT_USER_ID#"}}
         """
         Then there is no "last_production_desk" in task
-        Then there is no "last_authoring_desk" in task
+        And there is no "last_authoring_desk" in task
 
     @auth
     Scenario: Send Content from one desk to another desk and validate metadata set by API
@@ -59,13 +59,13 @@ Feature: Move or Send Content to another desk
           "task": {
             "desk": "#desks._id#",
             "stage": "#desks.incoming_stage#",
-            "last_production_desk": "#FINANCE_DESK_ID#",
             "last_authoring_desk": "#SPORTS_DESK_ID#"
             }
         }
         """
+        And there is no "last_production_desk" in task
 
-    @auth @test
+    @auth
     Scenario: Send Content from one desk to another desk with same desk_type does not change the last_production_desk and last_authoring_desk
         Given we have "desks" with "SPORTS_DESK_ID" and success
         """
@@ -98,11 +98,11 @@ Feature: Move or Send Content to another desk
           "task": {
             "desk": "#desks._id#",
             "stage": "#desks.incoming_stage#",
-            "last_production_desk": "#FINANCE_DESK_ID#",
             "last_authoring_desk": "#SPORTS_DESK_ID#"
             }
         }
         """
+        And there is no "last_production_desk" in task
         When we post to "/desks" with "NATIONAL_DESK_ID" and success
         """
         [{"name": "National", "desk_type": "production" }]
@@ -119,11 +119,11 @@ Feature: Move or Send Content to another desk
           "task": {
             "desk": "#desks._id#",
             "stage": "#desks.incoming_stage#",
-            "last_production_desk": "#FINANCE_DESK_ID#",
             "last_authoring_desk": "#SPORTS_DESK_ID#"
             }
         }
         """
+        And there is no "last_production_desk" in task
         When we post to "/desks" with "ENTERTAINMENT_DESK_ID" and success
         """
         [{"name": "Entertainment", "desk_type": "authoring" }]
@@ -141,16 +141,17 @@ Feature: Move or Send Content to another desk
             "desk": "#desks._id#",
             "stage": "#desks.incoming_stage#",
             "last_production_desk": "#NATIONAL_DESK_ID#",
-            "last_authoring_desk": "#ENTERTAINMENT_DESK_ID#"
+            "last_authoring_desk": "#SPORTS_DESK_ID#"
             }
         }
         """
+
 
     @auth
     Scenario: Send Content from one stage to another stage with same desk
         Given "desks"
         """
-        [{"name": "Sports"}]
+        [{"name": "Sports", "desk_type": "production"}]
         """
         When we post to "archive"
         """
@@ -179,6 +180,9 @@ Feature: Move or Send Content to another desk
         { "headline": "test1", "guid": "123", "state": "submitted", "_current_version": 2,
           "task": {"desk": "#desks._id#", "stage": "#stages._id#", "user": "#CONTEXT_USER_ID#"}}
         """
+        And there is no "last_authoring_desk" in task
+        And there is no "last_production_desk" in task
+
 
     @auth
     @clean

--- a/server/features/desks.feature
+++ b/server/features/desks.feature
@@ -30,7 +30,7 @@ Feature: Desks
             """
         When we get the default incoming stage
         And we delete latest
-        Then we get error 403
+        Then we get error 412
         """
         {"_status": "ERR", "_message": "Cannot delete a default stage."}
         """

--- a/server/features/desks.feature
+++ b/server/features/desks.feature
@@ -22,7 +22,7 @@ Feature: Desks
         And we get "/desks"
         Then we get list with 1 items
             """
-            {"_items": [{"name": "Sports Desk", "members": [{"user": "#users._id#"}]}]}
+            {"_items": [{"name": "Sports Desk", "members": [{"user": "#users._id#"}], "desk_type": "authoring"}]}
             """
         Then we get notifications
             """
@@ -41,13 +41,16 @@ Feature: Desks
 	    Given empty "desks"
 		When we post to "/desks"
             """
-            {"name": "Sports Desk"}
+            {"name": "Sports Desk", "desk_type": "production"}
             """
 		And we patch latest
 			 """
             {"name": "Sports Desk modified"}
              """
 		Then we get updated response
+            """
+            {"name": "Sports Desk modified", "desk_type": "production"}
+            """
         Then we get notifications
             """
             [{"event": "desk", "extra": {"updated": 1, "desk_id": "#desks._id#"}}]

--- a/server/features/stages.feature
+++ b/server/features/stages.feature
@@ -366,9 +366,9 @@ Feature: Stages
         [{"type": "text"}]
         """
         When we delete "/stages/#stages._id#"
-        Then we get error 403
+        Then we get error 412
         """
-        {"_status": "ERR", "_message": "Only empty stages can be deleted."}
+        {"_status": "ERR", "_message": "Cannot delete stage as it has article(s) or referenced by versions of the article(s)."}
         """
 
     @auth
@@ -527,9 +527,9 @@ Feature: Stages
         ]
         """
         When we delete "/stages/#stages._id#"
-        Then we get error 403
+        Then we get error 412
         """
-        {"_status": "ERR", "_message": "Stage is refered to by Ingest Routing Schemes : routing rule scheme 1"}
+        {"_status": "ERR", "_message": "Stage is referred by Ingest Routing Schemes : routing rule scheme 1"}
         """
 
     @auth
@@ -548,14 +548,14 @@ Feature: Stages
         }
         """
         When we delete "/stages/#desks.incoming_stage#"
-        Then we get error 403
+        Then we get error 412
         """
         {"_status": "ERR", "_message": "Cannot delete a default stage."}
         """
 
     @auth
-    @notification
-    Scenario: Can delete stage if there are only spiked documents
+    @notification @test
+    Scenario: Cannot delete stage if there are only spiked documents
         Given empty "archive"
         Given empty "stages"
         Given "desks"
@@ -570,18 +570,20 @@ Feature: Stages
         "desk": "#desks._id#"
         }
         """
-
+        Then we get OK response
         When we patch "/stages/#stages._id#"
         """
         {"desk":"#desks._id#"}
         """
+        Then we get OK response
         When we post to "archive"
         """
-        [{"headline": "This is spiked", "type": "text", "state": "spiked"}]
+        [{"headline": "This is spiked", "type": "text", "state": "spiked",
+            "task": {"desk": "#desks._id#", "stage": "#stages._id#"}}]
         """
+        Then we get OK response
         When we delete "/stages/#stages._id#"
-        Then we get response code 204
-        Then we get notifications
+        Then we get error 412
         """
-        [{"event": "stage", "extra": {"deleted": 1}}]
+        {"_status": "ERR", "_message": "Cannot delete stage as it has article(s) or referenced by versions of the article(s)."}
         """

--- a/server/features/stages.feature
+++ b/server/features/stages.feature
@@ -554,7 +554,7 @@ Feature: Stages
         """
 
     @auth
-    @notification @test
+    @notification
     Scenario: Cannot delete stage if there are only spiked documents
         Given empty "archive"
         Given empty "stages"

--- a/server/features/steps/steps.py
+++ b/server/features/steps/steps.py
@@ -1751,6 +1751,12 @@ def there_is_no_key_in_response(context, key):
     assert key not in data, 'key "%s" is in %s' % (key, data)
 
 
+@then('there is no "{key}" in task')
+def there_is_no_key_in_preferences(context, key):
+    data = get_json_data(context.response)['task']
+    assert key not in data, 'key "%s" is in task' % key
+
+
 @then('there is no "{key}" in "{namespace}" preferences')
 def there_is_no_key_in_preferences(context, key, namespace):
     data = get_json_data(context.response)['user_preferences']


### PR DESCRIPTION
This feature allow the user to monitor content sent from a particular desk to all desks or a particular desk. 
See https://dev.sourcefabric.org/browse/SD-3352 for more information:

- [x] Modify the desk schema to specify `desk_types`
- [x] Modify the desk frontend for `desk_types`.
- [x] Modify the archive/item schema to track the `last_authoring_desk` and `last_production_desk`.
- [x] Modify the 'send_to' related functionality to track the desk movement.
- [x] Modify Global search on frontend to allow to selection for desks.
