### PR TITLE
(fix) [SD-3663] Takes are being created in the default incoming stage instead of the working stage

### DIFF
--- a/server/apps/archive/archive_link.py
+++ b/server/apps/archive/archive_link.py
@@ -63,7 +63,7 @@ class ArchiveLinkService(Service):
             if not desk:
                 raise SuperdeskApiError.forbiddenError("No privileges to create new take on requested desk.")
 
-            link['task']['stage'] = desk['incoming_stage']
+            link['task']['stage'] = desk['working_stage']
 
         if link_id:
             link = service.find_one(req=None, _id=link_id)

--- a/server/features/content_link.feature
+++ b/server/features/content_link.feature
@@ -793,6 +793,7 @@ Feature: Link content in takes
                 "type": "composite"
             },
             "linked_in_packages": [{"package_type" : "takes","package" : "#TAKE_PACKAGE#"}],
+            "task": {"desk": "#desks._id#", "stage": "#desks.working_stage#"},
             "priority": 1,
             "urgency": 1,
             "ednote": "ednote",


### PR DESCRIPTION
Resolves: [SD-3663](https://dev.sourcefabric.org/browse/SD-3663)