### PR TITLE
Editor: when multiBlockEdition is true, wrap all blocks into paragraphs SDPA-49

### DIFF
--- a/client/app/scripts/superdesk/editor/editor.js
+++ b/client/app/scripts/superdesk/editor/editor.js
@@ -625,7 +625,7 @@ function SdTextEditorController(_) {
         },
         commitChanges: function() {
             var new_body = '';
-            if (vm.blocks.length > 1) {
+            if (vm.config.multiBlockEdition) {
                 vm.blocks.forEach(function(block) {
                     if (angular.isDefined(block.body) && block.body.trim() !== '') {
                         if (block.blockType === 'embed') {
@@ -857,11 +857,12 @@ angular.module('superdesk.editor', ['superdesk.editor.spellcheck', 'angular-embe
             templateUrl: 'scripts/superdesk/editor/views/editor.html',
             controllerAs: 'vm',
             controller: SdTextEditorController,
+            bindToController: true,
             link: function(scope, element, attr, controllers) {
                 var controller = controllers[0];
                 var ngModel = controllers[1];
                 $timeout(function() {
-                    if (scope.config.multiBlockEdition) {
+                    if (controller.config.multiBlockEdition) {
                         controller.initEditorWithMultipleBlock(ngModel);
                     } else {
                         controller.initEditorWithOneBlock(ngModel);

--- a/client/app/scripts/superdesk/editor/views/editor.html
+++ b/client/app/scripts/superdesk/editor/views/editor.html
@@ -1,5 +1,5 @@
 <div ng-repeat="block in vm.blocks" class="block__container">
-    <div ng-if="config.multiBlockEdition" class="block__remove" ng-click="vm.removeBlock(block)">
+    <div ng-if="vm.config.multiBlockEdition" class="block__remove" ng-click="vm.removeBlock(block)">
         <i class="icon-close-small"></i>
     </div>
     <div sd-text-editor-block-embed
@@ -9,10 +9,10 @@
     </div>
     <div sd-text-editor-block-text="block"
          ng-if="block.blockType === 'text'"
-         type="type"
-         config="config"
-         language="language"
+         type="vm.type"
+         config="vm.config"
+         language="vm.language"
          ng-change="vm.commitChanges()"
          ng-model="block.body"></div>
-    <sd-add-embed ng-if="config.multiBlockEdition" class="block__add-embed"></sd-add-embed>
+    <sd-add-embed ng-if="vm.config.multiBlockEdition" class="block__add-embed"></sd-add-embed>
 </div>


### PR DESCRIPTION
When creating a story with a single paragraph (e.g. a SNAP) HTML P tags was not including in the resulting response.