### PR TITLE
[SD-2450] Automatic routing to publish

### DIFF
--- a/server/apps/publish/content/common.py
+++ b/server/apps/publish/content/common.py
@@ -157,6 +157,7 @@ class BasePublishService(BaseService):
         try:
             user = get_user()
             last_updated = updates.get(config.LAST_UPDATED, utcnow())
+            auto_publish = updates.pop('auto_publish', False)
 
             if original[ITEM_TYPE] == CONTENT_TYPE.COMPOSITE:
                 self._publish_package_items(original, updates)
@@ -204,7 +205,7 @@ class BasePublishService(BaseService):
                     logger.exception('Nothing is saved to publish queue for story: {} for action: {}'.
                                      format(original[config.ID_FIELD], self.publish_type))
 
-            self._update_archive(original=original, updates=updates, should_insert_into_versions=False)
+            self._update_archive(original=original, updates=updates, should_insert_into_versions=auto_publish)
             push_notification('item:publish', item=str(id), unique_name=original['unique_name'],
                               desk=str(original.get('task', {}).get('desk', '')),
                               user=str(user.get(config.ID_FIELD, '')))

--- a/server/apps/rules/routing_rules.py
+++ b/server/apps/rules/routing_rules.py
@@ -434,6 +434,6 @@ class RoutingRuleSchemeService(BaseService):
         items_to_publish = self.__fetch(ingest_item, destinations)
         for item in items_to_publish:
             try:
-                get_resource_service('archive_publish').patch(item, {})
+                get_resource_service('archive_publish').patch(item, {'auto_publish': True})
             except:
                 logger.exception("Failed to publish item %s." % item)

--- a/server/features/steps/steps.py
+++ b/server/features/steps/steps.py
@@ -368,6 +368,15 @@ def step_impl_fetch_from_provider_ingest_using_routing_with_desk(context, provid
         fetch_from_provider(context, provider_name, guid, routing_scheme, desk_id, stage_id)
 
 
+@when('we ingest with routing scheme "{provider_name}" "{guid}"')
+def step_impl_ingest_with_routing_scheme(context, provider_name, guid):
+    with context.app.test_request_context(context.app.config['URL_PREFIX']):
+        _id = apply_placeholders(context, context.text)
+        routing_scheme = get_resource_service('routing_schemes').find_one(_id=_id, req=None)
+        embed_routing_scheme_rules(routing_scheme)
+        fetch_from_provider(context, provider_name, guid, routing_scheme)
+
+
 def fetch_from_provider(context, provider_name, guid, routing_scheme=None, desk_id=None, stage_id=None):
     ingest_provider_service = get_resource_service('ingest_providers')
     provider = ingest_provider_service.find_one(name=provider_name, req=None)

--- a/server/macros/update_to_pass_validation.py
+++ b/server/macros/update_to_pass_validation.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013, 2014 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+from superdesk.locators.locators import find_cities
+import logging
+from apps.archive.common import format_dateline_to_locmmmddsrc
+from superdesk.utc import get_date
+
+logger = logging.getLogger(__name__)
+
+
+def update_to_pass_validation(item, **kwargs):
+    """
+    This is a test macro that does what is required to ensure that a text item will pass publication validation.
+    It is intended to be used to test auto publishing, that is publishing directly from ingest.
+    At the moment virtually all content received from Reuters fails validation.
+    :param item:
+    :param kwargs:
+    :return:
+    """
+    try:
+        item['slugline'] = item['slugline'][:24] if len(item['slugline']) > 24 else item['slugline']
+        item['headline'] = item['headline'][:64] if len(item['headline']) > 64 else item['headline']
+        if 'dateline' not in item:
+            cities = find_cities(country_code='AU', state_code='NSW')
+            located = [c for c in cities if c['city'].lower() == 'sydney']
+            if located:
+                item['dateline'] = {'date': item['firstcreated'], 'located': located[0]}
+            item['dateline']['source'] = item['source']
+            item['dateline']['text'] = format_dateline_to_locmmmddsrc(located[0], get_date(item['firstcreated']),
+                                                                      source=item['source'])
+        return item
+    except:
+        logging.exception('Test update to pass validation macro exception')
+
+name = 'update to pass validation'
+label = 'Update to pass validation'
+shortcut = '$'
+callback = update_to_pass_validation


### PR DESCRIPTION
It seems that if the publish happens due to a routing rule we do not get a version created in archive_versions, presumably due to the fact that the publish is not done under the eve context, this PR fixes that. (not in love with the solution, would be happy for alternative suggestions)

It also includes a macro that will truncate the headline, slugline and adds a dateline (bogus), this is to allow Reuters content to pass validation and successfully publish, in order for the functionality to be tested.