### PR TITLE
[SD-3386] Fixup datelines using macros

### DIFF
--- a/server/apps/archive/common.py
+++ b/server/apps/archive/common.py
@@ -109,7 +109,7 @@ def set_dateline(doc, repo_type):
                 doc['dateline']['text'] = format_dateline_to_locmmmddsrc(located, dateline_ts)
 
 
-def format_dateline_to_locmmmddsrc(located, current_timestamp):
+def format_dateline_to_locmmmddsrc(located, current_timestamp, source=ORGANIZATION_NAME_ABBREVIATION):
     """
     Formats dateline to "Location, Month Date Source -"
 
@@ -137,7 +137,7 @@ def format_dateline_to_locmmmddsrc(located, current_timestamp):
         formatted_date = current_timestamp.strftime('%b %d')
 
     return "{location} {mmmdd} {source} -".format(location=dateline_location.upper(), mmmdd=formatted_date,
-                                                  source=ORGANIZATION_NAME_ABBREVIATION)
+                                                  source=source)
 
 
 def set_byline(doc, repo_type=ARCHIVE):

--- a/server/apps/io/dpa.py
+++ b/server/apps/io/dpa.py
@@ -17,6 +17,7 @@ from superdesk.utc import utc
 from superdesk.utils import get_sorted_files, FileSortAttributes
 from superdesk.errors import ParserError, ProviderError
 from superdesk.io.iptc7901 import Iptc7901FileParser
+from macros.dpa_derive_dateline import dpa_derive_dateline
 
 logger = logging.getLogger(__name__)
 
@@ -47,6 +48,7 @@ class DPAIngestService(FileIngestService):
                     last_updated = datetime.fromtimestamp(stat.st_mtime, tz=utc)
                     if self.is_latest_content(last_updated, provider.get('last_updated')):
                         item = self.parser.parse_file(filepath, provider)
+                        dpa_derive_dateline(item)
 
                         self.move_file(self.path, filename, provider=provider, success=True)
                         yield [item]

--- a/server/apps/io/reuters.py
+++ b/server/apps/io/reuters.py
@@ -27,6 +27,7 @@ from flask import current_app as app
 from macros.reuters_derive_dateline import reuters_derive_dateline
 from superdesk.metadata.item import ITEM_TYPE, CONTENT_TYPE
 
+
 class ReutersIngestService(IngestService):
     """Reuters ingest service."""
 

--- a/server/apps/io/reuters.py
+++ b/server/apps/io/reuters.py
@@ -24,7 +24,8 @@ from superdesk.io.newsml_2_0 import NewsMLTwoParser
 from .reuters_token import get_token
 from superdesk.errors import IngestApiError
 from flask import current_app as app
-
+from macros.reuters_derive_dateline import reuters_derive_dateline
+from superdesk.metadata.item import ITEM_TYPE, CONTENT_TYPE
 
 class ReutersIngestService(IngestService):
     """Reuters ingest service."""
@@ -95,6 +96,8 @@ class ReutersIngestService(IngestService):
         payload = {'id': guid}
         tree = self.get_tree('item', payload)
         items = self.parser.parse_message(tree, self.provider)
+        for item in (i for i in items if i[ITEM_TYPE] == CONTENT_TYPE.TEXT):
+            reuters_derive_dateline(item)
         return items
 
     def get_ids(self, channel, last_updated, updated):

--- a/server/apps/io/reuters.py
+++ b/server/apps/io/reuters.py
@@ -24,8 +24,6 @@ from superdesk.io.newsml_2_0 import NewsMLTwoParser
 from .reuters_token import get_token
 from superdesk.errors import IngestApiError
 from flask import current_app as app
-from macros.reuters_derive_dateline import reuters_derive_dateline
-from superdesk.metadata.item import ITEM_TYPE, CONTENT_TYPE
 
 
 class ReutersIngestService(IngestService):
@@ -97,8 +95,6 @@ class ReutersIngestService(IngestService):
         payload = {'id': guid}
         tree = self.get_tree('item', payload)
         items = self.parser.parse_message(tree, self.provider)
-        for item in (i for i in items if i[ITEM_TYPE] == CONTENT_TYPE.TEXT):
-            reuters_derive_dateline(item)
         return items
 
     def get_ids(self, channel, last_updated, updated):

--- a/server/macros/dpa_derive_dateline.py
+++ b/server/macros/dpa_derive_dateline.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013, 2014 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+from superdesk.locators.locators import find_cities
+
+
+def dpa_derive_dateline(item, **kwargs):
+    """
+    DPA content is recieved in IPTC7901 format, this macro attempts to parse a dateline from the first few lines of
+    the item body and populate the dataline location, it also populates the dateline source.
+    If a dateline is matched the coresponding string is removed from the article text.
+    :param item:
+    :param kwargs:
+    :return:
+    """
+    lines = item['body_html'].splitlines()
+    if lines:
+        # expect the dateline in the first 5 lines, sometimes there is what appears to be a headline preceeding it.
+        for line_num in range(0, min(len(lines), 5)):
+            city, source, the_rest = lines[line_num].partition(' (dpa) - ')
+            # test if we found a candidate and ensure that the city starts the line and is not crazy long
+            if source and lines[line_num].find(city) == 0 and len(city) < 20:
+                cities = find_cities()
+                located = [c for c in cities if c['city'].lower() == city.lower()]
+                if 'dateline' not in item:
+                    item['dateline'] = {}
+                item['dateline']['located'] = located[0] if len(located) > 0 else {'city_code': city, 'city': city,
+
+                                                                                   'tz': 'UTC', 'dateline': 'city'}
+                item['dateline']['source'] = 'dpa'
+                item['dateline']['text'] = city
+                lines[line_num] = lines[line_num].replace(city + source, '')
+                item['body_html'] = '\r\n'.join(lines)
+                break
+    return item
+
+
+name = 'Derive dateline from article text for DPA'
+label = 'DPA dateline derivation'
+shortcut = '$'
+callback = dpa_derive_dateline

--- a/server/macros/dpa_derive_dateline_test.py
+++ b/server/macros/dpa_derive_dateline_test.py
@@ -38,4 +38,4 @@ class DPADeriveDatelineTests(TestCase):
         item = dict()
         item['body_html'] = 'No dateline here'
         dpa_derive_dateline(item)
-        self.assertNotIn('located', item)
+        self.assertNotIn('dateline', item)

--- a/server/macros/dpa_derive_dateline_test.py
+++ b/server/macros/dpa_derive_dateline_test.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013, 2014 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+from unittest import TestCase
+from .dpa_derive_dateline import dpa_derive_dateline
+
+
+class DPADeriveDatelineTests(TestCase):
+
+    def simple_case_test(self):
+        item = dict()
+        item['body_html'] = 'Madrid (dpa) - Results and standings Spanish Primera Division\r\n(kick-off times in GMT):'
+        dpa_derive_dateline(item)
+        self.assertEqual(item['dateline']['located']['city'], 'Madrid')
+
+    def text_before_test(self):
+        item = dict()
+        item['body_html'] = '\r\nComedian Morales running as outsider in Guatemala =\r\n        \r\n'
+        item['body_html'] += 'Guatemala City (dpa) - Comedian Jimmy Morales has one major asset'
+        dpa_derive_dateline(item)
+        self.assertEqual(item['dateline']['located']['city'], 'Guatemala City')
+
+    def know_city_test(self):
+        item = dict()
+        item['body_html'] = 'Dubbo (dpa) - Where on earth is that'
+        dpa_derive_dateline(item)
+        self.assertEqual(item['dateline']['located']['city'], 'Dubbo')
+        self.assertEqual(item['dateline']['located']['country'], 'Australia')
+
+    def no_match_test(self):
+        item = dict()
+        item['body_html'] = 'No dateline here'
+        dpa_derive_dateline(item)
+        self.assertNotIn('located', item)

--- a/server/macros/noise11_derive_metadata.py
+++ b/server/macros/noise11_derive_metadata.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013, 2014 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+import logging
+import superdesk
+from superdesk.io.iptc import subject_codes
+from superdesk.locators.locators import find_cities
+from apps.archive.common import format_dateline_to_locmmmddsrc
+from superdesk.utc import get_date
+
+logger = logging.getLogger(__name__)
+
+
+def noise11_derive_metadata(item, **kwargs):
+    """
+    By definition anyhting from NOISE11 will be entertainment so set the category, subject and dateline
+    appropriately
+    :param item:
+    :param kwargs:
+    :return:
+    """
+    try:
+        if 'anpa_category' not in item:
+            category_map = superdesk.get_resource_service('vocabularies').find_one(req=None, _id='categories')
+            if category_map:
+                map_entry = next((code for code in category_map['items'] if code['qcode'] == 'e' and code['is_active']),
+                                 None)
+                item['anpa_category'] = [{'qcode': 'e', 'name': map_entry['name']}]
+
+        if 'subject' not in item:
+            qcode = '01000000'
+            item['subject'] = [{'qcode': qcode, 'name': subject_codes[qcode]}]
+
+        cities = find_cities()
+        located = [c for c in cities if c['city'].lower() == 'sydney']
+
+        if located and 'dateline' not in item:
+            item['dateline'] = {'date': item['firstcreated'], 'located': located[0]}
+        item['dateline']['source'] = item['source']
+        item['dateline']['text'] = format_dateline_to_locmmmddsrc(located[0], get_date(item['firstcreated']),
+                                                                  source=item['source'])
+
+        return item
+    except Exception as ex:
+        logger.exception(ex)
+
+
+name = 'Derive metadata for Noise11'
+label = 'Noise11 metadata derivation'
+shortcut = '$'
+callback = noise11_derive_metadata

--- a/server/macros/noise11_derive_metadata.py
+++ b/server/macros/noise11_derive_metadata.py
@@ -38,7 +38,7 @@ def noise11_derive_metadata(item, **kwargs):
             qcode = '01000000'
             item['subject'] = [{'qcode': qcode, 'name': subject_codes[qcode]}]
 
-        cities = find_cities()
+        cities = find_cities(country_code='AU', state_code='NSW')
         located = [c for c in cities if c['city'].lower() == 'sydney']
 
         if located and 'dateline' not in item:

--- a/server/macros/noise11_derive_metadata_test.py
+++ b/server/macros/noise11_derive_metadata_test.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013, 2014 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+from test_factory import SuperdeskTestCase
+import datetime
+from .noise11_derive_metadata import noise11_derive_metadata
+
+
+class Noise11DeriveMetaDataTests(SuperdeskTestCase):
+
+    vocab = [{'_id': 'categories', 'items': [{'is_active': True, 'name': 'Entertainment', 'qcode': 'e'}]}]
+    now = datetime.datetime(2015, 6, 13, 11, 45, 19, 0)
+
+    def setUp(self):
+        super().setUp()
+        self.app.data.insert('vocabularies', self.vocab)
+
+    def simple_case_test(self):
+        item = dict()
+        item['firstcreated'] = datetime.datetime(2015, 10, 26, 11, 45, 19, 0)
+        item['source'] = 'NOISE11'
+        noise11_derive_metadata(item)
+        self.assertEqual(item['dateline']['text'], 'SYDNEY Oct 26 NOISE11 -')

--- a/server/macros/reuters_derive_dateline.py
+++ b/server/macros/reuters_derive_dateline.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013, 2014 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+from superdesk.locators.locators import find_cities
+from bs4 import BeautifulSoup
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def reuters_derive_dateline(item, **kwargs):
+    """
+    It seems that most locations injected into the item by the parser are Bangalor
+    This function looks for a dateline in the article body an uses that.
+    :param items:
+    :return:
+    """
+    try:
+        html = item.get('body_html')
+        if html:
+            soup = BeautifulSoup(html)
+            pars = soup.findAll('p')
+            if len(pars) >= 2:
+                if 'byline' in item and item.get('byline') in pars[0].get_text():
+                    first = pars[1].get_text()
+                else:
+                    first = pars[0].get_text()
+                city, source, the_rest = first.partition(' (Reuters) - ')
+                if source:
+                    # sometimes the city is followed by a comma and either a date or a state
+                    city = city.split(',')[0]
+                    if any(char.isdigit() for char in city):
+                        return
+                    cities = find_cities()
+                    located = [c for c in cities if c['city'].lower() == city.lower()]
+                    # if not dateline we create one
+                    if 'dateline' not in item:
+                        item['dateline'] = {}
+                    # there is already a dateline that is not Bangalore don't do anything just return
+                    elif 'located' in item['dateline'] and 'BANGALOR' != item['dateline']['located'].get(
+                            'city').upper():
+                        return
+
+                    item['dateline']['located'] = located[0] if len(located) > 0 else {'city_code': city,
+                                                                                       'city': city,
+                                                                                       'tz': 'UTC',
+                                                                                       'dateline': 'city'}
+                    item['dateline']['source'] = item.get('original_source', 'Reuters')
+                    item['dateline']['text'] = city
+        return item
+    except:
+        logging.exception('Reuters dateline macro exception')
+
+name = 'Derive dateline from article text for Reuters'
+label = 'Reuters dateline derivation'
+shortcut = '$'
+callback = reuters_derive_dateline

--- a/server/macros/reuters_derive_dateline.py
+++ b/server/macros/reuters_derive_dateline.py
@@ -11,6 +11,9 @@
 from superdesk.locators.locators import find_cities
 from bs4 import BeautifulSoup
 import logging
+from apps.archive.common import format_dateline_to_locmmmddsrc
+from superdesk.utc import get_date
+from superdesk.metadata.item import BYLINE
 
 logger = logging.getLogger(__name__)
 
@@ -28,7 +31,7 @@ def reuters_derive_dateline(item, **kwargs):
             soup = BeautifulSoup(html)
             pars = soup.findAll('p')
             if len(pars) >= 2:
-                if 'byline' in item and item.get('byline') in pars[0].get_text():
+                if BYLINE in item and item.get(BYLINE) in pars[0].get_text():
                     first = pars[1].get_text()
                 else:
                     first = pars[0].get_text()
@@ -44,7 +47,7 @@ def reuters_derive_dateline(item, **kwargs):
                     if 'dateline' not in item:
                         item['dateline'] = {}
                     # there is already a dateline that is not Bangalore don't do anything just return
-                    elif 'located' in item['dateline'] and 'BANGALOR' != item['dateline']['located'].get(
+                    elif 'located' in item['dateline'] and 'BANGALORE' != item['dateline']['located'].get(
                             'city').upper():
                         return
 
@@ -53,10 +56,15 @@ def reuters_derive_dateline(item, **kwargs):
                                                                                        'tz': 'UTC',
                                                                                        'dateline': 'city'}
                     item['dateline']['source'] = item.get('original_source', 'Reuters')
-                    item['dateline']['text'] = city
+                    item['dateline']['text'] = format_dateline_to_locmmmddsrc(item['dateline']['located'],
+                                                                              get_date(item['firstcreated']),
+                                                                              source=item.get('original_source',
+                                                                                              'Reuters'))
+
         return item
     except:
         logging.exception('Reuters dateline macro exception')
+
 
 name = 'Derive dateline from article text for Reuters'
 label = 'Reuters dateline derivation'

--- a/server/macros/reuters_derive_dateline_test.py
+++ b/server/macros/reuters_derive_dateline_test.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013, 2014 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+from unittest import TestCase
+from .reuters_derive_dateline import reuters_derive_dateline
+
+
+class DPADeriveDatelineTests(TestCase):
+    def simple_case_test(self):
+        item = dict()
+        item['body_html'] = '<p>DETROIT (Reuters) - General Motors Co <GM.N> Chief Financial Officer Chuck Stevens \
+            said on Wednesday the macroeconomic challenges in Brazil will remain in the near term but the company \
+            has \"huge upside leverage once the macro situation changes\" in South America\'s largest \
+            economy.</p>\n<p>GM\'s car sales so far in October are up versus a year ago, Stevens said to reporters \
+            after the No. 1 U.S. automaker reported third-quarter financial results.</p>\n<p>Stevens also \
+            reaffirmed GM\'s past forecasts that it will show profit in Europe in 2016. It would be GM\'s first \
+            profit in Europe since 1999.</p>\n<p> (Reporting by Bernie Woodall and Joseph White; \
+            Editing by Chizu Nomiyamam and Jeffrey Benkoe)</p>'
+        reuters_derive_dateline(item)
+        self.assertEqual(item['dateline']['located']['city'], 'Detroit')
+
+    def with_a_date_test(self):
+        item = dict()
+        item['body_html'] = '<p>PARIS, Oct 22 (Reuters) - Eurotunnel said on\nThursday that third-quarter revenue \
+        rose 3 percent to 334.4\nmillion euros ($379.48 million), as economic recovery helped\noffset the \
+        impact of the disruption to traffic resulting from\nthe migrant crisis.</p>\n<p>The operator of the \
+        Channel Tunnel linking France and\nBritain said that business remained dynamic, driven by a\nrecovering \
+        economy in Britain and to a lesser extent in the\neuro-zone.</p>\n<p>But a camp of around 6,000 migrants \
+        in the Calais area\nfleeing war, political turmoil and poverty outside Europe has\ncaused disruption to \
+        traffic since Summer.</p>\n<p>Eurotunnel carries Eurostar high-speed trains between Paris,\nBrussels and \
+        London, as well as shuttle trains containing\npassenger cars, coaches and freight trucks.</p>\n<p>Rail \
+        freight tonnage fell 27 percent year-on-year and the\nnumber of freight trains using the Channel \
+        tunnel fell 33\npercent, the company said - blaming the drop on the migrant\ncrisis.</p>\n<p>Passenger \
+        traffic in the quarter rose 2 percent year-on-year\nto 2,866,155 on the Eurostar. Traffic however fell \
+        1 percent on\ntrucks and 9 percent on coaches compared with the same period\nlast year.</p>\n<p>In July \
+        Eurotunnel asked the French and British governments\nto reimburse it for close to 10 million euros it spent \
+        to beef\nup security to cope with a migrant crisis at the French port of\nCalais.</p>\n<p>Third quarter \
+        sales figures no longer include MyFerryLink,\nthe ferry service between Britain and France, which ended \
+        its \nits activity on June 29.</p>\n<p>($1 = 0.8812 euros)\n\n (Reporting by Dominique Vidalon; Editing \
+        by Andrew Callus)</p>",'
+        reuters_derive_dateline(item)
+        self.assertEqual(item['dateline']['located']['city'], 'PARIS')
+
+    def with_a_byline_test(self):
+        item = dict()
+        item['byline'] = 'By Karl Plume'
+        item['body_html'] = '<p>By Karl Plume</p>\n<p>CHICAGO, Oct 21 (Reuters) - Chicago Cubs supporters have \
+        uttered the phrase \"wait till next year\" perhaps more than any other fans in baseball, with their team\'s \
+        championship drought stretching to 107 years after being swept from this year\'s playoffs by the New York \
+        Mets.</p>\n<p>However, the 2015 Cubs have given Chicago\'s north-side faithful reason to believe that \
+        their wait for a title, the longest in U.S. professional sports, might soon come to an end.</p>\n<p>The \
+        Mets ensured the Cubs\' unprecedented streak will continue another year with an 8-3 victory on Wednesday \
+        that saw them capture the National League pennant and claim a place in the World Series against \
+        Kansas City or Toronto.</p>\n<p>While the Cubs\' clubhouse was disappointed after the defeat, there were \
+        real signs of hope.</p>'
+        reuters_derive_dateline(item)
+        self.assertEqual(item['dateline']['located']['city'], 'Chicago')
+
+    def with_a_dateline_already_leave_it_alone_test(self):
+        item = dict()
+        item['dateline'] = {'located': {'city': 'Chicargo'}}
+        item['body_html'] = '<p>DONT CARE (Reuters) - Chicago Cubs supporters have \
+        uttered the phrase \"wait till next year\" perhaps more than any other fans in baseball, with their team\'s \
+        championship drought stretching to 107 years after being swept from this year\'s playoffs by the New York \
+        Mets.</p>\n<p>However, the 2015 Cubs have given Chicago\'s north-side faithful reason to believe that \
+        their wait for a title, the longest in U.S. professional sports, might soon come to an end.</p>\n<p>The \
+        Mets ensured the Cubs\' unprecedented streak will continue another year with an 8-3 victory on Wednesday \
+        that saw them capture the National League pennant and claim a place in the World Series against \
+        Kansas City or Toronto.</p>\n<p>While the Cubs\' clubhouse was disappointed after the defeat, there were \
+        real signs of hope.</p>'
+        reuters_derive_dateline(item)
+        self.assertEqual(item['dateline']['located']['city'], 'Chicargo')
+
+    def with_just_a_date_test(self):
+        item = dict()
+        item['body_html'] = '<p>Oct 22 (Reuters) - Eurotunnel said on\nThursday that third-quarter revenue \
+        rose 3 percent to 334.4\nmillion euros ($379.48 million), as economic recovery helped\noffset the \
+        impact of the disruption to traffic resulting from\nthe migrant crisis.</p>\n<p>The operator of the \
+        Channel Tunnel linking France and\nBritain said that business remained dynamic, driven by a\nrecovering \
+        economy in Britain and to a lesser extent in the\neuro-zone.</p>'
+        reuters_derive_dateline(item)
+        self.assertNotIn('dateline', item)

--- a/server/macros/reuters_derive_dateline_test.py
+++ b/server/macros/reuters_derive_dateline_test.py
@@ -10,11 +10,13 @@
 
 from unittest import TestCase
 from .reuters_derive_dateline import reuters_derive_dateline
+import datetime
 
 
 class DPADeriveDatelineTests(TestCase):
     def simple_case_test(self):
         item = dict()
+        item['firstcreated'] = datetime.datetime(2015, 10, 26, 11, 45, 19, 0)
         item['body_html'] = '<p>DETROIT (Reuters) - General Motors Co <GM.N> Chief Financial Officer Chuck Stevens \
             said on Wednesday the macroeconomic challenges in Brazil will remain in the near term but the company \
             has \"huge upside leverage once the macro situation changes\" in South America\'s largest \
@@ -28,6 +30,7 @@ class DPADeriveDatelineTests(TestCase):
 
     def with_a_date_test(self):
         item = dict()
+        item['firstcreated'] = datetime.datetime(2015, 10, 26, 11, 45, 19, 0)
         item['body_html'] = '<p>PARIS, Oct 22 (Reuters) - Eurotunnel said on\nThursday that third-quarter revenue \
         rose 3 percent to 334.4\nmillion euros ($379.48 million), as economic recovery helped\noffset the \
         impact of the disruption to traffic resulting from\nthe migrant crisis.</p>\n<p>The operator of the \
@@ -50,6 +53,7 @@ class DPADeriveDatelineTests(TestCase):
 
     def with_a_byline_test(self):
         item = dict()
+        item['firstcreated'] = datetime.datetime(2015, 10, 26, 11, 45, 19, 0)
         item['byline'] = 'By Karl Plume'
         item['body_html'] = '<p>By Karl Plume</p>\n<p>CHICAGO, Oct 21 (Reuters) - Chicago Cubs supporters have \
         uttered the phrase \"wait till next year\" perhaps more than any other fans in baseball, with their team\'s \
@@ -65,6 +69,7 @@ class DPADeriveDatelineTests(TestCase):
 
     def with_a_dateline_already_leave_it_alone_test(self):
         item = dict()
+        item['firstcreated'] = datetime.datetime(2015, 10, 26, 11, 45, 19, 0)
         item['dateline'] = {'located': {'city': 'Chicargo'}}
         item['body_html'] = '<p>DONT CARE (Reuters) - Chicago Cubs supporters have \
         uttered the phrase \"wait till next year\" perhaps more than any other fans in baseball, with their team\'s \
@@ -80,6 +85,7 @@ class DPADeriveDatelineTests(TestCase):
 
     def with_just_a_date_test(self):
         item = dict()
+        item['firstcreated'] = datetime.datetime(2015, 10, 26, 11, 45, 19, 0)
         item['body_html'] = '<p>Oct 22 (Reuters) - Eurotunnel said on\nThursday that third-quarter revenue \
         rose 3 percent to 334.4\nmillion euros ($379.48 million), as economic recovery helped\noffset the \
         impact of the disruption to traffic resulting from\nthe migrant crisis.</p>\n<p>The operator of the \
@@ -87,3 +93,18 @@ class DPADeriveDatelineTests(TestCase):
         economy in Britain and to a lesser extent in the\neuro-zone.</p>'
         reuters_derive_dateline(item)
         self.assertNotIn('dateline', item)
+
+    def from_bagalore_test(self):
+        item = {'dateline': {'located': {'city': 'Bangalore'}}}
+        item['firstcreated'] = datetime.datetime(2015, 10, 26, 11, 45, 19, 0)
+        item['body_html'] = '<p>Wagga Wagga (Reuters) - Chicago Cubs supporters have \
+        uttered the phrase \"wait till next year\" perhaps more than any other fans in baseball, with their team\'s \
+        championship drought stretching to 107 years after being swept from this year\'s playoffs by the New York \
+        Mets.</p>\n<p>However, the 2015 Cubs have given Chicago\'s north-side faithful reason to believe that \
+        their wait for a title, the longest in U.S. professional sports, might soon come to an end.</p>\n<p>The \
+        Mets ensured the Cubs\' unprecedented streak will continue another year with an 8-3 victory on Wednesday \
+        that saw them capture the National League pennant and claim a place in the World Series against \
+        Kansas City or Toronto.</p>\n<p>While the Cubs\' clubhouse was disappointed after the defeat, there were \
+        real signs of hope.</p>'
+        reuters_derive_dateline(item)
+        self.assertEqual(item['dateline']['located']['city'], 'Wagga Wagga')


### PR DESCRIPTION
The problem is that the datelines we receive from some of the ingest providers/parsers do not conform to what we want. 

I've implemented a couple of macros to try to sort them out, the macros can be called as part of routing or maybe when we re-factor the ingest it might be an idea to nominate a macro to call on ingest.

We can't implement this stuff in the parsers as the same parser may be used for different providers.  