### PR TITLE
(feat & imp) SD-3183 and Vocabulary UI Improvements

### DIFF
--- a/client/app/scripts/superdesk-authoring/metadata/views/metadata-widget.html
+++ b/client/app/scripts/superdesk-authoring/metadata/views/metadata-widget.html
@@ -27,7 +27,7 @@
 			</li>
 			<li class="terms-box">
 				<label translate>Keywords</label>
-				<div sd-meta-words-list data-item="item" data-field="keywords" data-change="autosave(item)" data-list="item.keywords" data-disabled="!_editable"></div>
+				<div sd-meta-words-list data-item="item" data-field="keywords" data-change="autosave(item)" data-header="_editable" data-list="metadata.keywords" data-disabled="!_editable"></div>
 			</li>
 			<li>
 				<label translate>Language</label>

--- a/client/app/scripts/superdesk-authoring/metadata/views/metadata-words-list.html
+++ b/client/app/scripts/superdesk-authoring/metadata/views/metadata-words-list.html
@@ -1,8 +1,16 @@
-<div class="term-editor data visible">
-    <input class="line-input" ng-model="term" type="text" ng-disabled="disabled" autocomplete="off" ng-keyup="selectTerm($event, term)"/>
+<div class="term-editor data visible" ng-show="header">
+    <div sd-typeahead items="words" term="selectedTerm" search="search(term)" select="select(item)" data-disabled="disabled">
+        <ul>
+            <li typeahead-item="t" ng-repeat="t in words">
+                {{ :: t.name }}
+            </li>
+        </ul>
+    </div>
 </div>
+
 <div class="terms" ng-if="item[field].length">
     <ul>
-        <li ng-repeat="t in item[field]" ng-click="removeTerm(t)">{{ t }}</li>
+        <li ng-if="!disabled" ng-repeat="t in item[field]" ng-click="removeTerm(t)">{{ t }}<i class="icon-close-small"></i></li>
+        <li ng-if="disabled" ng-repeat="t in item[field]">{{ t }}</li>
     </ul>
 </div>

--- a/client/app/scripts/superdesk-authoring/metadata/views/metadata-words-list.html
+++ b/client/app/scripts/superdesk-authoring/metadata/views/metadata-words-list.html
@@ -10,7 +10,7 @@
 
 <div class="terms" ng-if="item[field].length">
     <ul>
-        <li ng-if="!disabled" ng-repeat="t in item[field]" ng-click="removeTerm(t)">{{ t }}<i class="icon-close-small"></i></li>
-        <li ng-if="disabled" ng-repeat="t in item[field]">{{ t }}</li>
+        <li ng-if="!disabled" ng-repeat="t in item[field] track by t" ng-click="removeTerm(t)">{{ t }}<i class="icon-close-small"></i></li>
+        <li ng-if="disabled" ng-repeat="t in item[field] track by t">{{ t }}</li>
     </ul>
 </div>

--- a/client/app/scripts/superdesk-vocabularies/styles/vocabularies.less
+++ b/client/app/scripts/superdesk-vocabularies/styles/vocabularies.less
@@ -23,6 +23,10 @@
 	}
 }
 
+.vocabularyStatus {
+    top: 5px;
+}
+
 .divider {
 	.nav-divider();
 }

--- a/client/app/scripts/superdesk-vocabularies/tests/vocabularies.spec.js
+++ b/client/app/scripts/superdesk-vocabularies/tests/vocabularies.spec.js
@@ -16,7 +16,7 @@ describe('vocabularies', function() {
             }
         );
         $rootScope.$digest();
-        expect(api.query).toHaveBeenCalledWith('vocabularies');
+        expect(api.query).toHaveBeenCalledWith('vocabularies', {where: {type: 'manageable'}});
         expect(result).toBe(fixture);
         expect(vocabularies.vocabularies).toBe(fixture);
     }));
@@ -29,16 +29,16 @@ describe('vocabularies', function() {
             beforeEach(inject(function($rootScope, $controller) {
                 scope = $rootScope.$new();
                 scope.vocabulary = {items: [
-                    {foo: 'flareon', bar: 'beedrill'},
-                    {bar: 'bellsprout', spam: 'sandslash'},
-                    {qux: 'quagsire', foo: 'frillish', corge: 'corfish'}
+                    {foo: 'flareon', bar: 'beedrill', is_active: true},
+                    {bar: 'bellsprout', spam: 'sandslash', is_active: true},
+                    {qux: 'quagsire', foo: 'frillish', corge: 'corfish', is_active: true}
                 ]};
                 $controller('VocabularyEdit', {$scope: scope});
             }));
 
             it('being detected correctly', function() {
                 expect(scope.model).toEqual(
-                    {foo: null, bar: null, spam: null, qux: null, corge: null}
+                    {foo: null, bar: null, spam: null, qux: null, corge: null, is_active: null}
                 );
             });
         });
@@ -49,7 +49,7 @@ describe('vocabularies', function() {
 
             beforeEach(inject(function($rootScope, $controller) {
                 scope = $rootScope.$new();
-                testItem = {foo: 'flareon', bar: 'beedrill'};
+                testItem = {'foo': 'flareon', 'bar': 'beedrill', 'is_active': true};
                 scope.vocabulary = {items: [testItem]};
                 $controller('VocabularyEdit', {$scope: scope});
             }));
@@ -57,28 +57,21 @@ describe('vocabularies', function() {
             it('can add items', function() {
                 scope.addItem();
                 expect(scope.vocabulary.items.length).toBe(2);
-                expect(scope.vocabulary.items[1]).toEqual({foo: null, bar: null});
-            });
-
-            it('can remove items', function() {
-                var testItem2 = {foo: 'flaaffy', bar: 'bidoof'};
-                scope.vocabulary.items.push(testItem2);
-                scope.removeItem(testItem);
-                expect(scope.vocabulary.items.length).toBe(1);
-                expect(scope.vocabulary.items[0]).toEqual(testItem2);
-                scope.removeItem(testItem2);
-                expect(scope.vocabulary.items.length).toBe(0);
+                expect(scope.vocabulary.items[1]).toEqual({foo: null, bar: null, is_active: true});
             });
 
             it('can save vocabulary', inject(function(api, $q, $rootScope, metadata) {
                 scope.vocabulary.items[0].foo = 'feraligatr';
                 scope.vocabulary.items[0].bar = 'bayleef';
+                scope.vocabulary.items[0].is_active = true;
+
                 spyOn(api, 'save').and.returnValue($q.when());
                 spyOn(metadata, 'initialize').and.returnValue($q.when());
                 scope.save();
+
                 $rootScope.$digest();
                 expect(api.save).toHaveBeenCalledWith('vocabularies', {
-                    items: [{foo: 'feraligatr', bar: 'bayleef'}]
+                    items: [{foo: 'feraligatr', bar: 'bayleef', is_active: true}]
                 });
                 expect(metadata.initialize).toHaveBeenCalled();
             }));
@@ -87,10 +80,12 @@ describe('vocabularies', function() {
                 var vocabularyLink = scope.vocabulary;
                 scope.vocabulary.items[0].foo = 'furret';
                 scope.vocabulary.items[0].bar = 'buizel';
+
                 scope.cancel();
                 $rootScope.$digest();
+
                 expect(vocabularyLink).toEqual({
-                    items: [{foo: 'flareon', bar: 'beedrill'}]
+                    items: [{foo: 'flareon', bar: 'beedrill', is_active: true}]
                 });
             }));
         });

--- a/client/app/scripts/superdesk-vocabularies/views/vocabulary-config-modal.html
+++ b/client/app/scripts/superdesk-vocabularies/views/vocabulary-config-modal.html
@@ -1,32 +1,39 @@
 <form name="editForm">
-  <div sd-modal data-model="vocabulary" class="add-vocabulary-popup">
-    <div class="modal-header">
-      <a href="" class="close" ng-click="cancel()"><i class="icon-close-small"></i></a>
-      <h3 translate>Edit Vocabulary: {{ :: vocabulary._id}}</h3>
+    <div sd-modal data-model="vocabulary" class="add-vocabulary-popup">
+        <div class="modal-header">
+            <a href="" class="close" ng-click="cancel()"><i class="icon-close-small"></i></a>
+
+            <h3 translate>Edit Vocabulary: {{ :: vocabulary.display_name }}</h3>
+        </div>
+
+        <div class="modal-body">
+            <ng-form name="vocabularyForm" class="vocabularyForm">
+
+                <fieldset>
+                    <div ng-repeat="(key, value) in model" ng-if="key !== 'is_active'" class="field vocabularyField">
+                        <label translate>{{ :: key }}</label>
+                    </div>
+
+                    <div ng-repeat="item in vocabulary.items track by $index">
+                        <div ng-repeat="(key, value) in model" ng-if="key !== 'is_active'" class="field vocabularyField">
+                            <input type="text" ng-model="item[key]" ng-disabled="!item.is_active" required>
+                        </div>
+                        <span class="pull-right vocabularyStatus" sd-switch ng-model="item.is_active"></span>
+                    </div>
+
+                    <li class="divider"></li>
+                    <button id="add-new-btn" class="btn pull-right" ng-click="addItem()" translate>Add</button>
+                </fieldset>
+
+            </ng-form>
+        </div>
+
+        <div class="modal-footer">
+            <button id="save-edit-btn" type="submit" class="btn btn-info pull-right" ng-click="save()"
+                    ng-disabled="editForm.$invalid" translate>Save
+            </button>
+            <button id="cancel-edit-btn" type="button" class="btn pull-right" ng-click="cancel()" translate>Cancel
+            </button>
+        </div>
     </div>
-
-    <div class="modal-body">
-      <ng-form name="vocabularyForm" class="vocabularyForm">
-
-        <fieldset>
-            <div ng-repeat="(key, value) in model" class="field vocabularyField">
-              <label translate>{{ :: key }}</label>
-            </div>
-          <div ng-repeat="item in vocabulary.items track by $index">
-            <div ng-repeat="(key, value) in model" class="field vocabularyField">
-              <input type="text" ng-model="item[key]">
-            </div>
-            <button id="del-btn" class="btn del" ng-click="removeItem(item)">✕</button>
-          </div>
-          <li class="divider"></li>
-          <button id="add-new-btn" class="btn" ng-click="addItem()" translate>Add</button>
-        </fieldset>
-
-    </div>
-
-    <div class="modal-footer">
-      <button id="save-edit-btn" type="submit" class="btn btn-info pull-right" ng-click="save()" ng-disabled="editForm.$invalid" translate>Save</button>
-      <button id="cancel-edit-btn" type="button" class="btn pull-right" ng-click="cancel()" translate>Cancel</button>
-    </div>
-  </div>
 </form>

--- a/client/app/scripts/superdesk-vocabularies/views/vocabulary-config.html
+++ b/client/app/scripts/superdesk-vocabularies/views/vocabulary-config.html
@@ -2,7 +2,7 @@
   <ul class="pills-list">
 
     <li ng-repeat="vocabulary in vocabularies._items">
-      <h6>{{ :: vocabulary._id }}</h6>&nbsp;
+      <h6>{{ :: vocabulary.display_name }}</h6>&nbsp;
       <em><strong>({{ vocabulary.items.length }})</strong></em>
       <div class="actions">
         <button

--- a/client/app/scripts/superdesk-vocabularies/vocabularies.js
+++ b/client/app/scripts/superdesk-vocabularies/vocabularies.js
@@ -22,11 +22,12 @@
          */
         this.getVocabularies = function() {
             if (typeof service.vocabularies === 'undefined') {
-                return api.query('vocabularies')
-                .then(function(result) {
-                    service.vocabularies = result;
-                    return service.vocabularies;
-                });
+                return api.query('vocabularies', {where: {type: 'manageable'}}).then(
+                    function(result) {
+                        service.vocabularies = result;
+                        return service.vocabularies;
+                    }
+                );
             } else {
                 return $q.when(service.vocabularies);
             }
@@ -110,16 +111,11 @@
          * Add new blank vocabulary item.
          */
         $scope.addItem = function() {
-            $scope.vocabulary.items.push(model);
-        };
+            var newVocabulary = {};
+            _.extend(newVocabulary, $scope.model);
+            newVocabulary.is_active = true;
 
-        /**
-         * Remove vocabulary item.
-         *
-         * @param {Object} item
-         */
-        $scope.removeItem = function(item) {
-            $scope.vocabulary.items.splice($scope.vocabulary.items.indexOf(item), 1);
+            $scope.vocabulary.items.push(newVocabulary);
         };
 
         // try to reproduce data model of vocabulary:

--- a/server/apps/prepopulate/app_prepopulate_data.json
+++ b/server/apps/prepopulate/app_prepopulate_data.json
@@ -294,6 +294,8 @@
     {
         "data": {
             "_id": "subscriber_types",
+            "display_name": "Subscriber Types",
+            "type": "unmanageable",
             "items": [
                 {"is_active": true, "name": "Digital/Internet", "value": "digital",
                     "formats": [{"name": "NINJS", "value": "ninjs"}, {"name": "AAP NewsML 1.2", "value": "newsml12"}, {"name": "NewsML G2", "value": "newsmlg2"},
@@ -313,6 +315,8 @@
     {
         "data": {
             "_id": "categories",
+            "display_name": "Categories",
+            "type": "manageable",
             "items": [
                 {"is_active": true, "name": "Australian General News", "qcode": "a"},
                 {"is_active": true, "name": "Australian Weather", "qcode": "b", "subject": "17000000"},
@@ -349,6 +353,8 @@
     {
         "data": {
             "_id": "default_categories",
+            "display_name": "Default Categories",
+            "type": "manageable",
             "items" : [
                 {"qcode" : "a", "is_active" : true},
                 {"qcode" : "e", "is_active" : true},

--- a/server/apps/prepopulate/data_initialization/vocabularies.json
+++ b/server/apps/prepopulate/data_initialization/vocabularies.json
@@ -1,6 +1,8 @@
 [
     {
         "_id": "categories",
+        "display_name": "Categories",
+        "type": "manageable",
         "items": [
             {"is_active": true, "name": "Australian General News", "qcode": "a"},
             {"is_active": true, "name": "Australian Weather", "qcode": "b", "subject": "17000000"},
@@ -32,6 +34,8 @@
     },
     {
         "_id": "default_categories",
+        "display_name": "Default Categories",
+        "type": "manageable",
         "items": [
             {"is_active": true, "qcode": "a"},
             {"is_active": true, "qcode": "e"},
@@ -44,6 +48,8 @@
     },
     {
         "_id": "genre",
+        "display_name": "Genre",
+        "type": "manageable",
         "items": [
             {"is_active": true, "name": "Article (news)", "value": "Article"},
             {"is_active": true, "name": "Sidebar", "value": "Sidebar"},
@@ -72,6 +78,8 @@
     },
     {
         "_id": "urgency",
+        "display_name": "Urgency",
+        "type": "manageable",
         "items": [
             {"is_active": true, "name": "1", "value": 1},
             {"is_active": true, "name": "2", "value": 2},
@@ -82,6 +90,8 @@
     },
     {
         "_id": "priority",
+        "display_name": "Priority",
+        "type": "unmanageable",
         "items": [
             {"is_active": true, "name": "1", "value": 1},
             {"is_active": true, "name": "2", "value": 2},
@@ -96,6 +106,8 @@
     },
     {
         "_id": "type",
+        "display_name": "Article Type",
+        "type": "unmanageable",
         "items": [
             {"is_active": true, "name": "text", "value": "text"},
             {"is_active": true, "name": "preformatted", "value": "preformatted"},
@@ -108,6 +120,8 @@
     },
     {
         "_id": "signal",
+        "display_name": "Signal",
+        "type": "unmanageable",
         "items": [
             {"is_active": true, "name": "Correction", "value": "Correction"},
             {"is_active": true, "name": "Update", "value": "Update"},
@@ -118,6 +132,8 @@
     },
     {
         "_id": "rightsinfo",
+        "display_name": "Copyrights",
+        "type": "manageable",
         "items": [
             {
                 "is_active": true,
@@ -137,6 +153,8 @@
     },
     {
         "_id": "geographical_restrictions",
+        "display_name": "Geographical Restrictions",
+        "type": "manageable",
         "items": [
             {"is_active": true, "name": "New South Wales", "value": "NSW"},
             {"is_active": true, "name": "Victoria", "value": "VIC"},
@@ -150,6 +168,8 @@
     },
     {
         "_id": "subscriber_types",
+        "display_name": "Subscriber Types",
+        "type": "unmanageable",
         "items": [
             {"is_active": true, "name": "All", "value": "all",
                 "formats": [{"name": "NINJS", "value": "ninjs"}, {"name": "AAP NewsML 1.2", "value": "newsml12"}, {"name": "NewsML G2", "value": "newsmlg2"}]},
@@ -166,6 +186,8 @@
     },
     {
         "_id": "locators",
+        "display_name": "Locators",
+        "type": "unmanageable",
         "items": [
             {"is_active": true, "name": "ACT", "qcode": "ACT",
                 "state": "Australian Capital Territory",
@@ -220,9 +242,24 @@
     },
     {
         "_id": "crop_sizes",
+        "display_name": "Image Crop Sizes",
+        "type": "manageable",
         "items": [
             {"is_active": true, "name": "4-3", "width": 800, "height": 600},
             {"is_active": true, "name": "16-9", "width": 1280, "height": 720}
+        ]
+    },
+    {
+        "_id": "keywords",
+        "display_name": "Keywords for Articles",
+        "type": "manageable",
+        "items": [
+            {"is_active": true, "name": "Science and Technology",       "value": "SciTech"},
+            {"is_active": true, "name": "International Health Stories", "value": "Medicine"},
+            {"is_active": true, "name": "Health",                       "value": "Health"},
+            {"is_active": true, "name": "Motoring",                     "value": "Motoring"},
+            {"is_active": true, "name": "Soccer",                       "value": "Soccer"},
+            {"is_active": true, "name": "Property",                     "value": "Property"}
         ]
     }
 ]

--- a/server/features/steps/fixtures/vocabularies.json
+++ b/server/features/steps/fixtures/vocabularies.json
@@ -1,6 +1,8 @@
 [
     {
         "_id": "categories",
+        "display_name": "Categories",
+        "type": "manageable",
         "items": [
             {"is_active": true, "name": "Australian General News", "qcode": "a"},
             {"is_active": true, "name": "Australian Weather", "qcode": "b", "subject": "17000000"},
@@ -32,6 +34,8 @@
     },
     {
         "_id": "default_categories",
+        "display_name": "Default Categories",
+        "type": "manageable",
         "items": [
             {"is_active": true, "qcode": "a"},
             {"is_active": true, "qcode": "e"},
@@ -44,6 +48,8 @@
     },
     {
         "_id": "genre",
+        "display_name": "Genre",
+        "type": "manageable",
         "items": [
             {"is_active": true, "name": "Article (news)", "value": "Article"},
             {"is_active": true, "name": "Sidebar", "value": "Sidebar"},
@@ -72,6 +78,8 @@
     },
     {
         "_id": "urgency",
+        "display_name": "Urgency",
+        "type": "manageable",
         "items": [
             {"is_active": true, "name": "1", "value": 1},
             {"is_active": true, "name": "2", "value": 2},
@@ -82,6 +90,8 @@
     },
     {
         "_id": "priority",
+        "display_name": "Priority",
+        "type": "unmanageable",
         "items": [
             {"is_active": true, "name": "1", "value": 1},
             {"is_active": true, "name": "2", "value": 2},
@@ -96,6 +106,8 @@
     },
     {
         "_id": "type",
+        "display_name": "Article Type",
+        "type": "unmanageable",
         "items": [
             {"is_active": true, "name": "text", "value": "text"},
             {"is_active": true, "name": "preformatted", "value": "preformatted"},
@@ -108,6 +120,8 @@
     },
     {
         "_id": "signal",
+        "display_name": "Signal",
+        "type": "unmanageable",
         "items": [
             {"is_active": true, "name": "Correction", "value": "Correction"},
             {"is_active": true, "name": "Update", "value": "Update"},
@@ -118,6 +132,8 @@
     },
     {
         "_id": "rightsinfo",
+        "display_name": "Copyrights",
+        "type": "manageable",
         "items": [
             {
                 "is_active": true,
@@ -137,6 +153,8 @@
     },
     {
         "_id": "geographical_restrictions",
+        "display_name": "Geographical Restrictions",
+        "type": "manageable",
         "items": [
             {"is_active": true, "name": "New South Wales", "value": "NSW"},
             {"is_active": true, "name": "Victoria", "value": "VIC"},
@@ -150,9 +168,11 @@
     },
     {
         "_id": "subscriber_types",
+        "display_name": "Subscriber Types",
+        "type": "unmanageable",
         "items": [
             {"is_active": true, "name": "All", "value": "all",
-                "formats": [{"name": "NINJS", "value": "ninjs"}, {"name": "NewsML G2", "value": "newsmlg2"}]},
+                "formats": [{"name": "NINJS", "value": "ninjs"}, {"name": "AAP NewsML 1.2", "value": "newsml12"}, {"name": "NewsML G2", "value": "newsmlg2"}]},
             {"is_active": true, "name": "Digital/Internet", "value": "digital",
                 "formats": [{"name": "NINJS", "value": "ninjs"}, {"name": "AAP NewsML 1.2", "value": "newsml12"}, {"name": "NewsML G2", "value": "newsmlg2"},
                             {"name": "AAP Bulletin Builder", "value": "AAP BULLETIN BUILDER"}]},
@@ -166,38 +186,80 @@
     },
     {
         "_id": "locators",
+        "display_name": "Locators",
+        "type": "unmanageable",
         "items": [
-            {"is_active": true, "name": "ACT", "qcode": "ACT"},
+            {"is_active": true, "name": "ACT", "qcode": "ACT",
+                "state": "Australian Capital Territory",
+                "country": "Australia", "world_region": "Oceania"},
             {"is_active": true, "name": "ADV", "qcode": "ADV"},
-            {"is_active": true, "name": "AFR", "qcode": "AFR"},
-            {"is_active": true, "name": "ASIA", "qcode": "ASIA"},
-            {"is_active": true, "name": "CAN", "qcode": "CAN"},
-            {"is_active": true, "name": "CHN", "qcode": "CHN"},
-            {"is_active": true, "name": "CIS", "qcode": "CIS"},
-            {"is_active": true, "name": "EUR", "qcode": "EUR"},
-            {"is_active": true, "name": "FED", "qcode": "FED"},
-            {"is_active": true, "name": "IRE", "qcode": "IRE"},
-            {"is_active": true, "name": "JPN", "qcode": "JPN"},
-            {"is_active": true, "name": "MID", "qcode": "MID"},
-            {"is_active": true, "name": "NSW", "qcode": "NSW"},
-            {"is_active": true, "name": "NT", "qcode": "NT"},
-            {"is_active": true, "name": "NZ", "qcode": "NZ"},
-            {"is_active": true, "name": "PAC", "qcode": "PAC"},
-            {"is_active": true, "name": "QLD", "qcode": "QLD"},
-            {"is_active": true, "name": "SA", "qcode": "SA"},
+            {"is_active": true, "name": "AFR", "qcode": "AFR",
+                "state": "", "country": "", "world_region": "Africa"},
+            {"is_active": true, "name": "ASIA", "qcode": "ASIA",
+                "state": "", "country": "", "world_region": "Asia"},
+            {"is_active": true, "name": "CAN", "qcode": "CAN",
+                "state": "", "country": "Canada", "world_region": "North America"},
+            {"is_active": true, "name": "CHN", "qcode": "CHN",
+                "state": "", "country": "China", "world_region": "Asia"},
+            {"is_active": true, "name": "CIS", "qcode": "CIS",
+                "state": "", "country": "", "world_region": "Commonwealth of Independent States"},
+            {"is_active": true, "name": "EUR", "qcode": "EUR",
+                "state": "", "country": "", "world_region": "Europe"},
+            {"is_active": true, "name": "FED", "qcode": "FED",
+                "state": "", "country": "Australia", "world_region": "Oceania"},
+            {"is_active": true, "name": "IRE", "qcode": "IRE",
+                "state": "", "country": "Ireland", "world_region": "Europe"},
+            {"is_active": true, "name": "JPN", "qcode": "JPN",
+                "state": "", "country": "Japan", "world_region": "Asia"},
+            {"is_active": true, "name": "MID", "qcode": "MID",
+                "state": "", "country": "", "world_region": "Middle East"},
+            {"is_active": true, "name": "NSW", "qcode": "NSW",
+                "state": "New South Wales",
+                "country": "Australia", "world_region": "Oceania"},
+            {"is_active": true, "name": "NT", "qcode": "NT",
+                "state": "Northern Territory",
+                "country": "Australia", "world_region": "Oceania"},
+            {"is_active": true, "name": "NZ", "qcode": "NZ",
+                "state": "", "country": "New Zealand", "world_region": "Oceania"},
+            {"is_active": true, "name": "PAC", "qcode": "PAC",
+                "state": "", "country": "", "world_region": "Pacific Island Nations"},
+            {"is_active": true, "name": "QLD", "qcode": "QLD",
+                "state": "Queensland", "country": "Australia", "world_region": "Oceania"},
+            {"is_active": true, "name": "SA", "qcode": "SA",
+                "state": "South Australia", "country": "Australia", "world_region": "Oceania"},
             {"is_active": true, "name": "SAM", "qcode": "SAM"},
-            {"is_active": true, "name": "TAS", "qcode": "TAS"},
-            {"is_active": true, "name": "UK", "qcode": "UK"},
-            {"is_active": true, "name": "US", "qcode": "US"},
-            {"is_active": true, "name": "VIC", "qcode": "VIC"},
-            {"is_active": true, "name": "WA", "qcode": "WA"}
+            {"is_active": true, "name": "TAS", "qcode": "TAS",
+                "state": "Tasmania", "country": "Australia", "world_region": "Oceania"},
+            {"is_active": true, "name": "UK", "qcode": "UK",
+                "state": "", "country": "", "world_region": "Europe"},
+            {"is_active": true, "name": "US", "qcode": "US",
+                "state": "", "country": "United States Of America", "world_region": "North America"},
+            {"is_active": true, "name": "VIC", "qcode": "VIC",
+                "state": "Victoria", "country": "Australia", "world_region": "Oceania"},
+            {"is_active": true, "name": "WA", "qcode": "WA",
+                "state": "Western Australia", "country": "Australia", "world_region": "Oceania"}
         ]
     },
     {
         "_id": "crop_sizes",
+        "display_name": "Image Crop Sizes",
+        "type": "manageable",
         "items": [
             {"is_active": true, "name": "4-3", "width": 800, "height": 600},
             {"is_active": true, "name": "16-9", "width": 1280, "height": 720}
+        ]
+    },
+    {
+        "_id": "keywords",
+        "display_name": "Keywords for Articles",
+        "type": "manageable",
+        "items": [
+            {"is_active": true, "name": "Science and Technology",       "value": "SciTech"},
+            {"is_active": true, "name": "International Health Stories", "value": "Medicine"},
+            {"is_active": true, "name": "Health",                       "value": "Health"},
+            {"is_active": true, "name": "Motoring",                     "value": "Motoring"},
+            {"is_active": true, "name": "Soccer",                       "value": "Soccer"},
+            {"is_active": true, "name": "Property",                     "value": "Property"}
         ]
     }
 ]

--- a/server/features/vocabularies.feature
+++ b/server/features/vocabularies.feature
@@ -64,3 +64,21 @@ Feature: Vocabularies
           ]
       }
       """
+
+  @auth
+  @vocabulary
+  Scenario: Fetch all when type is not specified and fetch based on type when specified
+    When we get "/vocabularies"
+    Then we get existing resource
+    """
+    {"_items" :[{"_id": "locators"}, {"_id": "categories"}]}
+    """
+    When we get "/vocabularies?where={"type":"manageable"}"
+    Then we get existing resource
+    """
+    {"_items": [{"_id": "crop_sizes", "display_name": "Image Crop Sizes", "type": "manageable",
+     "items": [{"is_active": true, "name": "4-3", "width": 800, "height": 600},
+               {"is_active": true, "name": "16-9", "width": 1280, "height": 720}]
+     }]}
+    """
+    And there is no "locators" in response

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -6,4 +6,4 @@ wooper==0.4.2
 pymongo==2.8
 Eve==0.6.0
 
--e git+git://github.com/superdesk/superdesk-core@6d927bf4#egg=Superdesk-Core==0.0.1-dev
+-e git+git://github.com/superdesk/superdesk-core@c3c6425#egg=Superdesk-Core==0.0.1-dev


### PR DESCRIPTION
1. [SD-3183](https://dev.sourcefabric.org/browse/SD-3183) Using keywords as labels to group content arbitrarily
2. Adding following features to Vocabularies:
      1. Adding "type" to each vocabulary which defines whether a vocabulary is system driven or manageable by user.
      2. Adding "display_name" to each vocabulary which is used in UI.
      3. Vocabulary UI displays only manageable type vocabularies
      4. Vocabulary UI displays both active and inactive vocabularies
3. Fixed the below issues in Vocabularies UI:
      1. Updating a vocabulary item removes is_active flag from collection
      2. No vocabulary should be allowed to delete as it might have been used in transactional data. So replaced delete with sd-switch

Requires https://github.com/superdesk/superdesk-core/pull/35

##### Instructions to the Merger(s):
1. Underlying structure of Vocabulary is changed. After merging please drop vocabularies collection and recreate collection using `vocabularies.json` file.