### PR TITLE
fix(authoring): Changed the way widget is assigned to number

### DIFF
--- a/client/app/scripts/superdesk-authoring/widgets/widgets.js
+++ b/client/app/scripts/superdesk-authoring/widgets/widgets.js
@@ -42,8 +42,8 @@ function WidgetsManagerCtrl($scope, $routeParams, authoringWidgets, archiveServi
          * Navigate throw right tab widgets with keyboard combination
          * Combination: Ctrl + {{widget number}}
          */
-        angular.forEach($scope.widgets, function (widget) {
-            keyboardManager.bind('ctrl+' + widget.order, function () {
+        angular.forEach(_.sortBy($scope.widgets, 'order'), function (widget, index) {
+            keyboardManager.bind('ctrl+' + (index+1), function () {
                 $scope.activate(widget);
             }, {inputDisabled: false});
         });

--- a/client/app/scripts/superdesk-authoring/widgets/widgets.js
+++ b/client/app/scripts/superdesk-authoring/widgets/widgets.js
@@ -43,7 +43,7 @@ function WidgetsManagerCtrl($scope, $routeParams, authoringWidgets, archiveServi
          * Combination: Ctrl + {{widget number}}
          */
         angular.forEach(_.sortBy($scope.widgets, 'order'), function (widget, index) {
-            keyboardManager.bind('ctrl+' + (index+1), function () {
+            keyboardManager.bind('ctrl+' + (index + 1), function () {
                 $scope.activate(widget);
             }, {inputDisabled: false});
         });

--- a/client/app/scripts/superdesk-workspace/workspace.js
+++ b/client/app/scripts/superdesk-workspace/workspace.js
@@ -350,7 +350,7 @@
                     e.preventDefault();
                     $location.url('/workspace/personal');
                 }, opt);
-                keyboardManager.bind('alt+s', function (e) {
+                keyboardManager.bind('alt+f', function (e) {
                     e.preventDefault();
                     $location.url('search');
                 }, opt);

--- a/client/spec/workspace_spec.js
+++ b/client/spec/workspace_spec.js
@@ -27,7 +27,7 @@ describe('workspace', function () {
         expect(browser.getLocationAbsUrl()).toMatch('/workspace/personal');
 
         // Can switch to search view by pressing alt + s
-        altKey('s');
+        altKey('f');
         expect(browser.getLocationAbsUrl()).toMatch('/search');
 
         // Can get back to dashboard by pressing alt + h


### PR DESCRIPTION
Previous case: Widget is assigned to number by number in order field. Problem here is that in some cases same number is assigned for two widgets.

New case: Widget is assigned by index number from forEach loop. Also, widgets are first sorted by order.

Improvement for task: SD-3414