### PR TITLE
(fix) Reuters ingest routing

### DIFF
--- a/server/apps/io/reuters.py
+++ b/server/apps/io/reuters.py
@@ -13,7 +13,7 @@
 import traceback
 import datetime
 from urllib.parse import urlparse, urlunparse
-
+from superdesk.logging import logger
 import requests
 
 from superdesk.io.ingest_service import IngestService
@@ -102,9 +102,12 @@ class ReutersIngestService(IngestService):
         ids = []
         payload = {'channel': channel, 'fieldsRef': 'id'}
         payload['dateRange'] = "%s-%s" % (self.format_date(last_updated), self.format_date(updated))
+        logger.info('Reuters requesting Date Range |{}| for channel {}'.format(payload['dateRange'], channel))
         tree = self.get_tree('items', payload)
         for result in tree.findall('result'):
-            ids.append(result.find('guid').text)
+            id = result.find('guid').text
+            if id not in ids:
+                ids.append(id)
         return ids
 
     def get_channels(self):

--- a/server/apps/io/reuters.py
+++ b/server/apps/io/reuters.py
@@ -99,15 +99,13 @@ class ReutersIngestService(IngestService):
 
     def get_ids(self, channel, last_updated, updated):
         """Get ids of documents which should be updated."""
-        ids = []
+        ids = set()
         payload = {'channel': channel, 'fieldsRef': 'id'}
         payload['dateRange'] = "%s-%s" % (self.format_date(last_updated), self.format_date(updated))
         logger.info('Reuters requesting Date Range |{}| for channel {}'.format(payload['dateRange'], channel))
         tree = self.get_tree('items', payload)
         for result in tree.findall('result'):
-            id = result.find('guid').text
-            if id not in ids:
-                ids.append(id)
+            ids.add(result.find('guid').text)
         return ids
 
     def get_channels(self):

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -6,4 +6,4 @@ wooper==0.4.2
 pymongo==2.8
 Eve==0.6.0
 
--e git+git://github.com/superdesk/superdesk-core@a5ad19d#egg=Superdesk-Core==0.0.1-dev
+-e git+git://github.com/superdesk/superdesk-core@7f3a507#egg=Superdesk-Core==0.0.1-dev


### PR DESCRIPTION
Requires superdesk/superdesk-core#65
It seems that the dateRange request to Reuters may return duplicated guids