### PR TITLE
(fix) Modified code to intercept the login and logout to open/close websockets

### DIFF
--- a/client/app/scripts/superdesk/auth/auth.js
+++ b/client/app/scripts/superdesk/auth/auth.js
@@ -62,6 +62,10 @@ define([
     }
 
     angular.module('superdesk.session', [])
+        .constant('SESSION_EVENTS', {
+            LOGIN: 'login',
+            LOGOUT: 'logout'
+        })
         .service('session', require('./session-service'));
 
     return angular.module('superdesk.auth', [

--- a/client/app/scripts/superdesk/auth/session-service.js
+++ b/client/app/scripts/superdesk/auth/session-service.js
@@ -63,9 +63,9 @@ define(['lodash'], function(_) {
             setToken(session.token);
             setSessionId(session._id);
             setSessionHref(session._links && session._links.self.href);
-
             this.identity = null;
             resolveIdentity(this.updateIdentity(identity));
+            $rootScope.$broadcast('login');
         };
 
         function resolveIdentity(identity) {
@@ -83,6 +83,7 @@ define(['lodash'], function(_) {
             this.sessionId = null;
             setToken(null);
             setSessionId(null);
+            $rootScope.$broadcast('logout');
         };
 
         /**

--- a/client/app/scripts/superdesk/auth/session-service.js
+++ b/client/app/scripts/superdesk/auth/session-service.js
@@ -4,8 +4,8 @@ define(['lodash'], function(_) {
     /**
      * Session Service stores current user data
      */
-    SessionService.$inject = ['$q', '$rootScope', 'storage'];
-    function SessionService($q, $rootScope, storage) {
+    SessionService.$inject = ['$q', '$rootScope', 'storage', 'SESSION_EVENTS'];
+    function SessionService($q, $rootScope, storage, SESSION_EVENTS) {
 
         var TOKEN_KEY = 'sess:token';
         var TOKEN_HREF = 'sess:href';
@@ -65,7 +65,7 @@ define(['lodash'], function(_) {
             setSessionHref(session._links && session._links.self.href);
             this.identity = null;
             resolveIdentity(this.updateIdentity(identity));
-            $rootScope.$broadcast('login');
+            $rootScope.$broadcast(SESSION_EVENTS.LOGIN);
         };
 
         function resolveIdentity(identity) {
@@ -83,7 +83,7 @@ define(['lodash'], function(_) {
             this.sessionId = null;
             setToken(null);
             setSessionId(null);
-            $rootScope.$broadcast('logout');
+            $rootScope.$broadcast(SESSION_EVENTS.LOGOUT);
         };
 
         /**

--- a/client/app/scripts/superdesk/auth/session-service_spec.js
+++ b/client/app/scripts/superdesk/auth/session-service_spec.js
@@ -32,11 +32,14 @@ define([
             expect(session.identity.name).toBe('user');
         }));
 
-        it('can be set expired', inject(function (session) {
+        it('can be set expired', inject(function (session, $rootScope) {
+            spyOn($rootScope, '$broadcast');
             session.start(SESSION, {name: 'foo'});
+            expect($rootScope.$broadcast).toHaveBeenCalledWith('login');
             session.expire();
             expect(session.token).toBe(null);
             expect(session.identity.name).toBe('foo');
+            expect($rootScope.$broadcast).toHaveBeenCalledWith('logout');
         }));
 
         it('can resolve identity on start', inject(function (session, $rootScope) {

--- a/client/app/scripts/superdesk/notification/notification.js
+++ b/client/app/scripts/superdesk/notification/notification.js
@@ -10,8 +10,8 @@
 (function() {
     'use strict';
 
-    WebSocketProxy.$inject = ['$rootScope', 'config', '$interval'];
-    function WebSocketProxy($rootScope, config, $interval) {
+    WebSocketProxy.$inject = ['$rootScope', 'config', '$interval', 'session'];
+    function WebSocketProxy($rootScope, config, $interval, session) {
 
         var ws = null;
         var connectTimer = -1;
@@ -35,8 +35,17 @@
         }
 
         var connect = function() {
-            ws = new WebSocket(config.server.ws);
-            bindEvents();
+            if (!ws) {
+                ws = new WebSocket(config.server.ws);
+                bindEvents();
+            }
+        };
+
+        var disconnect = function() {
+            if (ws) {
+                ws.close();
+                ws = null;
+            }
         };
 
         var bindEvents = function() {
@@ -61,7 +70,7 @@
                 $rootScope.$broadcast('disconnected');
                 $interval.cancel(connectTimer);
                 connectTimer = $interval(function() {
-                    if (ws) {
+                    if (ws && session.sessionId) {
                         connect();  // Retry to connect for every TIMEOUT interval.
                     }
                 }, TIMEOUT, 0, false);  // passed invokeApply = false to prevent triggering digest cycle
@@ -69,6 +78,14 @@
         };
 
         connect();
+
+        $rootScope.$on('logout', function(event) {
+            disconnect();
+        });
+
+        $rootScope.$on('login', function(event) {
+            connect();
+        });
     }
 
     /**

--- a/client/app/scripts/superdesk/notification/notification.js
+++ b/client/app/scripts/superdesk/notification/notification.js
@@ -10,8 +10,8 @@
 (function() {
     'use strict';
 
-    WebSocketProxy.$inject = ['$rootScope', 'config', '$interval', 'session'];
-    function WebSocketProxy($rootScope, config, $interval, session) {
+    WebSocketProxy.$inject = ['$rootScope', 'config', '$interval', 'session', 'SESSION_EVENTS'];
+    function WebSocketProxy($rootScope, config, $interval, session, SESSION_EVENTS) {
 
         var ws = null;
         var connectTimer = -1;
@@ -79,13 +79,9 @@
 
         connect();
 
-        $rootScope.$on('logout', function(event) {
-            disconnect();
-        });
+        $rootScope.$on(SESSION_EVENTS.LOGOUT, disconnect);
 
-        $rootScope.$on('login', function(event) {
-            connect();
-        });
+        $rootScope.$on(SESSION_EVENTS.LOGIN, connect);
     }
 
     /**


### PR DESCRIPTION
[SD-3548](https://dev.sourcefabric.org/browse/SD-3548)

Close the websocket on session timeout or logout and open the websocket on login. This will stop the events getting fired on the client after session timeout or logout.