### PR TITLE
(fix)  Added/Modified validator definition for other content types

### DIFF
--- a/server/apps/prepopulate/data_initialization/validators.json
+++ b/server/apps/prepopulate/data_initialization/validators.json
@@ -7,8 +7,9 @@
             "headline": {
                 "type": "string",
                 "required": true,
-                "minlength": 1,
-                "maxlength": 55
+                "nullable": false,
+                "empty": false,
+                "maxlength": 64
             },
             "abstract": {
                 "type": "string",
@@ -18,9 +19,7 @@
             "type": {
                 "type": "string",
                 "required": "true",
-                "allowed": [
-                    "text"
-                ]
+                "allowed": ["text"]
             },
             "anpa_category": {
                 "type": "list",
@@ -35,12 +34,155 @@
             "slugline": {
                 "type": "string",
                 "required": true,
-                "maxlength": 24,
-                "minlength": 1
+                "nullable": false,
+                "empty": false,
+                "maxlength": 24
             },
             "body_html": {
                 "type": "string",
-                "required": true
+                "required": true,
+                "nullable": false,
+                "empty": false
+            },
+            "subject": {
+                "type": "list",
+                "required": true,
+                "minlength": 1
+            },
+            "urgency": {
+                "type": "integer",
+                "required": true,
+                "allowed": [1, 2, 3, 4, 5]
+            },
+            "priority": {
+                "type": "integer",
+                "required": true,
+                "allowed": [1, 2, 3, 4, 5, 6, 7, 8, 9]
+            },
+            "dateline": {
+                "type": "dict",
+                "required": true,
+                "schema": {
+                    "located": {"type": "dict", "required": true},
+                    "text": {"type": "string", "required": true}
+                }
+            }
+        }
+    },
+    {
+        "_id": "correct_text",
+        "act": "correct",
+        "type": "text",
+        "schema": {
+            "headline": {
+                "type": "string",
+                "required": true,
+                "nullable": false,
+                "empty": false,
+                "maxlength": 64
+            },
+            "abstract": {
+                "type": "string",
+                "required": false,
+                "maxlength": 160
+            },
+            "type": {
+                "type": "string",
+                "required": "true",
+                "allowed": ["text"]
+            },
+            "anpa_category": {
+                "type": "list",
+                "required": true,
+                "minlength": 1
+            },
+            "pubstatus": {
+                "type": "string",
+                "required": true,
+                "allowed": ["usable"]
+            },
+            "slugline": {
+                "type": "string",
+                "required": true,
+                "nullable": false,
+                "empty": false,
+                "maxlength": 24
+            },
+            "body_html": {
+                "type": "string",
+                "required": true,
+                "nullable": false,
+                "empty": false
+            },
+            "subject": {
+                "type": "list",
+                "required": true,
+                "minlength": 1
+            },
+            "urgency": {
+                "type": "integer",
+                "required": true,
+                "allowed": [1, 2, 3, 4, 5]
+            },
+            "priority": {
+                "type": "integer",
+                "required": true,
+                "allowed": [1, 2, 3, 4, 5, 6, 7, 8, 9]
+            },
+            "dateline": {
+                "type": "dict",
+                "required": true,
+                "schema": {
+                    "located": {"type": "dict", "required": true},
+                    "text": {"type": "string", "required": true}
+                }
+            }
+        }
+    },
+    {
+        "_id": "kill_text",
+        "act": "kill",
+        "type": "text",
+        "schema": {
+            "headline": {
+                "type": "string",
+                "required": true,
+                "nullable": false,
+                "empty": false,
+                "maxlength": 64
+            },
+            "abstract": {
+                "type": "string",
+                "required": false,
+                "maxlength": 160
+            },
+            "type": {
+                "type": "string",
+                "required": "true",
+                "allowed": ["text"]
+            },
+            "anpa_category": {
+                "type": "list",
+                "required": true,
+                "minlength": 1
+            },
+            "pubstatus": {
+                "type": "string",
+                "required": true,
+                "allowed": ["canceled"]
+            },
+            "slugline": {
+                "type": "string",
+                "required": true,
+                "nullable": false,
+                "empty": false,
+                "maxlength": 24
+            },
+            "body_html": {
+                "type": "string",
+                "required": true,
+                "nullable": false,
+                "empty": false
             },
             "subject": {
                 "type": "list",
@@ -75,8 +217,9 @@
             "headline": {
                 "type": "string",
                 "required": true,
-                "minlength": 1,
-                "maxlength": 55
+                "nullable": false,
+                "empty": false,
+                "maxlength": 64
             },
             "abstract": {
                 "type": "string",
@@ -86,9 +229,7 @@
             "type": {
                 "type": "string",
                 "required": "true",
-                "allowed": [
-                    "preformatted"
-                ]
+                "allowed": ["preformatted"]
             },
             "anpa_category": {
                 "type": "list",
@@ -103,12 +244,155 @@
             "slugline": {
                 "type": "string",
                 "required": true,
-                "maxlength": 24,
-                "minlength": 1
+                "nullable": false,
+                "empty": false,
+                "maxlength": 24
             },
             "body_html": {
                 "type": "string",
-                "required": true
+                "required": true,
+                "nullable": false,
+                "empty": false
+            },
+            "subject": {
+                "type": "list",
+                "required": true,
+                "minlength": 1
+            },
+            "urgency": {
+                "type": "integer",
+                "required": true,
+                "allowed": [1, 2, 3, 4, 5]
+            },
+            "priority": {
+                "type": "integer",
+                "required": true,
+                "allowed": [1, 2, 3, 4, 5, 6, 7, 8, 9]
+            },
+            "dateline": {
+                "type": "dict",
+                "required": true,
+                "schema": {
+                    "located": {"type": "dict", "required": true},
+                    "text": {"type": "string", "required": true}
+                }
+            }
+        }
+    },
+    {
+        "_id": "correct_preformatted",
+        "act": "correct",
+        "type": "preformatted",
+        "schema": {
+            "headline": {
+                "type": "string",
+                "required": true,
+                "nullable": false,
+                "empty": false,
+                "maxlength": 64
+            },
+            "abstract": {
+                "type": "string",
+                "required": false,
+                "maxlength": 160
+            },
+            "type": {
+                "type": "string",
+                "required": "true",
+                "allowed": ["preformatted"]
+            },
+            "anpa_category": {
+                "type": "list",
+                "required": true,
+                "minlength": 1
+            },
+            "pubstatus": {
+                "type": "string",
+                "required": true,
+                "allowed": ["usable"]
+            },
+            "slugline": {
+                "type": "string",
+                "required": true,
+                "nullable": false,
+                "empty": false,
+                "maxlength": 24
+            },
+            "body_html": {
+                "type": "string",
+                "required": true,
+                "nullable": false,
+                "empty": false
+            },
+            "subject": {
+                "type": "list",
+                "required": true,
+                "minlength": 1
+            },
+            "urgency": {
+                "type": "integer",
+                "required": true,
+                "allowed": [1, 2, 3, 4, 5]
+            },
+            "priority": {
+                "type": "integer",
+                "required": true,
+                "allowed": [1, 2, 3, 4, 5, 6, 7, 8, 9]
+            },
+            "dateline": {
+                "type": "dict",
+                "required": true,
+                "schema": {
+                    "located": {"type": "dict", "required": true},
+                    "text": {"type": "string", "required": true}
+                }
+            }
+        }
+    },
+    {
+        "_id": "kill_preformatted",
+        "act": "kill",
+        "type": "preformatted",
+        "schema": {
+            "headline": {
+                "type": "string",
+                "required": true,
+                "nullable": false,
+                "empty": false,
+                "maxlength": 64
+            },
+            "abstract": {
+                "type": "string",
+                "required": false,
+                "maxlength": 160
+            },
+            "type": {
+                "type": "string",
+                "required": "true",
+                "allowed": ["preformatted"]
+            },
+            "anpa_category": {
+                "type": "list",
+                "required": true,
+                "minlength": 1
+            },
+            "pubstatus": {
+                "type": "string",
+                "required": true,
+                "allowed": ["canceled"]
+            },
+            "slugline": {
+                "type": "string",
+                "required": true,
+                "nullable": false,
+                "empty": false,
+                "maxlength": 24
+            },
+            "body_html": {
+                "type": "string",
+                "required": true,
+                "nullable": false,
+                "empty": false
             },
             "subject": {
                 "type": "list",
@@ -140,6 +424,75 @@
         "act": "publish",
         "type": "picture",
         "schema": {
+            "headline": {
+                "type": "string",
+                "required": true,
+                "nullable": false,
+                "empty": false,
+                "maxlength": 64
+            },
+            "abstract": {
+                "type": "string",
+                "required": false,
+                "maxlength": 160
+            },
+            "type": {
+                "type": "string",
+                "required": "true",
+                "allowed": ["picture"]
+            },
+            "anpa_category": {
+                "type": "list",
+                "required": true,
+                "minlength": 1
+            },
+            "pubstatus": {
+                "type": "string",
+                "required": true,
+                "allowed": ["usable"]
+            },
+            "slugline": {
+                "type": "string",
+                "required": true,
+                "nullable": false,
+                "empty": false,
+                "maxlength": 24
+            },
+            "subject": {
+                "type": "list",
+                "required": true,
+                "minlength": 1
+            },
+            "urgency": {
+                "type": "integer",
+                "required": true,
+                "allowed": [1, 2, 3, 4, 5]
+            },
+            "priority": {
+                "type": "integer",
+                "required": true,
+                "allowed": [1, 2, 3, 4, 5, 6, 7, 8, 9]
+            },
+            "dateline": {
+                "type": "dict",
+                "required": true,
+                "schema": {
+                    "located": {"type": "dict", "required": true},
+                    "text": {"type": "string", "required": true}
+                }
+            },
+            "description": {
+                "type": "string",
+                "required": true,
+                "nullable": false,
+                "empty": false
+            },
+            "mimetype": {
+                "type": "string",
+                "required": true,
+                "nullable": false,
+                "empty": false
+            },
             "renditions": {
                 "type": "dict",
                 "required": true,
@@ -155,6 +508,75 @@
         "act": "correct",
         "type": "picture",
         "schema": {
+            "headline": {
+                "type": "string",
+                "required": true,
+                "nullable": false,
+                "empty": false,
+                "maxlength": 64
+            },
+            "abstract": {
+                "type": "string",
+                "required": false,
+                "maxlength": 160
+            },
+            "type": {
+                "type": "string",
+                "required": "true",
+                "allowed": ["picture"]
+            },
+            "anpa_category": {
+                "type": "list",
+                "required": true,
+                "minlength": 1
+            },
+            "pubstatus": {
+                "type": "string",
+                "required": true,
+                "allowed": ["usable"]
+            },
+            "slugline": {
+                "type": "string",
+                "required": true,
+                "nullable": false,
+                "empty": false,
+                "maxlength": 24
+            },
+            "subject": {
+                "type": "list",
+                "required": true,
+                "minlength": 1
+            },
+            "urgency": {
+                "type": "integer",
+                "required": true,
+                "allowed": [1, 2, 3, 4, 5]
+            },
+            "priority": {
+                "type": "integer",
+                "required": true,
+                "allowed": [1, 2, 3, 4, 5, 6, 7, 8, 9]
+            },
+            "dateline": {
+                "type": "dict",
+                "required": true,
+                "schema": {
+                    "located": {"type": "dict", "required": true},
+                    "text": {"type": "string", "required": true}
+                }
+            },
+            "description": {
+                "type": "string",
+                "required": true,
+                "nullable": false,
+                "empty": false
+            },
+            "mimetype": {
+                "type": "string",
+                "required": true,
+                "nullable": false,
+                "empty": false
+            },
             "renditions": {
                 "type": "dict",
                 "required": false,
@@ -169,20 +591,45 @@
         "_id": "kill_picture",
         "act": "kill",
         "type": "picture",
-        "schema": {}
-    },
-    {
-        "_id": "correct_text",
-        "act": "correct",
-        "type": "text",
         "schema": {
-            "dateline": {
-                "type": "dict",
+            "headline": {
+                "type": "string",
                 "required": true,
-                "schema": {
-                    "located": {"type": "dict", "required": true},
-                    "text": {"type": "string", "required": true}
-                }
+                "nullable": false,
+                "empty": false,
+                "maxlength": 64
+            },
+            "abstract": {
+                "type": "string",
+                "required": false,
+                "maxlength": 160
+            },
+            "type": {
+                "type": "string",
+                "required": "true",
+                "allowed": ["picture"]
+            },
+            "anpa_category": {
+                "type": "list",
+                "required": true,
+                "minlength": 1
+            },
+            "pubstatus": {
+                "type": "string",
+                "required": true,
+                "allowed": ["canceled"]
+            },
+            "slugline": {
+                "type": "string",
+                "required": true,
+                "nullable": false,
+                "empty": false,
+                "maxlength": 24
+            },
+            "subject": {
+                "type": "list",
+                "required": true,
+                "minlength": 1
             },
             "urgency": {
                 "type": "integer",
@@ -193,14 +640,7 @@
                 "type": "integer",
                 "required": true,
                 "allowed": [1, 2, 3, 4, 5, 6, 7, 8, 9]
-            }
-        }
-    },
-    {
-        "_id": "correct_preformatted",
-        "act": "correct",
-        "type": "preformatted",
-        "schema": {
+            },
             "dateline": {
                 "type": "dict",
                 "required": true,
@@ -209,44 +649,24 @@
                     "text": {"type": "string", "required": true}
                 }
             },
-            "urgency": {
-                "type": "integer",
+            "description": {
+                "type": "string",
                 "required": true,
-                "allowed": [1, 2, 3, 4, 5]
+                "nullable": false,
+                "empty": false
             },
-            "priority": {
-                "type": "integer",
+            "mimetype": {
+                "type": "string",
                 "required": true,
-                "allowed": [1, 2, 3, 4, 5, 6, 7, 8, 9]
-            }
-        }
-    },
-    {
-        "_id": "kill_text",
-        "act": "kill",
-        "type": "text",
-        "schema": {
-            "dateline": {
+                "nullable": false,
+                "empty": false
+            },
+            "renditions": {
                 "type": "dict",
-                "required": true,
+                "required": false,
                 "schema": {
-                    "located": {"type": "dict", "required": true},
-                    "text": {"type": "string", "required": true}
-                }
-            }
-        }
-    },
-    {
-        "_id": "kill_preformatted",
-        "act": "kill",
-        "type": "preformatted",
-        "schema": {
-            "dateline": {
-                "type": "dict",
-                "required": true,
-                "schema": {
-                    "located": {"type": "dict", "required": true},
-                    "text": {"type": "string", "required": true}
+                    "4-3": {"type": "dict", "required": false},
+                    "16-9": {"type": "dict", "required": false}
                 }
             }
         }
@@ -255,7 +675,457 @@
         "_id": "publish_video",
         "act": "publish",
         "type": "video",
-        "schema": {}
+        "schema": {
+            "headline": {
+                "type": "string",
+                "required": true,
+                "nullable": false,
+                "empty": false,
+                "maxlength": 64
+            },
+            "abstract": {
+                "type": "string",
+                "required": false,
+                "maxlength": 160
+            },
+            "type": {
+                "type": "string",
+                "required": "true",
+                "allowed": ["video"]
+            },
+            "anpa_category": {
+                "type": "list",
+                "required": true,
+                "minlength": 1
+            },
+            "pubstatus": {
+                "type": "string",
+                "required": true,
+                "allowed": ["usable"]
+            },
+            "slugline": {
+                "type": "string",
+                "required": true,
+                "nullable": false,
+                "empty": false,
+                "maxlength": 24
+            },
+            "subject": {
+                "type": "list",
+                "required": true,
+                "minlength": 1
+            },
+            "urgency": {
+                "type": "integer",
+                "required": true,
+                "allowed": [1, 2, 3, 4, 5]
+            },
+            "priority": {
+                "type": "integer",
+                "required": true,
+                "allowed": [1, 2, 3, 4, 5, 6, 7, 8, 9]
+            },
+            "dateline": {
+                "type": "dict",
+                "required": true,
+                "schema": {
+                    "located": {"type": "dict", "required": true},
+                    "text": {"type": "string", "required": true}
+                }
+            },
+            "description": {
+                "type": "string",
+                "required": true,
+                "nullable": false,
+                "empty": false
+            },
+            "mimetype": {
+                "type": "string",
+                "required": true,
+                "nullable": false,
+                "empty": false
+            }
+        }
+    },
+    {
+        "_id": "correct_video",
+        "act": "correct",
+        "type": "video",
+        "schema": {
+            "headline": {
+                "type": "string",
+                "required": true,
+                "nullable": false,
+                "empty": false,
+                "maxlength": 64
+            },
+            "abstract": {
+                "type": "string",
+                "required": false,
+                "maxlength": 160
+            },
+            "type": {
+                "type": "string",
+                "required": "true",
+                "allowed": ["video"]
+            },
+            "anpa_category": {
+                "type": "list",
+                "required": true,
+                "minlength": 1
+            },
+            "pubstatus": {
+                "type": "string",
+                "required": true,
+                "allowed": ["usable"]
+            },
+            "slugline": {
+                "type": "string",
+                "required": true,
+                "nullable": false,
+                "empty": false,
+                "maxlength": 24
+            },
+            "subject": {
+                "type": "list",
+                "required": true,
+                "minlength": 1
+            },
+            "urgency": {
+                "type": "integer",
+                "required": true,
+                "allowed": [1, 2, 3, 4, 5]
+            },
+            "priority": {
+                "type": "integer",
+                "required": true,
+                "allowed": [1, 2, 3, 4, 5, 6, 7, 8, 9]
+            },
+            "dateline": {
+                "type": "dict",
+                "required": true,
+                "schema": {
+                    "located": {"type": "dict", "required": true},
+                    "text": {"type": "string", "required": true}
+                }
+            },
+            "description": {
+                "type": "string",
+                "required": true,
+                "nullable": false,
+                "empty": false
+            },
+            "mimetype": {
+                "type": "string",
+                "required": true,
+                "nullable": false,
+                "empty": false
+            }
+        }
+    },
+    {
+        "_id": "kill_video",
+        "act": "kill",
+        "type": "video",
+        "schema": {
+            "headline": {
+                "type": "string",
+                "required": true,
+                "nullable": false,
+                "empty": false,
+                "maxlength": 64
+            },
+            "abstract": {
+                "type": "string",
+                "required": false,
+                "maxlength": 160
+            },
+            "type": {
+                "type": "string",
+                "required": "true",
+                "allowed": ["video"]
+            },
+            "anpa_category": {
+                "type": "list",
+                "required": true,
+                "minlength": 1
+            },
+            "pubstatus": {
+                "type": "string",
+                "required": true,
+                "allowed": ["canceled"]
+            },
+            "slugline": {
+                "type": "string",
+                "required": true,
+                "nullable": false,
+                "empty": false,
+                "maxlength": 24
+            },
+            "subject": {
+                "type": "list",
+                "required": true,
+                "minlength": 1
+            },
+            "urgency": {
+                "type": "integer",
+                "required": true,
+                "allowed": [1, 2, 3, 4, 5]
+            },
+            "priority": {
+                "type": "integer",
+                "required": true,
+                "allowed": [1, 2, 3, 4, 5, 6, 7, 8, 9]
+            },
+            "dateline": {
+                "type": "dict",
+                "required": true,
+                "schema": {
+                    "located": {"type": "dict", "required": true},
+                    "text": {"type": "string", "required": true}
+                }
+            },
+            "description": {
+                "type": "string",
+                "required": true,
+                "nullable": false,
+                "empty": false
+            },
+            "mimetype": {
+                "type": "string",
+                "required": true,
+                "nullable": false,
+                "empty": false
+            }
+        }
+    },
+    {
+        "_id": "publish_audio",
+        "act": "publish",
+        "type": "audio",
+        "schema": {
+            "headline": {
+                "type": "string",
+                "required": true,
+                "nullable": false,
+                "empty": false,
+                "maxlength": 64
+            },
+            "abstract": {
+                "type": "string",
+                "required": false,
+                "maxlength": 160
+            },
+            "type": {
+                "type": "string",
+                "required": "true",
+                "allowed": ["audio"]
+            },
+            "anpa_category": {
+                "type": "list",
+                "required": true,
+                "minlength": 1
+            },
+            "pubstatus": {
+                "type": "string",
+                "required": true,
+                "allowed": ["usable"]
+            },
+            "slugline": {
+                "type": "string",
+                "required": true,
+                "nullable": false,
+                "empty": false,
+                "maxlength": 24
+            },
+            "subject": {
+                "type": "list",
+                "required": true,
+                "minlength": 1
+            },
+            "urgency": {
+                "type": "integer",
+                "required": true,
+                "allowed": [1, 2, 3, 4, 5]
+            },
+            "priority": {
+                "type": "integer",
+                "required": true,
+                "allowed": [1, 2, 3, 4, 5, 6, 7, 8, 9]
+            },
+            "dateline": {
+                "type": "dict",
+                "required": true,
+                "schema": {
+                    "located": {"type": "dict", "required": true},
+                    "text": {"type": "string", "required": true}
+                }
+            },
+            "description": {
+                "type": "string",
+                "required": true,
+                "nullable": false,
+                "empty": false
+            },
+            "mimetype": {
+                "type": "string",
+                "required": true,
+                "nullable": false,
+                "empty": false
+            }
+        }
+    },
+    {
+        "_id": "correct_audio",
+        "act": "correct",
+        "type": "audio",
+        "schema": {
+            "headline": {
+                "type": "string",
+                "required": true,
+                "nullable": false,
+                "empty": false,
+                "maxlength": 64
+            },
+            "abstract": {
+                "type": "string",
+                "required": false,
+                "maxlength": 160
+            },
+            "type": {
+                "type": "string",
+                "required": "true",
+                "allowed": ["audio"]
+            },
+            "anpa_category": {
+                "type": "list",
+                "required": true,
+                "minlength": 1
+            },
+            "pubstatus": {
+                "type": "string",
+                "required": true,
+                "allowed": ["usable"]
+            },
+            "slugline": {
+                "type": "string",
+                "required": true,
+                "nullable": false,
+                "empty": false,
+                "maxlength": 24
+            },
+            "subject": {
+                "type": "list",
+                "required": true,
+                "minlength": 1
+            },
+            "urgency": {
+                "type": "integer",
+                "required": true,
+                "allowed": [1, 2, 3, 4, 5]
+            },
+            "priority": {
+                "type": "integer",
+                "required": true,
+                "allowed": [1, 2, 3, 4, 5, 6, 7, 8, 9]
+            },
+            "dateline": {
+                "type": "dict",
+                "required": true,
+                "schema": {
+                    "located": {"type": "dict", "required": true},
+                    "text": {"type": "string", "required": true}
+                }
+            },
+            "description": {
+                "type": "string",
+                "required": true,
+                "nullable": false,
+                "empty": false
+            },
+            "mimetype": {
+                "type": "string",
+                "required": true,
+                "nullable": false,
+                "empty": false
+            }
+        }
+    },
+    {
+        "_id": "kill_audio",
+        "act": "kill",
+        "type": "audio",
+        "schema": {
+            "headline": {
+                "type": "string",
+                "required": true,
+                "nullable": false,
+                "empty": false,
+                "maxlength": 64
+            },
+            "abstract": {
+                "type": "string",
+                "required": false,
+                "maxlength": 160
+            },
+            "type": {
+                "type": "string",
+                "required": "true",
+                "allowed": ["audio"]
+            },
+            "anpa_category": {
+                "type": "list",
+                "required": true,
+                "minlength": 1
+            },
+            "pubstatus": {
+                "type": "string",
+                "required": true,
+                "allowed": ["canceled"]
+            },
+            "slugline": {
+                "type": "string",
+                "required": true,
+                "nullable": false,
+                "empty": false,
+                "maxlength": 24
+            },
+            "subject": {
+                "type": "list",
+                "required": true,
+                "minlength": 1
+            },
+            "urgency": {
+                "type": "integer",
+                "required": true,
+                "allowed": [1, 2, 3, 4, 5]
+            },
+            "priority": {
+                "type": "integer",
+                "required": true,
+                "allowed": [1, 2, 3, 4, 5, 6, 7, 8, 9]
+            },
+            "dateline": {
+                "type": "dict",
+                "required": true,
+                "schema": {
+                    "located": {"type": "dict", "required": true},
+                    "text": {"type": "string", "required": true}
+                }
+            },
+            "description": {
+                "type": "string",
+                "required": true,
+                "nullable": false,
+                "empty": false
+            },
+            "mimetype": {
+                "type": "string",
+                "required": true,
+                "nullable": false,
+                "empty": false
+            }
+        }
     },
     {
         "_id": "publish_composite",
@@ -265,8 +1135,50 @@
             "headline": {
                 "type": "string",
                 "required": true,
-                "minlength": 1,
-                "maxlength": 55
+                "nullable": false,
+                "empty": false,
+                "maxlength": 64
+            },
+            "type": {
+                "type": "string",
+                "required": "true",
+                "allowed": ["composite"]
+            },
+            "anpa_category": {
+                "type": "list",
+                "required": true,
+                "minlength": 1
+            },
+            "pubstatus": {
+                "type": "string",
+                "required": true,
+                "allowed": ["usable"]
+            },
+            "slugline": {
+                "type": "string",
+                "required": true,
+                "nullable": false,
+                "empty": false,
+                "maxlength": 24
+            },
+            "subject": {
+                "type": "list",
+                "required": true,
+                "minlength": 1
+            },
+            "urgency": {
+                "type": "integer",
+                "required": true,
+                "allowed": [1, 2, 3, 4, 5]
+            },
+            "priority": {
+                "type": "integer",
+                "required": true,
+                "allowed": [1, 2, 3, 4, 5, 6, 7, 8, 9]
+            },
+            "groups": {
+                "type": "list",
+                "minlength": 1
             }
         }
     },
@@ -278,8 +1190,50 @@
             "headline": {
                 "type": "string",
                 "required": true,
-                "minlength": 1,
-                "maxlength": 55
+                "nullable": false,
+                "empty": false,
+                "maxlength": 64
+            },
+            "type": {
+                "type": "string",
+                "required": "true",
+                "allowed": ["composite"]
+            },
+            "anpa_category": {
+                "type": "list",
+                "required": true,
+                "minlength": 1
+            },
+            "pubstatus": {
+                "type": "string",
+                "required": true,
+                "allowed": ["usable"]
+            },
+            "slugline": {
+                "type": "string",
+                "required": true,
+                "nullable": false,
+                "empty": false,
+                "maxlength": 24
+            },
+            "subject": {
+                "type": "list",
+                "required": true,
+                "minlength": 1
+            },
+            "urgency": {
+                "type": "integer",
+                "required": true,
+                "allowed": [1, 2, 3, 4, 5]
+            },
+            "priority": {
+                "type": "integer",
+                "required": true,
+                "allowed": [1, 2, 3, 4, 5, 6, 7, 8, 9]
+            },
+            "groups": {
+                "type": "list",
+                "minlength": 1
             }
         }
     },
@@ -291,8 +1245,131 @@
             "headline": {
                 "type": "string",
                 "required": true,
-                "minlength": 1,
-                "maxlength": 55
+                "nullable": false,
+                "empty": false,
+                "maxlength": 64
+            },
+            "type": {
+                "type": "string",
+                "required": "true",
+                "allowed": ["composite"]
+            },
+            "anpa_category": {
+                "type": "list",
+                "required": true,
+                "minlength": 1
+            },
+            "pubstatus": {
+                "type": "string",
+                "required": true,
+                "allowed": ["canceled"]
+            },
+            "slugline": {
+                "type": "string",
+                "required": true,
+                "nullable": false,
+                "empty": false,
+                "maxlength": 24
+            },
+            "subject": {
+                "type": "list",
+                "required": true,
+                "minlength": 1
+            },
+            "urgency": {
+                "type": "integer",
+                "required": true,
+                "allowed": [1, 2, 3, 4, 5]
+            },
+            "priority": {
+                "type": "integer",
+                "required": true,
+                "allowed": [1, 2, 3, 4, 5, 6, 7, 8, 9]
+            },
+            "groups": {
+                "type": "list",
+                "minlength": 1
+            }
+        }
+    },
+    {
+        "_id": "publish_graphic",
+        "act": "publish",
+        "type": "graphic",
+        "schema": {
+            "type": {
+                "type": "string",
+                "required": "true",
+                "allowed": ["graphic"]
+            },
+            "anpa_category": {
+                "type": "list",
+                "required": true,
+                "minlength": 1
+            },
+            "pubstatus": {
+                "type": "string",
+                "required": true,
+                "allowed": ["usable"]
+            },
+            "subject": {
+                "type": "list",
+                "required": true,
+                "minlength": 1
+            }
+        }
+    },
+    {
+        "_id": "correct_graphic",
+        "act": "correct",
+        "type": "graphic",
+        "schema": {
+            "type": {
+                "type": "string",
+                "required": "true",
+                "allowed": ["graphic"]
+            },
+            "anpa_category": {
+                "type": "list",
+                "required": true,
+                "minlength": 1
+            },
+            "pubstatus": {
+                "type": "string",
+                "required": true,
+                "allowed": ["usable"]
+            },
+            "subject": {
+                "type": "list",
+                "required": true,
+                "minlength": 1
+            }
+        }
+    },
+    {
+        "_id": "kill_graphic",
+        "act": "kill",
+        "type": "graphic",
+        "schema": {
+            "type": {
+                "type": "string",
+                "required": "true",
+                "allowed": ["graphic"]
+            },
+            "anpa_category": {
+                "type": "list",
+                "required": true,
+                "minlength": 1
+            },
+            "pubstatus": {
+                "type": "string",
+                "required": true,
+                "allowed": ["canceled"]
+            },
+            "subject": {
+                "type": "list",
+                "required": true,
+                "minlength": 1
             }
         }
     }

--- a/server/apps/prepopulate/data_initialization/validators.json
+++ b/server/apps/prepopulate/data_initialization/validators.json
@@ -426,7 +426,7 @@
         "schema": {
             "headline": {
                 "type": "string",
-                "required": true,
+                "required": false,
                 "nullable": false,
                 "empty": false,
                 "maxlength": 64
@@ -465,17 +465,17 @@
             },
             "urgency": {
                 "type": "integer",
-                "required": true,
+                "required": false,
                 "allowed": [1, 2, 3, 4, 5]
             },
             "priority": {
                 "type": "integer",
-                "required": true,
+                "required": false,
                 "allowed": [1, 2, 3, 4, 5, 6, 7, 8, 9]
             },
             "dateline": {
                 "type": "dict",
-                "required": true,
+                "required": false,
                 "schema": {
                     "located": {"type": "dict", "required": true},
                     "text": {"type": "string", "required": true}
@@ -510,7 +510,7 @@
         "schema": {
             "headline": {
                 "type": "string",
-                "required": true,
+                "required": false,
                 "nullable": false,
                 "empty": false,
                 "maxlength": 64
@@ -549,17 +549,17 @@
             },
             "urgency": {
                 "type": "integer",
-                "required": true,
+                "required": false,
                 "allowed": [1, 2, 3, 4, 5]
             },
             "priority": {
                 "type": "integer",
-                "required": true,
+                "required": false,
                 "allowed": [1, 2, 3, 4, 5, 6, 7, 8, 9]
             },
             "dateline": {
                 "type": "dict",
-                "required": true,
+                "required": false,
                 "schema": {
                     "located": {"type": "dict", "required": true},
                     "text": {"type": "string", "required": true}
@@ -594,7 +594,7 @@
         "schema": {
             "headline": {
                 "type": "string",
-                "required": true,
+                "required": false,
                 "nullable": false,
                 "empty": false,
                 "maxlength": 64
@@ -633,12 +633,12 @@
             },
             "urgency": {
                 "type": "integer",
-                "required": true,
+                "required": false,
                 "allowed": [1, 2, 3, 4, 5]
             },
             "priority": {
                 "type": "integer",
-                "required": true,
+                "required": false,
                 "allowed": [1, 2, 3, 4, 5, 6, 7, 8, 9]
             },
             "dateline": {
@@ -651,7 +651,7 @@
             },
             "description": {
                 "type": "string",
-                "required": true,
+                "required": false,
                 "nullable": false,
                 "empty": false
             },
@@ -678,7 +678,7 @@
         "schema": {
             "headline": {
                 "type": "string",
-                "required": true,
+                "required": false,
                 "nullable": false,
                 "empty": false,
                 "maxlength": 64
@@ -717,17 +717,17 @@
             },
             "urgency": {
                 "type": "integer",
-                "required": true,
+                "required": false,
                 "allowed": [1, 2, 3, 4, 5]
             },
             "priority": {
                 "type": "integer",
-                "required": true,
+                "required": false,
                 "allowed": [1, 2, 3, 4, 5, 6, 7, 8, 9]
             },
             "dateline": {
                 "type": "dict",
-                "required": true,
+                "required": false,
                 "schema": {
                     "located": {"type": "dict", "required": true},
                     "text": {"type": "string", "required": true}
@@ -754,7 +754,7 @@
         "schema": {
             "headline": {
                 "type": "string",
-                "required": true,
+                "required": false,
                 "nullable": false,
                 "empty": false,
                 "maxlength": 64
@@ -793,17 +793,17 @@
             },
             "urgency": {
                 "type": "integer",
-                "required": true,
+                "required": false,
                 "allowed": [1, 2, 3, 4, 5]
             },
             "priority": {
                 "type": "integer",
-                "required": true,
+                "required": false,
                 "allowed": [1, 2, 3, 4, 5, 6, 7, 8, 9]
             },
             "dateline": {
                 "type": "dict",
-                "required": true,
+                "required": false,
                 "schema": {
                     "located": {"type": "dict", "required": true},
                     "text": {"type": "string", "required": true}
@@ -830,7 +830,7 @@
         "schema": {
             "headline": {
                 "type": "string",
-                "required": true,
+                "required": false,
                 "nullable": false,
                 "empty": false,
                 "maxlength": 64
@@ -869,17 +869,17 @@
             },
             "urgency": {
                 "type": "integer",
-                "required": true,
+                "required": false,
                 "allowed": [1, 2, 3, 4, 5]
             },
             "priority": {
                 "type": "integer",
-                "required": true,
+                "required": false,
                 "allowed": [1, 2, 3, 4, 5, 6, 7, 8, 9]
             },
             "dateline": {
                 "type": "dict",
-                "required": true,
+                "required": false,
                 "schema": {
                     "located": {"type": "dict", "required": true},
                     "text": {"type": "string", "required": true}
@@ -906,7 +906,7 @@
         "schema": {
             "headline": {
                 "type": "string",
-                "required": true,
+                "required": false,
                 "nullable": false,
                 "empty": false,
                 "maxlength": 64
@@ -945,17 +945,17 @@
             },
             "urgency": {
                 "type": "integer",
-                "required": true,
+                "required": false,
                 "allowed": [1, 2, 3, 4, 5]
             },
             "priority": {
                 "type": "integer",
-                "required": true,
+                "required": false,
                 "allowed": [1, 2, 3, 4, 5, 6, 7, 8, 9]
             },
             "dateline": {
                 "type": "dict",
-                "required": true,
+                "required": false,
                 "schema": {
                     "located": {"type": "dict", "required": true},
                     "text": {"type": "string", "required": true}
@@ -982,7 +982,7 @@
         "schema": {
             "headline": {
                 "type": "string",
-                "required": true,
+                "required": false,
                 "nullable": false,
                 "empty": false,
                 "maxlength": 64
@@ -1021,17 +1021,17 @@
             },
             "urgency": {
                 "type": "integer",
-                "required": true,
+                "required": false,
                 "allowed": [1, 2, 3, 4, 5]
             },
             "priority": {
                 "type": "integer",
-                "required": true,
+                "required": false,
                 "allowed": [1, 2, 3, 4, 5, 6, 7, 8, 9]
             },
             "dateline": {
                 "type": "dict",
-                "required": true,
+                "required": false,
                 "schema": {
                     "located": {"type": "dict", "required": true},
                     "text": {"type": "string", "required": true}
@@ -1058,7 +1058,7 @@
         "schema": {
             "headline": {
                 "type": "string",
-                "required": true,
+                "required": false,
                 "nullable": false,
                 "empty": false,
                 "maxlength": 64
@@ -1097,17 +1097,17 @@
             },
             "urgency": {
                 "type": "integer",
-                "required": true,
+                "required": false,
                 "allowed": [1, 2, 3, 4, 5]
             },
             "priority": {
                 "type": "integer",
-                "required": true,
+                "required": false,
                 "allowed": [1, 2, 3, 4, 5, 6, 7, 8, 9]
             },
             "dateline": {
                 "type": "dict",
-                "required": true,
+                "required": false,
                 "schema": {
                     "located": {"type": "dict", "required": true},
                     "text": {"type": "string", "required": true}
@@ -1134,7 +1134,7 @@
         "schema": {
             "headline": {
                 "type": "string",
-                "required": true,
+                "required": false,
                 "nullable": false,
                 "empty": false,
                 "maxlength": 64
@@ -1168,12 +1168,12 @@
             },
             "urgency": {
                 "type": "integer",
-                "required": true,
+                "required": false,
                 "allowed": [1, 2, 3, 4, 5]
             },
             "priority": {
                 "type": "integer",
-                "required": true,
+                "required": false,
                 "allowed": [1, 2, 3, 4, 5, 6, 7, 8, 9]
             },
             "groups": {
@@ -1189,7 +1189,7 @@
         "schema": {
             "headline": {
                 "type": "string",
-                "required": true,
+                "required": false,
                 "nullable": false,
                 "empty": false,
                 "maxlength": 64
@@ -1223,12 +1223,12 @@
             },
             "urgency": {
                 "type": "integer",
-                "required": true,
+                "required": false,
                 "allowed": [1, 2, 3, 4, 5]
             },
             "priority": {
                 "type": "integer",
-                "required": true,
+                "required": false,
                 "allowed": [1, 2, 3, 4, 5, 6, 7, 8, 9]
             },
             "groups": {
@@ -1244,7 +1244,7 @@
         "schema": {
             "headline": {
                 "type": "string",
-                "required": true,
+                "required": false,
                 "nullable": false,
                 "empty": false,
                 "maxlength": 64
@@ -1278,12 +1278,12 @@
             },
             "urgency": {
                 "type": "integer",
-                "required": true,
+                "required": false,
                 "allowed": [1, 2, 3, 4, 5]
             },
             "priority": {
                 "type": "integer",
-                "required": true,
+                "required": false,
                 "allowed": [1, 2, 3, 4, 5, 6, 7, 8, 9]
             },
             "groups": {


### PR DESCRIPTION
Resolves:
[SD-3460](https://dev.sourcefabric.org/browse/SD-3460) Header length being appropriate still gives an error before publish
[SD-3513](https://dev.sourcefabric.org/browse/SD-3513) Cannot kill or correct video items. Also, added/modified validator definition for other content types.

**Information to Mergers**
After merging, please drop validators collection and recreate from the `validators.json` file.