### PR TITLE
Fix handling different time zones in ingest routing schedule

### DIFF
--- a/client/app/scripts/superdesk-dashboard/world-clock/tests/WorldClockConfigController_spec.js
+++ b/client/app/scripts/superdesk-dashboard/world-clock/tests/WorldClockConfigController_spec.js
@@ -45,13 +45,17 @@ describe('WorldClockConfigController', function () {
                 'Foo/Bar': []
             }
         };
+
         fakeTzdata.zones = serverTzdata.zones;
         fakeTzdata.links = serverTzdata.links;
+        fakeTzdata.getTzNames = function () {
+            return ['Australia/Sydney', 'Europe/Rome', 'Foo/Bar'];
+        };
 
         getTzdataDeferred.resolve(serverTzdata);
         scope.$digest();
 
-        expectedList = ['Europe/Rome', 'Australia/Sydney', 'Foo/Bar'];
+        expectedList = ['Australia/Sydney', 'Europe/Rome', 'Foo/Bar'];
         expect(scope.availableZones).toEqual(expectedList);
     });
 

--- a/client/app/scripts/superdesk-dashboard/world-clock/tests/WorldClockConfigController_spec.js
+++ b/client/app/scripts/superdesk-dashboard/world-clock/tests/WorldClockConfigController_spec.js
@@ -1,0 +1,58 @@
+
+/**
+* Module with tests for the WorldClockConfigController
+*
+* @module WorldClockConfigController tests
+*/
+describe('WorldClockConfigController', function () {
+    'use strict';
+
+    var getTzdataDeferred,
+        fakeTzdata,
+        scope;
+
+    beforeEach(module('superdesk.dashboard.world-clock'));
+
+    beforeEach(inject(function ($controller, $rootScope, $q) {
+        scope = $rootScope.$new();
+        scope.configuration = {};
+
+        getTzdataDeferred = $q.defer();
+        fakeTzdata = {
+            $promise: getTzdataDeferred.promise,
+            zones: {},
+            links: {}
+        };
+
+        $controller('WorldClockConfigController', {
+            $scope: scope,
+            tzdata: fakeTzdata
+        });
+    }));
+
+    it('initializes the list of available time zone in scope', function () {
+        var expectedList,
+            serverTzdata;
+
+        scope.availableZones = [];  // make sure it is initially empty
+
+        serverTzdata = {
+            zones: {
+                'Europe/Rome': ['1 - CET'],
+                'Australia/Sydney': ['10 ADN EST']
+            },
+            links: {
+                'Foo/Bar': []
+            }
+        };
+        fakeTzdata.zones = serverTzdata.zones;
+        fakeTzdata.links = serverTzdata.links;
+
+        getTzdataDeferred.resolve(serverTzdata);
+        scope.$digest();
+
+        expectedList = ['Europe/Rome', 'Australia/Sydney', 'Foo/Bar'];
+        expect(scope.availableZones).toEqual(expectedList);
+    });
+
+});

--- a/client/app/scripts/superdesk-dashboard/world-clock/tests/WorldClockController_spec.js
+++ b/client/app/scripts/superdesk-dashboard/world-clock/tests/WorldClockController_spec.js
@@ -1,0 +1,53 @@
+
+/**
+* Module with tests for the WorldClockController
+*
+* @module WorldClockController tests
+*/
+describe('WorldClockController', function () {
+    'use strict';
+
+    var ctrl,
+        getTzdataDeferred,
+        fakeTzdata,
+        scope;
+
+    beforeEach(module('superdesk.dashboard.world-clock'));
+
+    beforeEach(inject(function ($controller, $rootScope, $q) {
+        scope = $rootScope.$new();
+
+        getTzdataDeferred = $q.defer();
+        fakeTzdata = {
+            $promise: getTzdataDeferred.promise,
+            zones: {},
+            links: {}
+        };
+
+        ctrl = $controller('WorldClockController', {
+            $scope: scope,
+            tzdata: fakeTzdata
+        });
+    }));
+
+    it('adds time zone data to Moment library on initialization', function () {
+        var serverTzdata = {
+            zones: {
+                'Europe/Rome': ['1 - CET'],
+                'Australia/Sydney': ['10 ADN EST']
+            },
+            links: {
+                'Foo/Bar': []
+            }
+        };
+        fakeTzdata.zones = serverTzdata.zones;
+        fakeTzdata.links = serverTzdata.links;
+
+        spyOn(ctrl._moment.tz, 'add');
+        getTzdataDeferred.resolve(serverTzdata);
+        scope.$digest();
+
+        expect(ctrl._moment.tz.add).toHaveBeenCalledWith(serverTzdata);
+    });
+
+});

--- a/client/app/scripts/superdesk-dashboard/world-clock/tests/tzdata_spec.js
+++ b/client/app/scripts/superdesk-dashboard/world-clock/tests/tzdata_spec.js
@@ -1,0 +1,53 @@
+
+/**
+* Module with tests for the tzdata factory
+*
+* @module tzdata factory tests
+*/
+describe('tzdata factory', function () {
+    'use strict';
+
+    var tzdata,
+        $httpBackend,
+        $rootScope;
+
+    beforeEach(module('superdesk.dashboard.world-clock'));
+
+    beforeEach(inject(function (_$httpBackend_, _$rootScope_, _tzdata_) {
+        tzdata = _tzdata_;
+        $httpBackend = _$httpBackend_;
+        $rootScope = _$rootScope_;
+    }));
+
+    it('requests correct time zone data from the server', function () {
+        var expectedUrl = new RegExp(
+            'superdesk-dashboard/world-clock/timezones-all.json$');
+
+        $httpBackend.expectGET(expectedUrl).respond({zones: {}, rules: {}});
+        $rootScope.$digest();
+
+        $httpBackend.verifyNoOutstandingExpectation();
+    });
+
+    it('stores fetched timezone data on sucess response', function () {
+        var response = {
+            zones: {
+                'Europe/Rome': ['1 - CET'],
+                'Australia/Sydney': ['10 ADN EST']
+            },
+            links: {
+                'Foo/Bar': []
+            }
+        };
+
+        tzdata.zones = null;
+        tzdata.links = null;
+        $httpBackend.whenGET(/.+/).respond(response);
+
+        $httpBackend.flush();
+        $rootScope.$digest();
+
+        expect(tzdata.zones).toEqual(response.zones);
+        expect(tzdata.links).toEqual(response.links);
+    });
+});

--- a/client/app/scripts/superdesk-dashboard/world-clock/tests/tzdata_spec.js
+++ b/client/app/scripts/superdesk-dashboard/world-clock/tests/tzdata_spec.js
@@ -50,4 +50,56 @@ describe('tzdata factory', function () {
         expect(tzdata.zones).toEqual(response.zones);
         expect(tzdata.links).toEqual(response.links);
     });
+
+    describe('getTzNames() method', function () {
+        it('returns an empty list if the data has not been fetched yet',
+            function () {
+                var result,
+                    serverResponse;
+
+                serverResponse = {
+                    zones: {
+                        'Europe/Rome': ['1 - CET'],
+                        'Australia/Sydney': ['10 ADN EST'],
+                        'Pacific/Auckland': ['13 NZDT']
+                    },
+                    links: {
+                        'Foo/Bar': []
+                    }
+                };
+                $httpBackend.whenGET(/.+/).respond(serverResponse);
+
+                // NOTE: no .flush(), simulate no response from the server yet
+
+                result = tzdata.getTzNames();
+                expect(result).toEqual([]);
+            }
+        );
+
+        it('returns a sorted list of available time zone names', function () {
+            var result,
+                serverResponse;
+
+            serverResponse = {
+                zones: {
+                    'Europe/Rome': ['1 - CET'],
+                    'Australia/Sydney': ['10 ADN EST'],
+                    'Pacific/Auckland': ['13 NZDT']
+                },
+                links: {
+                    'Foo/Bar': []
+                }
+            };
+            $httpBackend.whenGET(/.+/).respond(serverResponse);
+
+            $httpBackend.flush();
+            $rootScope.$digest();
+
+            result = tzdata.getTzNames();
+            expect(result).toEqual([
+                'Australia/Sydney', 'Europe/Rome',
+                'Foo/Bar', 'Pacific/Auckland'
+            ]);
+        });
+    });
 });

--- a/client/app/scripts/superdesk-dashboard/world-clock/world-clock.js
+++ b/client/app/scripts/superdesk-dashboard/world-clock/world-clock.js
@@ -23,6 +23,26 @@ define([
         .factory('tzdata', ['$resource', function ($resource) {
             var filename = require.toUrl('./timezones-all.json'),
                 tzResource = $resource(filename);
+
+            /**
+             * Returns a sorted list of all time zone names. If time zone data
+             * has not yet been fetched from the server, an empty list is
+             * returned.
+             * To determine whether or not the data has been fetched yet, the
+             * $promise property should be examined.
+             *
+             * @method getTzNames
+             * @return {Array} a list of time zone names
+             */
+            tzResource.prototype.getTzNames = function () {
+                return _.union(
+                    _.keys(this.zones),
+                    _.keys(this.links)
+                ).sort();
+            };
+
+            // return an array that will contain the fetched data when
+            // it arrives from the server
             return tzResource.get();
         }])
 
@@ -48,10 +68,7 @@ define([
             $scope.availableZones = [];
 
             tzdata.$promise.then(function () {
-                $scope.availableZones = _.union(
-                    _.keys(tzdata.zones),
-                    _.keys(tzdata.links)
-                );
+                $scope.availableZones = tzdata.getTzNames();
             });
 
             $scope.notify = function(action, zone) {

--- a/client/app/scripts/superdesk-ingest/ingest.spec.js
+++ b/client/app/scripts/superdesk-ingest/ingest.spec.js
@@ -186,15 +186,18 @@ describe('ingest', function() {
             };
             fakeTzData.zones = serverTzData.zones;
             fakeTzData.links = serverTzData.links;
+            fakeTzData.getTzNames = function () {
+                return ['Australia/Sydney', 'Europe/Rome', 'Foo/Bar'];
+            };
 
             isoScope.timeZones = [];
 
             getTzDataDeferred.resolve(serverTzData);
             isoScope.$digest();
 
-            expect(isoScope.timeZones).toEqual([
-                'Europe/Rome', 'Australia/Sydney', 'Foo/Bar'
-            ]);
+            expect(isoScope.timeZones).toEqual(
+                ['Australia/Sydney', 'Europe/Rome', 'Foo/Bar']
+            );
         });
 
         describe('scope\'s searchTimeZones() method', function () {

--- a/client/app/scripts/superdesk-ingest/ingest.spec.js
+++ b/client/app/scripts/superdesk-ingest/ingest.spec.js
@@ -111,4 +111,35 @@ describe('ingest', function() {
         });
     });
 
+    describe('sdIngestRoutingSchedule directive', function () {
+        var isoScope;  // the directive's isolate scope
+
+        beforeEach(module('superdesk.ingest'));
+        beforeEach(module('templates'));
+
+        beforeEach(module(function($provide) {
+            $provide.constant('config', {
+                server: {
+                    timezone: 'FOO (UTC+3.141592)'
+                }
+            });
+        }));
+
+        beforeEach(inject(function ($compile, $rootScope) {
+            var element,
+                html = '<div sd-ingest-routing-schedule></div>',
+                scope;
+
+            scope = $rootScope.$new();
+            element = $compile(html)(scope);
+            scope.$digest();
+
+            isoScope = element.isolateScope();
+        }));
+
+        it('initializes server timezone in scope', function () {
+            expect(isoScope.serverTimezone).toEqual('FOO (UTC+3.141592)');
+        });
+    });
+
 });

--- a/client/app/scripts/superdesk-ingest/ingest.spec.js
+++ b/client/app/scripts/superdesk-ingest/ingest.spec.js
@@ -124,12 +124,6 @@ describe('ingest', function() {
                 'sdWeekdayPicker', 'sdTimepickerAlt', 'sdTypeahead'
             ];
 
-            $provide.constant('config', {
-                server: {
-                    timezone: 'FOO (UTC+3.141592)'
-                }
-            });
-
             fakeTzData = {
                 $promise: null,
                 zones: {},
@@ -169,10 +163,6 @@ describe('ingest', function() {
                 schedule: {}
             };
         }));
-
-        it('initializes server timezone in scope', function () {
-            expect(isoScope.serverTimezone).toEqual('FOO (UTC+3.141592)');
-        });
 
         it('initially clears the time zone search term', function () {
             expect(isoScope.tzSearchTerm).toEqual('');

--- a/client/app/scripts/superdesk-ingest/module.js
+++ b/client/app/scripts/superdesk-ingest/module.js
@@ -1031,11 +1031,14 @@ define([
         };
     }
 
-    IngestRoutingSchedule.$inject = [];
-    function IngestRoutingSchedule() {
+    IngestRoutingSchedule.$inject = ['config'];
+    function IngestRoutingSchedule(config) {
         return {
             scope: {rule: '='},
-            templateUrl: 'scripts/superdesk-ingest/views/settings/ingest-routing-schedule.html'
+            templateUrl: 'scripts/superdesk-ingest/views/settings/ingest-routing-schedule.html',
+            link: function (scope, element, attrs) {
+                scope.serverTimezone = config.server.timezone;
+            }
         };
     }
 

--- a/client/app/scripts/superdesk-ingest/module.js
+++ b/client/app/scripts/superdesk-ingest/module.js
@@ -1055,10 +1055,7 @@ define([
                 scope.matchingTimeZones = [];
 
                 tzdata.$promise.then(function () {
-                    scope.timeZones = _.union(
-                        _.keys(tzdata.zones),
-                        _.keys(tzdata.links)
-                    );
+                    scope.timeZones = tzdata.getTzNames();
                 });
 
                 /**

--- a/client/app/scripts/superdesk-ingest/module.js
+++ b/client/app/scripts/superdesk-ingest/module.js
@@ -1031,13 +1031,86 @@ define([
         };
     }
 
-    IngestRoutingSchedule.$inject = ['config'];
-    function IngestRoutingSchedule(config) {
+    /**
+     * @memberof superdesk.ingest
+     * @ngdoc directive
+     * @name sdIngestRoutingSchedule
+     * @description
+     *   Creates the Schedule section (tab) of the routing rule edit form.
+     */
+    IngestRoutingSchedule.$inject = ['config', 'tzdata'];
+    function IngestRoutingSchedule(config, tzdata) {
         return {
-            scope: {rule: '='},
+            scope: {
+                rule: '='  // the routing rule whose schedule is being edited
+            },
             templateUrl: 'scripts/superdesk-ingest/views/settings/ingest-routing-schedule.html',
             link: function (scope, element, attrs) {
+                // TODO: remove? or rename to default timezone?
                 scope.serverTimezone = config.server.timezone;
+
+                scope.timeZones = [];     // all time zones to choose from
+                scope.tzSearchTerm = '';  // the current time zone search term
+
+                // filtered time zone list containing only those that match
+                // user-provided search term
+                scope.matchingTimeZones = [];
+
+                tzdata.$promise.then(function () {
+                    scope.timeZones = _.union(
+                        _.keys(tzdata.zones),
+                        _.keys(tzdata.links)
+                    );
+                });
+
+                /**
+                 * Sets the list of time zones to select from to only those
+                 * that contain the given search term (case-insensitive).
+                 * If the search term is empty, it results in an empty list.
+                 *
+                 * @method searchTimeZones
+                 * @param {string} searchTerm
+                 */
+                scope.searchTimeZones = function (searchTerm) {
+                    var termLower;
+
+                    scope.tzSearchTerm = searchTerm;
+
+                    if (!searchTerm) {
+                        scope.matchingTimeZones = [];
+                        return;
+                    }
+
+                    termLower = searchTerm.toLowerCase();
+                    scope.matchingTimeZones = _.filter(
+                        scope.timeZones,
+                        function (item) {
+                            return (item.toLowerCase().indexOf(termLower) >= 0);
+                        }
+                    );
+                };
+
+                /**
+                 * Sets the time zone of the routing rule's schedule and resets
+                 * the current time zone search term.
+                 *
+                 * @method selectTimeZone
+                 * @param {string} timeZone - name of the time zone to select
+                 */
+                scope.selectTimeZone = function (timeZone) {
+                    scope.rule.schedule.time_zone = timeZone;
+                    scope.tzSearchTerm = '';
+                };
+
+                /**
+                 * Clears the currently selected time zone of the routing
+                 * rule's schedule.
+                 *
+                 * @method clearSelectedTimeZone
+                 */
+                scope.clearSelectedTimeZone = function () {
+                    scope.rule.schedule.time_zone = null;
+                };
             }
         };
     }

--- a/client/app/scripts/superdesk-ingest/module.js
+++ b/client/app/scripts/superdesk-ingest/module.js
@@ -1038,16 +1038,14 @@ define([
      * @description
      *   Creates the Schedule section (tab) of the routing rule edit form.
      */
-    IngestRoutingSchedule.$inject = ['config', 'tzdata'];
-    function IngestRoutingSchedule(config, tzdata) {
+    IngestRoutingSchedule.$inject = ['tzdata'];
+    function IngestRoutingSchedule(tzdata) {
         return {
             scope: {
                 rule: '='  // the routing rule whose schedule is being edited
             },
             templateUrl: 'scripts/superdesk-ingest/views/settings/ingest-routing-schedule.html',
             link: function (scope, element, attrs) {
-                // TODO: remove? or rename to default timezone?
-                scope.serverTimezone = config.server.timezone;
 
                 scope.timeZones = [];     // all time zones to choose from
                 scope.tzSearchTerm = '';  // the current time zone search term

--- a/client/app/scripts/superdesk-ingest/styles/settings.less
+++ b/client/app/scripts/superdesk-ingest/styles/settings.less
@@ -187,6 +187,28 @@
 		width: 60%;
 		float: left;
 		margin-right: 10px;
+		.item-list {
+			list-style-type: none;
+			padding: 0.5em 0em;
+			li {
+				padding: 0.1em 0.75em;
+				color: #333;
+				font-size: 14px;
+				.text-normal();
+				cursor: pointer;
+				&:hover {
+					background-color: #5e5e5e;
+					color: white;
+				}
+				&.no-match {
+					cursor: default;
+					&:hover {
+						background-color: inherit;
+						color: inherit;
+					}
+				}
+			}
+		}
 	}
 	.general-tab {
 		.summary {

--- a/client/app/scripts/superdesk-ingest/tests/sdIngestRoutingContent.spec.js
+++ b/client/app/scripts/superdesk-ingest/tests/sdIngestRoutingContent.spec.js
@@ -9,11 +9,22 @@ describe('sdIngestRoutingContent directive', function () {
 
     var contentFilters,
         fakeGetFilters,
+        fakeTzData,
+        getTzDataDeferred,
         scope;
 
     beforeEach(module('templates'));
     beforeEach(module('superdesk.ingest'));
     beforeEach(module('superdesk.content_filters'));
+
+    beforeEach(module(function($provide) {
+        fakeTzData = {
+            $promise: null,
+            zones: {},
+            links: {}
+        };
+        $provide.constant('tzdata', fakeTzData);
+    }));
 
     beforeEach(inject(function ($compile, $rootScope, $q, _contentFilters_) {
         var html;
@@ -23,6 +34,9 @@ describe('sdIngestRoutingContent directive', function () {
         fakeGetFilters = $q.defer();
         spyOn(contentFilters, 'getAllContentFilters')
             .and.returnValue(fakeGetFilters.promise);
+
+        getTzDataDeferred = $q.defer();
+        fakeTzData.$promise = getTzDataDeferred.promise;
 
         scope = $rootScope.$new();
         html = '<div sd-ingest-routing-content></div>';

--- a/client/app/scripts/superdesk-ingest/views/settings/ingest-routing-schedule.html
+++ b/client/app/scripts/superdesk-ingest/views/settings/ingest-routing-schedule.html
@@ -6,7 +6,7 @@
     </div>
 
     <div class="field">
-        <label translate>Start Time</label>
+        <label translate>Start Time (inclusive)</label>
         <span
             sd-timepicker-alt
             no-utc-convert="true"
@@ -14,7 +14,7 @@
     </div>
 
     <div class="field">
-        <label translate>End Time</label>
+        <label translate>End Time (exclusive)</label>
         <span
             sd-timepicker-alt
             no-utc-convert="true"

--- a/client/app/scripts/superdesk-ingest/views/settings/ingest-routing-schedule.html
+++ b/client/app/scripts/superdesk-ingest/views/settings/ingest-routing-schedule.html
@@ -35,6 +35,7 @@
                     ng-repeat="tz in matchingTimeZones track by tz"
                     >{{ ::tz }}</li>
                 <li ng-show="tzSearchTerm && matchingTimeZones.length === 0"
+                    class="no-match"
                     translate>(no matches)</li>
             </ul>
 

--- a/client/app/scripts/superdesk-ingest/views/settings/ingest-routing-schedule.html
+++ b/client/app/scripts/superdesk-ingest/views/settings/ingest-routing-schedule.html
@@ -15,4 +15,8 @@
         <span sd-timepicker-alt data-model="rule.schedule.hour_of_day_to"></span>
     </div>
 
+    <div class="discreet">
+        <span translate>Times are in server's local timezone</span>:
+        {{:: serverTimezone}}
+    </div>
 </div>

--- a/client/app/scripts/superdesk-ingest/views/settings/ingest-routing-schedule.html
+++ b/client/app/scripts/superdesk-ingest/views/settings/ingest-routing-schedule.html
@@ -7,16 +7,53 @@
 
     <div class="field">
         <label translate>Start Time</label>
-        <span sd-timepicker-alt data-model="rule.schedule.hour_of_day_from"></span>
+        <span
+            sd-timepicker-alt
+            no-utc-convert="true"
+            data-model="rule.schedule.hour_of_day_from"></span>
     </div>
 
     <div class="field">
         <label translate>End Time</label>
-        <span sd-timepicker-alt data-model="rule.schedule.hour_of_day_to"></span>
+        <span
+            sd-timepicker-alt
+            no-utc-convert="true"
+            data-model="rule.schedule.hour_of_day_to"></span>
     </div>
 
-    <div class="discreet">
-        <span translate>Times are in server's local timezone</span>:
-        {{:: serverTimezone}}
+    <div class="field">
+        <label translate>Time Zone</label>
+        <div class="control" ng-hide="rule.schedule.time_zone">
+            <ul sd-typeahead
+                items="matchingTimeZones"
+                term="tzSearchTerm"
+                search="searchTimeZones(term)"
+                select="selectTimeZone(item)"
+                always-visible="tzSearchTerm">
+                <li
+                    typeahead-item="tz"
+                    ng-repeat="tz in matchingTimeZones track by tz"
+                    >{{ ::tz }}</li>
+                <li ng-show="tzSearchTerm && matchingTimeZones.length === 0"
+                    translate>(no matches)</li>
+            </ul>
+
+            <p class="discreet" translate>
+                If not set, the UTC+0 time zone is assumed.
+            </p>
+        </div>
+
+        <ul class="pills-list clearfix" ng-show="rule.schedule.time_zone">
+            <li class="pull-left">
+                <div class="name right-pad">{{rule.schedule.time_zone}}</div>
+                <div class="actions">
+                    <button
+                        ng-click="clearSelectedTimeZone()"
+                        title="{{:: 'Clear' | translate }}"
+                        ><i class="icon-trash"></i></button>
+                </div>
+            </li>
+        </ul>
     </div>
+
 </div>

--- a/client/app/scripts/superdesk/ui/tests/ui_spec.js
+++ b/client/app/scripts/superdesk/ui/tests/ui_spec.js
@@ -8,36 +8,40 @@ describe('superdesk ui', function() {
 
     var datetimeHelper;
 
-    beforeEach(inject(function (_datetimeHelper_) {
-        datetimeHelper = _datetimeHelper_;
-    }));
+    describe('datetimeHelper service', function () {
+        beforeEach(inject(function (_datetimeHelper_) {
+            datetimeHelper = _datetimeHelper_;
+        }));
 
-    it('should have datetimeHelper service be defined', function () {
-        expect(datetimeHelper).toBeDefined();
-    });
+        it('should be defined', function () {
+            expect(datetimeHelper).toBeDefined();
+        });
 
-    it('should validate time', function() {
-        expect(datetimeHelper.isValidTime('15:14:13')).toBe(true);
-        expect(datetimeHelper.isValidTime('00:00:00')).toBe(true);
-        expect(datetimeHelper.isValidTime('23:00:11')).toBe(true);
-        expect(datetimeHelper.isValidTime('15:14:')).toBe(false);
-        expect(datetimeHelper.isValidTime('15:14')).toBe(false);
-        expect(datetimeHelper.isValidTime('15:14:1o')).toBe(false);
-        expect(datetimeHelper.isValidTime('24:01:15')).toBe(false);
-    });
+        it('should validate time', function() {
+            expect(datetimeHelper.isValidTime('15:14:13')).toBe(true);
+            expect(datetimeHelper.isValidTime('00:00:00')).toBe(true);
+            expect(datetimeHelper.isValidTime('23:00:11')).toBe(true);
+            expect(datetimeHelper.isValidTime('15:14:')).toBe(false);
+            expect(datetimeHelper.isValidTime('15:14')).toBe(false);
+            expect(datetimeHelper.isValidTime('15:14:1o')).toBe(false);
+            expect(datetimeHelper.isValidTime('24:01:15')).toBe(false);
+        });
 
-    it('should validate date', function() {
-        expect(datetimeHelper.isValidDate('23/09/2015')).toBe(true);
-        expect(datetimeHelper.isValidDate('23/09/15')).toBe(false);
-        expect(datetimeHelper.isValidDate('23/O9/2015')).toBe(false);
-        expect(datetimeHelper.isValidDate('09/23/2015')).toBe(false);
-        expect(datetimeHelper.isValidDate('00/09/2015')).toBe(false);
-        expect(datetimeHelper.isValidDate('01/01/2015')).toBe(true);
-        expect(datetimeHelper.isValidDate('1/1/15')).toBe(false);
+        it('should validate date', function() {
+            expect(datetimeHelper.isValidDate('23/09/2015')).toBe(true);
+            expect(datetimeHelper.isValidDate('23/09/15')).toBe(false);
+            expect(datetimeHelper.isValidDate('23/O9/2015')).toBe(false);
+            expect(datetimeHelper.isValidDate('09/23/2015')).toBe(false);
+            expect(datetimeHelper.isValidDate('00/09/2015')).toBe(false);
+            expect(datetimeHelper.isValidDate('01/01/2015')).toBe(true);
+            expect(datetimeHelper.isValidDate('1/1/15')).toBe(false);
+        });
     });
 
     describe('sd-timepicker-alt directive', function() {
-        var $compile,
+        var getTzdataDeferred,
+            tzdataMock = {},  // mocked tzdata service
+            $compile,
             $rootScope;
 
         function format(num) {
@@ -76,9 +80,21 @@ describe('superdesk ui', function() {
             return $element;
         }
 
-        beforeEach(inject(function(_$compile_, _$rootScope_) {
+        // mock the tzdata service that gets injected into the directive
+        beforeEach(function () {
+            module(function ($provide) {
+                $provide.value('tzdata', tzdataMock);
+            });
+        });
+
+        beforeEach(inject(function(_$compile_, _$rootScope_, $q) {
             $compile = _$compile_;
             $rootScope = _$rootScope_;
+
+            getTzdataDeferred = $q.defer();
+            tzdataMock.$promise = getTzdataDeferred.promise;
+            tzdataMock.zones = {};
+            tzdataMock.links = {};
         }));
 
         it('can render local time and set utc time', function() {
@@ -124,10 +140,33 @@ describe('superdesk ui', function() {
                 isoScope = $elem.isolateScope();
             });
 
-            it('initializes scope variables to model values', function () {
+            it('initializes time variables to model values', function () {
                 expect(isoScope.hours).toEqual(18);
                 expect(isoScope.minutes).toEqual(50);
                 expect(parentModel.schedule.at).toEqual('1850');
+            });
+
+            it('initializes the list of time zone in scope', function () {
+                var expectedList,
+                    fetchedTzData;
+
+                fetchedTzData = {
+                    zones: {
+                        'Europe/Rome': ['1 - CET'],
+                        'Australia/Sydney': ['10 ADN EST']
+                    },
+                    links: {
+                        'Foo/Bar': []
+                    }
+                };
+                tzdataMock.zones = fetchedTzData.zones;
+                tzdataMock.links = fetchedTzData.links;
+
+                getTzdataDeferred.resolve(fetchedTzData);
+                isoScope.$digest();
+
+                expectedList = ['Europe/Rome', 'Australia/Sydney', 'Foo/Bar'];
+                expect(isoScope.timeZones).toEqual(expectedList);
             });
 
             describe('setHours() scope method', function () {

--- a/client/app/scripts/superdesk/ui/tests/ui_spec.js
+++ b/client/app/scripts/superdesk/ui/tests/ui_spec.js
@@ -97,6 +97,38 @@ describe('superdesk ui', function() {
             tzdataMock.links = {};
         }));
 
+        it('sets the hasValue flag if the model has a value', function () {
+            var elem,
+                isoScope,
+                parentModel;
+
+            parentModel = {
+                schedule: {at: '0000'}
+            };
+
+            elem = compileDirective(parentModel);
+            isoScope = elem.isolateScope();
+
+            expect(isoScope.hasValue).toBe(true);
+        });
+
+        it('clears the hasValue flag if the model does not have a value',
+            function () {
+                var elem,
+                    isoScope,
+                    parentModel;
+
+                parentModel = {
+                    schedule: {at: ''}
+                };
+
+                elem = compileDirective(parentModel);
+                isoScope = elem.isolateScope();
+
+                expect(isoScope.hasValue).toBe(false);
+            }
+        );
+
         it('can render local time and set utc time', function() {
             var now = new Date();
 
@@ -120,6 +152,40 @@ describe('superdesk ui', function() {
             iscope.setMinutes(now.getMinutes());
             expect(iscope.minutes).toBe(now.getMinutes());
             expect(iscope.model.substr(2, 2)).toBe(format(now.getUTCMinutes()));
+        });
+
+        describe('clearValue() scope method', function () {
+            var isoScope;
+
+            beforeEach(function () {
+                var elem,
+                    parentModel;
+
+                parentModel = {
+                    schedule: {at: '0000'}
+                };
+
+                elem = compileDirective(parentModel);
+                isoScope = elem.isolateScope();
+            });
+
+            it('clears the hasValue flag', function () {
+                isoScope.hasValue = true;
+                isoScope.clearValue();
+                expect(isoScope.hasValue).toBe(false);
+            });
+
+            it('resets the model value', function () {
+                isoScope.hours = 10;
+                isoScope.minutes = 20;
+                isoScope.model = '1020';
+
+                isoScope.clearValue();
+
+                expect(isoScope.hours).toEqual(0);
+                expect(isoScope.minutes).toEqual(0);
+                expect(isoScope.model).toEqual('');
+            });
         });
 
         describe('converting to UTC disabled', function () {
@@ -176,6 +242,12 @@ describe('superdesk ui', function() {
                     expect(isoScope.hours).toEqual(22);
                     expect(isoScope.model).toEqual('2250');
                 });
+
+                it('sets the hasValue flag', function () {
+                    isoScope.hasValue = false;
+                    isoScope.setHours(1);
+                    expect(isoScope.hasValue).toBe(true);
+                });
             });
 
             describe('setMinutes() scope method', function () {
@@ -184,6 +256,12 @@ describe('superdesk ui', function() {
                     isoScope.setMinutes(37);
                     expect(isoScope.minutes).toEqual(37);
                     expect(isoScope.model).toEqual('1837');
+                });
+
+                it('sets the hasValue flag', function () {
+                    isoScope.hasValue = false;
+                    isoScope.setMinutes(1);
+                    expect(isoScope.hasValue).toBe(true);
                 });
             });
         });

--- a/client/app/scripts/superdesk/ui/tests/ui_spec.js
+++ b/client/app/scripts/superdesk/ui/tests/ui_spec.js
@@ -227,11 +227,14 @@ describe('superdesk ui', function() {
                 };
                 tzdataMock.zones = fetchedTzData.zones;
                 tzdataMock.links = fetchedTzData.links;
+                tzdataMock.getTzNames = function () {
+                    return ['Australia/Sydney', 'Europe/Rome', 'Foo/Bar'];
+                };
 
                 getTzdataDeferred.resolve(fetchedTzData);
                 isoScope.$digest();
 
-                expectedList = ['Europe/Rome', 'Australia/Sydney', 'Foo/Bar'];
+                expectedList = ['Australia/Sydney', 'Europe/Rome', 'Foo/Bar'];
                 expect(isoScope.timeZones).toEqual(expectedList);
             });
 

--- a/client/app/scripts/superdesk/ui/ui.js
+++ b/client/app/scripts/superdesk/ui/ui.js
@@ -824,7 +824,21 @@ define([
     }
 
     /**
-     * Timepicker directive saving utc time to model but rendering local time.
+     * @memberof superdesk.ui
+     * @ngdoc directive
+     * @name sdTimepickerAlt
+     * @description
+     *   Timepicker directive saving utc time to model by defualt, and
+     *   rendering local time.
+     *
+     *   Optionally, saving the UTC time to the model can be disabled by
+     *   setting the no-utc-convert="true" attribute on the directive's DOM
+     *   element. If this option is set, local time will be stored in the model
+     *   (i.e. as picked by the user in the UI).
+     *
+     *   NOTE: the no-utc-convert attribute is only evaluated once, in the
+     *   directive linking phase. Subsequent changes of the attribute value
+     *   have no effect.
      */
     function TimepickerAltDirective() {
         var STEP = 5;
@@ -839,11 +853,19 @@ define([
         }
 
         return {
-            scope: {model: '='},
+            scope: {
+                model: '=',
+                noUtcConvert: '@'
+            },
             templateUrl: 'scripts/superdesk/ui/views/sd-timepicker-alt.html',
             link: function(scope) {
 
-                var d = new Date();
+                var d = new Date(),
+                    hours,
+                    minutes,
+                    utcConvert;
+
+                utcConvert = (scope.noUtcConvert || '').toLowerCase() !== 'true';
 
                 scope.open = false;
                 scope.hoursRange = range(0, 23);
@@ -877,8 +899,16 @@ define([
                 };
 
                 if (scope.model) {
-                    d.setUTCHours(scope.model.substr(0, 2));
-                    d.setUTCMinutes(scope.model.substr(2, 2));
+                    hours = scope.model.substr(0, 2);
+                    minutes = scope.model.substr(2, 2);
+
+                    if (utcConvert) {
+                        d.setUTCHours(hours);
+                        d.setUTCMinutes(minutes);
+                    } else {
+                        d.setHours(hours);
+                        d.setMinutes(minutes);
+                    }
                 } else {
                     d.setHours(0);
                     d.setMinutes(0);
@@ -892,7 +922,7 @@ define([
                 function update() {
                     scope.hours = d.getHours();
                     scope.minutes = d.getMinutes();
-                    scope.model = utc();
+                    scope.model = utcConvert ? utc() : noUtcTime(d);
                 }
 
                 /**
@@ -904,6 +934,20 @@ define([
                     var hours = d.getUTCHours().toString();
                     var minutes = d.getUTCMinutes().toString();
                     return ('00' + hours).slice(-2) + ('00' + minutes).slice(-2);
+                }
+
+                /**
+                 * Returns the '%H%M' time string (i.e. double-digit hour and
+                 * minute parts) from the given Date object using local time.
+                 *
+                 * @function noUtcTime
+                 * @param {Date} d
+                 * @return {string}
+                 */
+                function noUtcTime(d) {
+                    var hours = ('00' + d.getHours()).slice(-2),
+                        minutes = ('00' + d.getMinutes()).slice(-2);
+                    return hours + minutes;
                 }
             }
         };

--- a/client/app/scripts/superdesk/ui/ui.js
+++ b/client/app/scripts/superdesk/ui/ui.js
@@ -873,10 +873,7 @@ define([
                 scope.minutesRange = range(0, 59, STEP);
 
                 tzdata.$promise.then(function () {
-                    scope.timeZones = _.union(
-                        _.keys(tzdata.zones),
-                        _.keys(tzdata.links)
-                    );
+                    scope.timeZones = tzdata.getTzNames();
                 });
 
                 if (scope.model) {

--- a/client/app/scripts/superdesk/ui/ui.js
+++ b/client/app/scripts/superdesk/ui/ui.js
@@ -879,33 +879,6 @@ define([
                     );
                 });
 
-                /**
-                 * Set local hours
-                 *
-                 * @param {int} hours
-                 */
-                scope.setHours = function(hours) {
-                    d.setHours(hours);
-                    update();
-                };
-
-                /**
-                 * Set local minutes
-                 *
-                 * @param {int} minutes
-                 */
-                scope.setMinutes = function(minutes) {
-                    d.setMinutes(minutes);
-                    update();
-                };
-
-                /**
-                 * Toggle time picker on/off
-                 */
-                scope.toggle = function() {
-                    scope.open = !scope.open;
-                };
-
                 if (scope.model) {
                     hours = scope.model.substr(0, 2);
                     minutes = scope.model.substr(2, 2);
@@ -922,15 +895,65 @@ define([
                     d.setMinutes(0);
                 }
 
+                // whether or not the model actually has a value
+                scope.hasValue = !!scope.model;
+
+                /**
+                 * Set local hours
+                 *
+                 * @param {int} hours
+                 */
+                scope.setHours = function(hours) {
+                    d.setHours(hours);
+                    scope.hasValue = true;
+                    update();
+                };
+
+                /**
+                 * Set local minutes
+                 *
+                 * @param {int} minutes
+                 */
+                scope.setMinutes = function(minutes) {
+                    d.setMinutes(minutes);
+                    scope.hasValue = true;
+                    update();
+                };
+
+                /**
+                 * Toggle time picker on/off
+                 */
+                scope.toggle = function() {
+                    scope.open = !scope.open;
+                };
+
+                /**
+                 * Clears the model value (marking it as "no value selected").
+                 *
+                 * @method clearValue
+                 */
+                scope.clearValue = function () {
+                    d.setHours(0);
+                    d.setMinutes(0);
+                    scope.hasValue = false;
+                    update();
+                }
+
                 update();
 
                 /**
                  * Update scope using local time and model using utc time
                  */
                 function update() {
-                    scope.hours = d.getHours();
-                    scope.minutes = d.getMinutes();
-                    scope.model = utcConvert ? utc() : noUtcTime(d);
+                    if (scope.hasValue) {
+                        scope.hours = d.getHours();
+                        scope.minutes = d.getMinutes();
+                        scope.model = utcConvert ? utc() : noUtcTime(d);
+                    } else {
+                        scope.hours = 0;
+                        scope.minutes = 0;
+                        scope.model = '';
+                    }
                 }
 
                 /**

--- a/client/app/scripts/superdesk/ui/ui.js
+++ b/client/app/scripts/superdesk/ui/ui.js
@@ -840,7 +840,8 @@ define([
      *   directive linking phase. Subsequent changes of the attribute value
      *   have no effect.
      */
-    function TimepickerAltDirective() {
+    TimepickerAltDirective.$inject = ['tzdata'];
+    function TimepickerAltDirective(tzdata) {
         var STEP = 5;
 
         function range(min, max, step) {
@@ -870,6 +871,13 @@ define([
                 scope.open = false;
                 scope.hoursRange = range(0, 23);
                 scope.minutesRange = range(0, 59, STEP);
+
+                tzdata.$promise.then(function () {
+                    scope.timeZones = _.union(
+                        _.keys(tzdata.zones),
+                        _.keys(tzdata.links)
+                    );
+                });
 
                 /**
                  * Set local hours
@@ -1044,7 +1052,7 @@ define([
         };
     }
 
-    return angular.module('superdesk.ui', [])
+    return angular.module('superdesk.ui', ['superdesk.dashboard.world-clock'])
 
         .directive('sdShadow', ShadowDirective)
         .directive('sdAutoHeight', require('./autoheight-directive'))

--- a/client/app/scripts/superdesk/ui/ui.js
+++ b/client/app/scripts/superdesk/ui/ui.js
@@ -937,7 +937,7 @@ define([
                     d.setMinutes(0);
                     scope.hasValue = false;
                     update();
-                }
+                };
 
                 update();
 

--- a/client/app/scripts/superdesk/ui/views/sd-timepicker-alt.html
+++ b/client/app/scripts/superdesk/ui/views/sd-timepicker-alt.html
@@ -1,6 +1,18 @@
 <div>
-    <span class="input-small">{{ hours|leadingZero }}:{{ minutes|leadingZero }}</span>
+    <span
+        class="input-small"
+        ng-show="hasValue"
+        >{{ hours|leadingZero }}:{{ minutes|leadingZero }}</span>
+    <span
+        class="input-small"
+        ng-show="!hasValue">--- : ---</span>
+
     <button class="btn btn-default" ng-click="toggle()"><i class="icon-time"></i></button>
+    <button
+        class="btn btn-default"
+        ng-show="hasValue"
+        title="{{:: 'Clear Value' | translate}}"
+        ng-click="clearValue()"><i class="icon-remove"></i></button>
 </div>
 
 <div class="timepicker-popup" ng-show="open" ng-keydown="keydown({e: $event})" tabindex="0">

--- a/client/spec/dashboard_spec.js
+++ b/client/spec/dashboard_spec.js
@@ -25,8 +25,8 @@ describe('dashboard', function() {
 
     it('add multiple monitoring widgets', function() {
         dashboard.showDashboardSettings();
-        dashboard.addWidget(4);
-        dashboard.addWidget(4);
+        dashboard.addWidget(3);  // the monitoring widget
+        dashboard.addWidget(3);  // the monitoring widget
         dashboard.doneAction();
         expect(dashboard.getWidgets().count()).toBe(2);
         expect(dashboard.getGroups(0).count()).toBe(4);
@@ -53,7 +53,7 @@ describe('dashboard', function() {
 
     it('configure a label for the view', function() {
         dashboard.showDashboardSettings();
-        dashboard.addWidget(4);
+        dashboard.addWidget(3);  // the monitoring widget
         dashboard.doneAction();
 
         dashboard.showMonitoringSettings(0);

--- a/client/spec/helpers/pages.js
+++ b/client/spec/helpers/pages.js
@@ -93,6 +93,13 @@ function IngestDashboard() {
  *
  */
 function IngestSettings() {
+    var daysButonsBox = $('.day-filter-box');
+
+    this.saveBtn = element(by.buttonText('Save'));
+
+    // the main input box for setting the routing scheme's name
+    this.schemeNameInput = $('[placeholder="Scheme name"]');
+
     // the main navigation tabs on the ingest settings page
     this.tabs = {
         routingTab: element(by.buttonText('Routing'))
@@ -105,6 +112,9 @@ function IngestSettings() {
     // the settings pane for routing rule (in a modal)
     this.routingRuleSettings = {
         tabAction: element(by.buttonText('Action')),
+        tabSchedule: element(by.buttonText('Schedule')),
+
+        ruleNameInput: $('[placeholder="Rule name"]'),
 
         // NOTE: several elements appear twice - under the FETCH settings
         // and under the PUBLISH settings, hence the need to locate them all
@@ -117,6 +127,19 @@ function IngestSettings() {
         showPublishBtn: $$('.icon-plus-small').get(1),
         publishDeskList: element.all(by.name('desk')).get(1),
         publishStageList: element.all(by.name('stage')).get(1),
-        publishMacroList: element.all(by.name('macro')).get(1)
+        publishMacroList: element.all(by.name('macro')).get(1),
+
+        daysButtons: {
+            mon: daysButonsBox.element(by.buttonText('Monday')),
+            tue: daysButonsBox.element(by.buttonText('Tuesday')),
+            wed: daysButonsBox.element(by.buttonText('Wednesday')),
+            thu: daysButonsBox.element(by.buttonText('Thursday')),
+            fri: daysButonsBox.element(by.buttonText('Friday')),
+            sat: daysButonsBox.element(by.buttonText('Saturday')),
+            sun: daysButonsBox.element(by.buttonText('Sunday'))
+        },
+
+        timezoneInput: $('[term="tzSearchTerm"]').element(by.model('term')),
+        timezoneList: $('.item-list').all(by.tagName('li'))
     };
 }

--- a/client/spec/helpers/utils.js
+++ b/client/spec/helpers/utils.js
@@ -9,6 +9,7 @@ module.exports.waitForSuperdesk = waitForSuperdesk;
 module.exports.nav = nav;
 module.exports.getListOption = getListOption;
 module.exports.ctrlKey = ctrlKey;
+module.exports.assertToastMsg = assertToastMsg;
 
 // construct url from uri and base url
 exports.constructUrl = function(base, uri) {
@@ -177,4 +178,29 @@ function getListOption(dropdown, n) {
 function ctrlKey(key) {
     var Key = protractor.Key;
     browser.actions().sendKeys(Key.chord(Key.CONTROL, key)).perform();
+}
+
+/**
+ * Asserts that a toast message of a particular type has appeared with its
+ * message containing the given string.
+ *
+ * A workaround with setting the ignoreSyncronization flag is needed due to a
+ * protractor issue that does not find DOM elements dynamically displayed in a
+ * $timeout callback. More info here:
+ *    http://stackoverflow.com/questions/25062748/
+ *           testing-the-contents-of-a-temporary-element-with-protractor
+ *
+ * @param {string} type - type of the toast notificiation ("info", "success" or
+ *   "error")
+ * @param {string} msg - a string expected to be present in the toast message
+ */
+function assertToastMsg(type, msg) {
+    var cssSelector = '.notification-holder .alert-' + type,
+        toast = $(cssSelector);
+
+    browser.sleep(500);
+    browser.ignoreSynchronization = true;
+    expect(toast.getText()).toContain(msg);
+    browser.sleep(500);
+    browser.ignoreSynchronization = false;
 }

--- a/client/spec/ingest_settings_spec.js
+++ b/client/spec/ingest_settings_spec.js
@@ -68,4 +68,39 @@ describe('Ingest Settings: routing scheme', function() {
         expect(stageList.$('option:checked').getAttribute('value')).toEqual('');
         expect(macroList.$('option:checked').getAttribute('value')).toEqual('');
     });
+
+    it('contains the Schedule tab for editing routing schedules', function () {
+        var ruleSettings,
+            tzOption;
+
+        // Open the routing scheme edit modal under the Routing tab and set
+        // routing scheme name.
+        // Then add a new routing rule and set its name, and open the Schedule
+        // settings pane
+        ingestSettings.tabs.routingTab.click();
+        ingestSettings.newSchemeBtn.click();
+        ingestSettings.schemeNameInput.sendKeys('My Routing Scheme');
+
+        ruleSettings = ingestSettings.routingRuleSettings;
+        ingestSettings.newRoutingRuleBtn.click();
+        ruleSettings.ruleNameInput.sendKeys('Routing Rule 1');
+
+        ruleSettings.tabSchedule.click();
+
+        // one the Schedule tab now, set a few scheduling options...
+        // de-select Saturday and Sunday
+        ruleSettings.daysButtons.sat.click();
+        ruleSettings.daysButtons.sun.click();
+
+        // pick the time zone
+        ruleSettings.timezoneInput.sendKeys('Asia/Singapore');
+        tzOption = ruleSettings.timezoneList.get(0);
+        browser.driver.wait(protractor.until.elementIsVisible(tzOption), 3000);
+        tzOption.click();
+
+        // save the routing scheme and check that it was successfull
+        ingestSettings.saveBtn.click();
+
+        utils.assertToastMsg('success', 'Routing scheme saved');
+    });
 });

--- a/client/tasks/options/template.js
+++ b/client/tasks/options/template.js
@@ -6,10 +6,6 @@ module.exports = function(grunt) {
 
         var server = grunt.option('server') || process.env.SUPERDESK_URL || url;
         var ws = grunt.option('ws') || process.env.SUPERDESK_WS_URL || 'ws://localhost:5100';
-        var serverTimezone = (
-            grunt.option('server-tz') ||
-            process.env.SUPERDESK_SERVER_TZ ||
-            'GMT (UTC+0)');
 
         if (forceUrl) {
             server = url;
@@ -17,11 +13,7 @@ module.exports = function(grunt) {
 
         var config = {
             raven: {dsn: process.env.SUPERDESK_RAVEN_DSN || ''},
-            server: {
-                url: server,
-                ws: ws,
-                timezone: serverTimezone
-            },
+            server: {url: server, ws: ws},
             analytics: {
                 piwik: {
                     url: process.env.PIWIK_URL || '',

--- a/client/tasks/options/template.js
+++ b/client/tasks/options/template.js
@@ -6,6 +6,10 @@ module.exports = function(grunt) {
 
         var server = grunt.option('server') || process.env.SUPERDESK_URL || url;
         var ws = grunt.option('ws') || process.env.SUPERDESK_WS_URL || 'ws://localhost:5100';
+        var serverTimezone = (
+            grunt.option('server-tz') ||
+            process.env.SUPERDESK_SERVER_TZ ||
+            'GMT (UTC+0)');
 
         if (forceUrl) {
             server = url;
@@ -13,7 +17,11 @@ module.exports = function(grunt) {
 
         var config = {
             raven: {dsn: process.env.SUPERDESK_RAVEN_DSN || ''},
-            server: {url: server, ws: ws},
+            server: {
+                url: server,
+                ws: ws,
+                timezone: serverTimezone
+            },
             analytics: {
                 piwik: {
                     url: process.env.PIWIK_URL || '',

--- a/client/test-main.js
+++ b/client/test-main.js
@@ -91,6 +91,7 @@ tests.push('superdesk-workspace/workspace');
 // libs
 tests.push('bower_components/ment.io/dist/mentio');
 tests.push('angular-ui');
+tests.push('angular-resource');
 tests.push('angular-route');
 tests.push('angular-file-upload');
 tests.push('moment');

--- a/server/apps/rules/routing_rules.py
+++ b/server/apps/rules/routing_rules.py
@@ -275,7 +275,7 @@ class RoutingRuleSchemeService(BaseService):
 
         :param dict schedule: the routing schedule configuration to validate
 
-        :raises SuperdeskApiError: if `schedule` validation fails
+        :raises SuperdeskApiError: if validation of `schedule` fails
         """
         if schedule is not None \
                 and (len(schedule) == 0
@@ -293,13 +293,19 @@ class RoutingRuleSchemeService(BaseService):
                 except:
                     raise SuperdeskApiError.badRequestError(message="Invalid value for from time.")
 
-                try:
-                    to_time = datetime.strptime(schedule.get('hour_of_day_to'), '%H%M')
-                except:
-                    raise SuperdeskApiError.badRequestError(message="Invalid value for to time.")
+                to_time = schedule.get('hour_of_day_to', '')
+                if to_time:
+                    try:
+                        to_time = datetime.strptime(to_time, '%H%M')
+                    except:
+                        raise SuperdeskApiError.badRequestError(
+                            message="Invalid value for hour_of_day_to "
+                                    "(expected %H%M).")
 
-                if from_time > to_time:
-                    raise SuperdeskApiError.badRequestError(message="From time should be less than To Time.")
+                    if from_time > to_time:
+                        raise SuperdeskApiError.badRequestError(
+                            message="From time should be less than To Time."
+                        )
 
             time_zone = schedule.get('time_zone')
 

--- a/server/apps/rules/routing_rules_tests.py
+++ b/server/apps/rules/routing_rules_tests.py
@@ -55,7 +55,7 @@ class ValidateScheduleMethodTestCase(RoutingRuleSchemeServiceTest):
         'apps.rules.routing_rules.all_timezones_set',
         {'Foo/Bar', 'Foo/Baz', 'Here/There'}
     )
-    def test_foo(self):
+    def test_raises_error_on_unknown_time_zone(self):
         from superdesk.errors import SuperdeskApiError
 
         self.schedule['time_zone'] = 'Invalid/Zone'
@@ -68,3 +68,14 @@ class ValidateScheduleMethodTestCase(RoutingRuleSchemeServiceTest):
         msg = msg.lower() if msg else ''
         self.assertIn('time zone', msg)
         self.assertIn('invalid/zone', msg)
+
+    def test_allows_empty_end_time(self):
+        self.schedule['hour_of_day_from'] = '1030'
+        self.schedule['hour_of_day_to'] = ''
+
+        try:
+            self.instance._validate_schedule(self.schedule)
+        except Exception as ex:
+            self.fail(
+                "Unexpected exception on empty hour_of_day_to: {}".format(ex)
+            )

--- a/server/apps/rules/routing_rules_tests.py
+++ b/server/apps/rules/routing_rules_tests.py
@@ -1,5 +1,6 @@
 
 import unittest
+from unittest import mock
 from datetime import datetime, timedelta
 from .routing_rules import Weekdays
 
@@ -22,3 +23,48 @@ class WeekdaysTestCase(unittest.TestCase):
         now = datetime.now()
         day = now.strftime('%A')[:3].upper()
         self.assertEqual(day, Weekdays.dayname(now))
+
+
+class RoutingRuleSchemeServiceTest(unittest.TestCase):
+    """Base class for RoutingRuleSchemeService tests."""
+
+    def setUp(self):
+        try:
+            from .routing_rules import RoutingRuleSchemeService
+        except ImportError:
+            # a missing class should result in a failed test, not in an error
+            # that prevents all the tests in the module from even being run
+            self.fail(
+                "Could not import class under test "
+                "(RoutingRuleSchemeService).")
+        else:
+            self.instance = RoutingRuleSchemeService()
+
+
+class ValidateScheduleMethodTestCase(RoutingRuleSchemeServiceTest):
+    """Tests for the _validate_schedule() method."""
+
+    def setUp(self):
+        super().setUp()
+
+        self.schedule = {
+            'day_of_week': ['WED', 'FRI']
+        }
+
+    @mock.patch(
+        'apps.rules.routing_rules.all_timezones_set',
+        {'Foo/Bar', 'Foo/Baz', 'Here/There'}
+    )
+    def test_foo(self):
+        from superdesk.errors import SuperdeskApiError
+
+        self.schedule['time_zone'] = 'Invalid/Zone'
+
+        with self.assertRaises(SuperdeskApiError) as context:
+            self.instance._validate_schedule(self.schedule)
+
+        # also check the error message
+        msg = context.exception.message
+        msg = msg.lower() if msg else ''
+        self.assertIn('time zone', msg)
+        self.assertIn('invalid/zone', msg)

--- a/server/features/routing_rules.feature
+++ b/server/features/routing_rules.feature
@@ -239,7 +239,7 @@ Feature: Routing Scheme and Routing Rules
 
 
     @auth @test
-    Scenario: Create an valid Routing Scheme with an empty filter
+    Scenario: Create a valid Routing Scheme with an empty filter
       Given empty "desks"
 
       When we post to "/desks"
@@ -471,7 +471,7 @@ Feature: Routing Scheme and Routing Rules
               "schedule": {
                 "day_of_week": ["FRI", "TUE"],
                 "hour_of_day_from": "0400",
-                "hour_of_day_to": "0600",
+                "hour_of_day_to": "",
                 "time_zone": "Europe/Rome"
               }
             }

--- a/server/features/routing_rules.feature
+++ b/server/features/routing_rules.feature
@@ -358,6 +358,7 @@ Feature: Routing Scheme and Routing Rules
       ]
       """
       Then we get response code 400
+
       When we post to "/routing_schemes"
       """
       [
@@ -381,6 +382,7 @@ Feature: Routing Scheme and Routing Rules
       ]
       """
       Then we get response code 400
+
       When we post to "/routing_schemes"
       """
       [
@@ -404,6 +406,7 @@ Feature: Routing Scheme and Routing Rules
       ]
       """
       Then we get response code 400
+
       When we post to "/routing_schemes"
       """
       [
@@ -427,6 +430,7 @@ Feature: Routing Scheme and Routing Rules
       ]
       """
       Then we get response code 400
+
       When we post to "/routing_schemes"
       """
       [
@@ -442,7 +446,33 @@ Feature: Routing Scheme and Routing Rules
               "schedule": {
                 "day_of_week": ["FRI", "TUE"],
                 "hour_of_day_from": "0400",
-                "hour_of_day_to": "0600"
+                "hour_of_day_to": "0600",
+                "time_zone": "Timezone/Invalid"
+              }
+            }
+          ]
+        }
+      ]
+      """
+      Then we get response code 400
+
+      When we post to "/routing_schemes"
+      """
+      [
+        {
+          "name": "routing rule scheme 1",
+          "rules": [
+            {
+              "name": "Sports Rule",
+              "filter": "#FILTER_ID#",
+              "actions": {
+                "fetch": [{"desk": "#desks._id#", "stage": "#desks.incoming_stage#"}]
+              },
+              "schedule": {
+                "day_of_week": ["FRI", "TUE"],
+                "hour_of_day_from": "0400",
+                "hour_of_day_to": "0600",
+                "time_zone": "Europe/Rome"
               }
             }
           ]

--- a/server/features/routing_rules.feature
+++ b/server/features/routing_rules.feature
@@ -481,56 +481,6 @@ Feature: Routing Scheme and Routing Rules
       """
       Then we get response code 201
 
-    @auth @vocabulary
-    Scenario: Create an invalid Routing Scheme with an empty schedule
-      Given empty "desks"
-      Given we have "/filter_conditions" with "FCOND_ID" and success
-      """
-      [{
-          "name": "Sports Content",
-          "field": "subject",
-          "operator": "in",
-          "value": "04000000"
-      }]
-      """
-      And we have "/content_filters" with "FILTER_ID" and success
-      """
-      [{
-          "name": "Sports Content",
-          "content_filter": [
-              {
-                  "expression": {
-                      "fc": ["#FCOND_ID#"]
-                  }
-              }
-          ]
-      }]
-      """
-
-      When we post to "/desks"
-      """
-      {"name": "Sports", "members": [{"user": "#CONTEXT_USER_ID#"}]}
-      """
-      And we post to "/routing_schemes"
-      """
-      [
-        {
-          "name": "routing rule scheme 1",
-          "rules": [
-            {
-              "name": "Sports Rule",
-              "filter": "#FILTER_ID#",
-              "actions": {
-                "fetch": [{"desk": "#desks._id#", "stage": "#desks.incoming_stage#"}]
-              },
-              "schedule": {}
-            }
-          ]
-        }
-      ]
-      """
-      Then we get response code 400
-
     @auth
     Scenario: A user with no privilege to "routing schemes" can't create a Routing Scheme
       Given we login as user "foo" with password "bar" and user type "user"


### PR DESCRIPTION
Resolves [SD-3350](https://dev.sourcefabric.org/browse/SD-3350).

This PR fixes various issues with ingest routing schedule, e.g.:
* `sdTimepickerAlt` can be optionally configured to *not* convert selected times to UTC in the client browser, avoiding problems when time zone settings on the client's machine differ from the server time zone.
* It is now possible to select the time zone of the times of day in a routing schedule rule. This avoids the trouble of defining a time interval in a local time zone that would span across two different days in UTC due to the time shift (the latter was pretty much impossible to define until now).
The default behavior of the directive is still the same, preserving the backward compatibility.
If no time zone is defined in the routing schedule, UTC is assumed, meaning that all the existing schedules that do not have this information will still work normally.
* It is now possible to omit the ending time of day in a routing rule, which is interpreted as "until the end of the day". Until now it was not possible to do that, the latest possible time to choose for an end time was 23:55, meaning that there was a 5-minute gap until midnight, which was impossible  to cover.
* Optimization: time zone data is now fetched from the server only once - when the `tzdata` factory is instantiated. Before the change this data was fetched every time when a service/directive that uses `tzdata` was created.

**To be aware of:**
Currently the list of all time zones on the client and the server differ. While the server recognizes almost 500 common time zones (using `pytz`, based on the Olson database), the client only know about 50 of them. The reason is that `tzdata` service fetches the `world-clock/timezones-all.json` file which seems to be incomplete.