### PR TITLE
fix(templates): ignore template timestamps

### DIFF
--- a/server/apps/templates/content_templates.py
+++ b/server/apps/templates/content_templates.py
@@ -263,6 +263,8 @@ def get_item_from_template(template):
     item[ITEM_STATE] = CONTENT_STATE.SUBMITTED
     item['task'] = {'desk': template.get('template_desk'), 'stage': template.get('template_stage')}
     item['template'] = item.pop('_id')
+    item.pop('firstcreated', None)
+    item.pop('versioncreated', None)
     return item
 
 

--- a/server/features/steps/steps.py
+++ b/server/features/steps/steps.py
@@ -11,6 +11,7 @@
 
 import os
 import time
+import arrow
 from datetime import datetime, timedelta
 from superdesk.io.commands.update_ingest import LAST_ITEM_UPDATE
 import superdesk
@@ -84,6 +85,17 @@ def test_key_is_present(key, context, response):
         '"%s" should be empty or false, but it was "%s" in (%s)' % (key, response[key], response)
 
 
+def assert_is_now(val, key):
+    """Assert that given datetime value is now (with 5s tolerance).
+
+    :param val: datetime
+    :param key: val label - used for error reporting
+    """
+    now = arrow.get()
+    val = arrow.get(val)
+    assert val + timedelta(seconds=3) > now, '%s should be now, it is %s' % (key, val)
+
+
 def json_match(context_data, response_data):
     if isinstance(context_data, dict):
         assert isinstance(response_data, dict), 'response data is not dict, but %s' % type(response_data)
@@ -94,6 +106,9 @@ def json_match(context_data, response_data):
             if context_data[key] == "__any_value__":
                 test_key_is_present(key, context_data, response_data)
                 continue
+            if context_data[key] == "__now__":
+                assert_is_now(response_data[key], key)
+                return True
             if not json_match(context_data[key], response_data[key]):
                 return False
         return True

--- a/server/features/templates.feature
+++ b/server/features/templates.feature
@@ -67,7 +67,7 @@ Feature: Templates
 
         When we post to "content_templates"
         """
-        {"template_name": "test", "template_type": "create", "headline": "test", "type": "text", "slugline": "test",
+        {"template_name": "test", "template_type": "create", "headline": "test", "type": "text", "slugline": "test", "firstcreated": "2015-10-10T10:10:10+0000", "versioncreated": "2015-10-10T10:10:10+0000",
          "schedule": {"day_of_week": ["MON"], "create_at": "0815", "is_active": true},
          "template_desk": "#desks._id#", "template_stage": "#stages._id#"}
         """
@@ -84,6 +84,9 @@ Feature: Templates
         And we run create content task
         And we get "/archive"
         Then we get list with 1 items
+        """
+        {"_items": [{"firstcreated": "__now__", "versioncreated": "__now__"}]}
+        """
 
     @auth
     Scenario: Apply template to an item


### PR DESCRIPTION
when creating an item from template generate first/version created fields

SD-3433