### PR TITLE
Make search by slugline work

### DIFF
--- a/client/app/scripts/superdesk-search/search.js
+++ b/client/app/scripts/superdesk-search/search.js
@@ -202,7 +202,7 @@
 
                 if (search.q) {
                     criteria.query.filtered.query = {query_string: {
-                        query: search.q,
+                        query: search.q.replace(/\//g, '\\/'),
                         lenient: false,
                         default_operator: 'AND'
                     }};

--- a/client/spec/search_spec.js
+++ b/client/spec/search_spec.js
@@ -76,6 +76,17 @@ describe('Search', function() {
         expect(globalSearch.getItems().count()).toBe(1);
     });
 
+    it('can search by slugline', function () {
+        globalSearch.openFilterPanel();
+        expect(globalSearch.getItems().count()).toBe(10);
+        globalSearch.openParameters();
+        var bylineTextbox = element(by.id('search-slugline'));
+        bylineTextbox.clear();
+        bylineTextbox.sendKeys('one/two');
+        globalSearch.goButton.click();
+        expect(globalSearch.getItems().count()).toBe(1);
+    });
+
     it('can search by original creator', function () {
         globalSearch.openFilterPanel();
         expect(globalSearch.getItems().count()).toBe(10);

--- a/server/apps/prepopulate/app_prepopulate_data.json
+++ b/server/apps/prepopulate/app_prepopulate_data.json
@@ -538,7 +538,7 @@
         "username": "admin",
         "data": {
             "headline": "item5",
-            "slugline": "item5 slugline",
+            "slugline": "item5 slugline one/two ",
             "body_html" : "<p>item5 text</p>",
             "type": "text",
             "guid": "item5",

--- a/server/features/search.feature
+++ b/server/features/search.feature
@@ -119,3 +119,14 @@ Feature: Search Feature
         Then we get list with 1 items
         When we get "/archive/#archive._id#"
         Then we get response code 200
+
+    @auth
+    Scenario: Search by slugline
+        Given "ingest"
+            """
+            [{"guid": "1", "slugline": "ABUSE PHOTO"}]
+            """
+        When we get "/search?source={"query":{"filtered":{"filter": null,"query":{"query_string":{"query":"slugline:(abuse)","lenient":false,"default_operator":"AND"}}}}}"
+        Then we get list with 1 items
+        When we get "/search?source={"query":{"filtered":{"filter": null,"query":{"query_string":{"query":"slugline:(absent)","lenient":false,"default_operator":"AND"}}}}}"
+        Then we get list with 0 items

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -6,4 +6,4 @@ wooper==0.4.2
 pymongo==2.8
 Eve==0.6.0
 
--e git+git://github.com/superdesk/superdesk-core@8f0f5f3#egg=Superdesk-Core==0.0.1-dev
+-e git+git://github.com/superdesk/superdesk-core@8e843fc#egg=Superdesk-Core==0.0.1-dev


### PR DESCRIPTION
Tests for slugline search.

Also allows search for things that have a / in them, say AC/DC in the headline.

The PR is dependent on superdesk/superdesk-core#71