### PR TITLE
[SD-3627] (fix) Refactoring of content expiry

### DIFF
--- a/client/app/scripts/superdesk-desks/desks.js
+++ b/client/app/scripts/superdesk-desks/desks.js
@@ -882,6 +882,9 @@
                         if (item && item[expiryfield] != null) {
                             scope.ContentExpiry.Hours = getExpiryHours(item[expiryfield]);
                             scope.ContentExpiry.Minutes = getExpiryMinutes(item[expiryfield]);
+                        } else {
+                            scope.ContentExpiry.Hours = 0;
+                            scope.ContentExpiry.Minutes = 0;
                         }
                     };
                 }

--- a/client/app/scripts/superdesk-desks/views/desk-config-modal.html
+++ b/client/app/scripts/superdesk-desks/views/desk-config-modal.html
@@ -16,7 +16,9 @@
                             <span class="pull-right" sd-character-count data-item="desk.edit.name" data-limit="limits.desk"></span>
                             <div class="field">
                                 <label translate>Desk name</label>
-                                <input type="text" class="fullwidth-input" ng-model="desk.edit.name" ng-keyup="handleEdit($event);" required>
+                                <input type="text" class="fullwidth-input"
+                                       ng-model="desk.edit.name"
+                                       ng-keyup="handleEdit($event);" required>
                             </div>
                             <div class="field">
                                 <label translate>Desk description</label>
@@ -24,24 +26,17 @@
                             </div>
                             <div class="field">
                                 <label translate>Source for User Created Articles</label>
-                                <input type="text" class="fullwidth-input" ng-model="desk.edit.source" ng-keyup="handleEdit($event);" required>
+                                <input type="text" class="fullwidth-input"
+                                       ng-model="desk.edit.source"
+                                       ng-keyup="handleEdit($event);" required>
                             </div>
-                            <ul class="expiry">
-                                <li>
-                                    <div sd-content-expiry
-                                         data-item="desk.edit"
-                                         data-preview="false"
-                                         data-expiryfield="spike_expiry"
-                                         data-header="Spike Expiry"></div>
-                                </li>
-                                <li>
-                                    <div sd-content-expiry
-                                         data-item="desk.edit"
-                                         data-preview="false"
-                                         data-expiryfield="published_item_expiry"
-                                         data-header="Published Item Expiry"></div>
-                                </li>
-                            </ul>
+                            <div class="field">
+                                <div sd-content-expiry
+                                     data-item="desk.edit"
+                                     data-preview="false"
+                                     data-expiryfield="content_expiry"
+                                     data-header="Content Expiry"></div>
+                            </div>
                             <div class="field desk-type">
                                 <label translate>Desk Type</label>
                                 <select id="deskType" ng-model="desk.edit.desk_type"

--- a/client/spec/desks_spec.js
+++ b/client/spec/desks_spec.js
@@ -21,6 +21,7 @@ describe('desks', function() {
         desks.deskDescriptionElement().sendKeys('New Description');
         desks.deskSourceElement().sendKeys('Test');
         desks.setDeskType('production');
+        desks.setDeskContentExpiry(1, 10);
         desks.actionSaveAndContinueOnGeneralTab();
         desks.showTab('macros');
         desks.save();
@@ -28,6 +29,8 @@ describe('desks', function() {
         expect(desks.deskDescriptionElement().getAttribute('value')).toEqual('New Description');
         expect(desks.deskSourceElement().getAttribute('value')).toEqual('Test');
         expect(desks.getDeskType().getAttribute('value')).toEqual('string:production');
+        expect(desks.getDeskContentExpiryHours().getAttribute('value')).toEqual('1');
+        expect(desks.getDeskContentExpiryMinutes().getAttribute('value')).toEqual('10');
     });
 
     it('add desk', function() {
@@ -36,6 +39,7 @@ describe('desks', function() {
         desks.deskDescriptionElement().sendKeys('Test Description');
         desks.deskSourceElement().sendKeys('Test Source');
         desks.setDeskType('authoring');
+        desks.setDeskContentExpiry(10, 1);
         desks.actionSaveAndContinueOnGeneralTab();
         desks.showTab('macros');
         desks.save();
@@ -44,6 +48,8 @@ describe('desks', function() {
         expect(desks.deskDescriptionElement().getAttribute('value')).toEqual('Test Description');
         expect(desks.deskSourceElement().getAttribute('value')).toEqual('Test Source');
         expect(desks.getDeskType().getAttribute('value')).toEqual('string:authoring');
+        expect(desks.getDeskContentExpiryHours().getAttribute('value')).toEqual('10');
+        expect(desks.getDeskContentExpiryMinutes().getAttribute('value')).toEqual('1');
     });
 
     it('add desk with Done action', function() {
@@ -52,12 +58,15 @@ describe('desks', function() {
         desks.deskDescriptionElement().sendKeys('Test Description');
         desks.deskSourceElement().sendKeys('Test Source');
         desks.setDeskType('authoring');
+        desks.setDeskContentExpiry(10, 1);
         desks.actionDoneOnGeneralTab();
         desks.edit('Test Desk');
         expect(desks.deskNameElement().getAttribute('value')).toEqual('Test Desk');
         expect(desks.deskDescriptionElement().getAttribute('value')).toEqual('Test Description');
         expect(desks.deskSourceElement().getAttribute('value')).toEqual('Test Source');
         expect(desks.getDeskType().getAttribute('value')).toEqual('string:authoring');
+        expect(desks.getDeskContentExpiryHours().getAttribute('value')).toEqual('10');
+        expect(desks.getDeskContentExpiryMinutes().getAttribute('value')).toEqual('1');
     });
 
     it('add desk reflects default stage count', function() {

--- a/client/spec/helpers/desks.js
+++ b/client/spec/helpers/desks.js
@@ -232,4 +232,35 @@ function Desks() {
     this.getNewDeskButton = function() {
         return element(by.id('add-new-desk'));
     };
+
+    /**
+     * Get the Desk Content Expiry Hours.
+     * @returns {ElementFinder} Content Expiry Hours input element
+     */
+    this.getDeskContentExpiryHours = function() {
+        return element(by.model('ContentExpiry.Hours'));
+    };
+
+    /**
+     * Get the Desk Content Expiry Minutes.
+     * @returns {ElementFinder} Content Expiry Minutes input element
+     */
+    this.getDeskContentExpiryMinutes = function() {
+        return element(by.model('ContentExpiry.Minutes'));
+    };
+
+    /**
+     * Set the Desk Content Expiry.
+     * @param {int} hours
+     * @param {int} minutes
+     */
+    this.setDeskContentExpiry = function(hours, minutes) {
+        var hoursElm = this.getDeskContentExpiryHours(),
+            minutesElm = this.getDeskContentExpiryMinutes();
+
+        hoursElm.clear();
+        hoursElm.sendKeys(hours);
+        minutesElm.clear();
+        minutesElm.sendKeys(minutes);
+    };
 }

--- a/server/apps/prepopulate/data_initialization/desks.json
+++ b/server/apps/prepopulate/data_initialization/desks.json
@@ -64,7 +64,7 @@
             {"user": "54ed94da10245479ccc38410"}
         ],
         "name": "National",
-        "spike_expiry": 1440,
+        "content_expiry": 1440,
         "desk_type": "production"
     },
     {
@@ -126,7 +126,7 @@
             {"user": "54ed955910245479d505d296"}
         ],
         "name": "World news",
-        "spike_expiry": 1440,
+        "content_expiry": 1440,
         "desk_type": "production"
     },
     {
@@ -188,7 +188,7 @@
             {"user": "54ed955910245479d505d2a3"}
         ],
         "name": "Finance",
-        "spike_expiry": 1440,
+        "content_expiry": 1440,
         "desk_type": "production"
     },
     {
@@ -221,7 +221,7 @@
             {"user": "54ed952410245479ccc38447"}
         ],
         "name": "New Zealand",
-        "spike_expiry": 1440,
+        "content_expiry": 1440,
         "desk_type": "production"
     },
     {
@@ -300,7 +300,7 @@
             {"user": "54ed952410245479ccc3846c"}
         ],
         "name": "Sport",
-        "spike_expiry": 1440,
+        "content_expiry": 1440,
         "desk_type": "production"
     },
     {
@@ -327,7 +327,7 @@
             {"user": "54ed955910245479d505d295"}
         ],
         "name": "Features",
-        "spike_expiry": 1440,
+        "content_expiry": 1440,
         "desk_type": "production"
     },
     {
@@ -348,7 +348,7 @@
             {"user": "54ed952410245479ccc38477"}
         ],
         "name": "Special",
-        "spike_expiry": 1440,
+        "content_expiry": 1440,
         "desk_type": "production"
     },
     {
@@ -366,7 +366,7 @@
             {"user": "54ed955910245479d505d2a2"}
         ],
         "name": "Perth",
-        "spike_expiry": 4320,
+        "content_expiry": 4320,
         "desk_type": "authoring"
     },
     {
@@ -384,7 +384,7 @@
             {"user": "54ed955910245479d505d2a1"}
         ],
         "name": "Melbourne",
-        "spike_expiry": 4320,
+        "content_expiry": 4320,
         "desk_type": "authoring"
     },
     {
@@ -402,7 +402,7 @@
             {"user": "54ed955910245479d505d292"}
         ],
         "name": "Darwin",
-        "spike_expiry": 43200,
+        "content_expiry": 4320,
         "desk_type": "authoring"
     },
     {
@@ -419,7 +419,7 @@
             {"user": "54ed955910245479d505d299"}
         ],
         "name": "Adelaide",
-        "spike_expiry": 4320,
+        "content_expiry": 4320,
         "desk_type": "authoring"
     },
     {
@@ -437,7 +437,7 @@
             {"user": "54ed955910245479d505d29f"}
         ],
         "name": "Canberra",
-        "spike_expiry": 4320,
+        "content_expiry": 4320,
         "desk_type": "authoring"
     },
     {
@@ -455,7 +455,7 @@
             {"user": "54ed955910245479d505d29e"}
         ],
         "name": "Hobart",
-        "spike_expiry": 4320,
+        "content_expiry": 4320,
         "desk_type": "authoring"
     },
     {
@@ -472,7 +472,7 @@
             {"user": "54ed955910245479d505d29c"}
         ],
         "name": "Brisbane",
-        "spike_expiry": 4320,
+        "content_expiry": null,
         "desk_type": "authoring"
     },
     {
@@ -488,7 +488,7 @@
             {"user": "54ed946e10245479ccc38398"}
         ],
         "name": "Sydney",
-        "spike_expiry": 4320,
+        "content_expiry": null,
         "desk_type": "authoring"
     },
     {
@@ -506,7 +506,7 @@
             {"user": "54ed955910245479d505d28e"}
         ],
         "name": "Jakarta",
-        "spike_expiry": 4320,
+        "content_expiry": 4320,
         "desk_type": "authoring"
     },
     {
@@ -524,7 +524,7 @@
             {"user": "54ed955910245479d505d296"}
         ],
         "name": "London",
-        "spike_expiry": 4320,
+        "content_expiry": 4320,
         "desk_type": "authoring"
     },
     {
@@ -540,7 +540,7 @@
             {"user": "54ed94da10245479ccc383e2"}
         ],
         "name": "Broadcast",
-        "spike_expiry": 1440,
+        "content_expiry": 1440,
         "desk_type": "production"
     }
 ]

--- a/server/apps/publish/publish_content_tests.py
+++ b/server/apps/publish/publish_content_tests.py
@@ -96,7 +96,7 @@ class PublishContentTests(SuperdeskTestCase):
                  'original_creator': '553cea4d1d41c85d4d42ff98',
                  'task': {'desk': 1}}]
 
-    desks = [{'_id': 1, 'spike_expiry': 20, 'incoming_stage': 1}]
+    desks = [{'_id': 1, 'content_expiry': 20, 'incoming_stage': 1}]
     stages = [{'_id': 1, 'desk': 1}]
     published = [{'guid': 'tag:localhost:2015:69b961ab-2816-4b8a-a974-xy4532fe33f9',
                   'item_id': '2',

--- a/server/apps/tasks_tests.py
+++ b/server/apps/tasks_tests.py
@@ -10,7 +10,6 @@
 
 from test_factory import SuperdeskTestCase
 from apps.archive.common import get_item_expiry
-from app import get_app
 from superdesk.utc import get_expiry_date
 from apps.tasks import apply_stage_rule, compare_dictionaries
 from nose.tools import assert_raises
@@ -19,26 +18,22 @@ from superdesk.errors import SuperdeskApiError
 
 class TasksTestCase(SuperdeskTestCase):
 
-    app = None
-
-    def setUp(self):
-        app_config = self.get_test_settings()
-        self.app = get_app(app_config)
-
-    def get_test_settings(self):
-        test_settings = {}
-        test_settings['CONTENT_EXPIRY_MINUTES'] = 99
-        return test_settings
-
     def test_get_global_content_expiry(self):
-        calculated_minutes = get_item_expiry(self.app, None)
-        reference_minutes = get_expiry_date(99)
+        calculated_minutes = get_item_expiry(desk=None, stage=None)
+        reference_minutes = get_expiry_date(self.ctx.app.config['CONTENT_EXPIRY_MINUTES'])
+        self.assertEquals(calculated_minutes.hour, reference_minutes.hour)
+        self.assertEquals(calculated_minutes.minute, reference_minutes.minute)
+
+    def test_get_desk_content_expiry(self):
+        desk = {"content_expiry": 10}
+        calculated_minutes = get_item_expiry(desk=desk, stage=None)
+        reference_minutes = get_expiry_date(10)
         self.assertEquals(calculated_minutes.hour, reference_minutes.hour)
         self.assertEquals(calculated_minutes.minute, reference_minutes.minute)
 
     def test_get_stage_content_expiry(self):
         stage = {"content_expiry": 10}
-        calculated_minutes = get_item_expiry(self.app, stage)
+        calculated_minutes = get_item_expiry(desk=None, stage=stage)
         reference_minutes = get_expiry_date(10)
         self.assertEquals(calculated_minutes.hour, reference_minutes.hour)
         self.assertEquals(calculated_minutes.minute, reference_minutes.minute)

--- a/server/features/archive.feature
+++ b/server/features/archive.feature
@@ -170,7 +170,7 @@ Feature: News Items Archive
     Scenario: Browse public content
         Given "desks"
         """
-        [{"name": "Sports Desk", "spike_expiry": 60}]
+        [{"name": "Sports Desk", "content_expiry": 60}]
         """
         Given "archive"
             """

--- a/server/features/content_spike.feature
+++ b/server/features/content_spike.feature
@@ -15,7 +15,7 @@ Feature: Content Spiking
         Then we get OK response
         And we get spiked content "item-1"
         And we get version 2
-        And we get global spike expiry
+        And we get global content expiry
         When we get "/archive/item-1"
         Then we get existing resource
         """
@@ -29,7 +29,7 @@ Feature: Content Spiking
         Given empty "stages"
         Given "desks"
         """
-        [{"name": "Sports Desk", "spike_expiry": 60}]
+        [{"name": "Sports Desk", "content_expiry": 60}]
         """
         Given "archive"
         """
@@ -90,7 +90,7 @@ Feature: Content Spiking
         Given empty "stages"
         Given "desks"
         """
-        [{"name": "Sports Desk", "spike_expiry": 60}]
+        [{"name": "Sports Desk", "content_expiry": 60}]
         """
         Given "archive"
         """
@@ -100,13 +100,13 @@ Feature: Content Spiking
         And we unspike "item-1"
         Then we get unspiked content "item-1"
         And we get version 3
-        And we get global content expiry
+        And we get desk spike expiry after "60"
 
     @auth
     Scenario: Sign Off changes when content is spiked or unspiked
         Given "desks"
         """
-        [{"name": "Sports Desk", "spike_expiry": 60}]
+        [{"name": "Sports Desk", "content_expiry": 60}]
         """
         When we post to "/archive" with success
         """

--- a/server/features/embargo.feature
+++ b/server/features/embargo.feature
@@ -9,7 +9,7 @@ Feature: Embargo Date and Time on an Article (User Story: https://dev.sourcefabr
     """
     And "desks"
     """
-    [{"name": "Sports", "published_item_expiry": "4320"}]
+    [{"name": "Sports", "content_expiry": "4320"}]
     """
     And "subscribers"
     """

--- a/server/features/search.feature
+++ b/server/features/search.feature
@@ -13,7 +13,7 @@ Feature: Search Feature
     Scenario: Can search archive
         Given "desks"
         """
-        [{"name": "Sports Desk", "spike_expiry": 60}]
+        [{"name": "Sports Desk", "content_expiry": 60}]
         """
         Given "archive"
             """
@@ -35,7 +35,7 @@ Feature: Search Feature
     Scenario: Can limit search to 1 result per shard
         Given "desks"
         """
-        [{"name": "Sports Desk", "spike_expiry": 60}]
+        [{"name": "Sports Desk", "content_expiry": 60}]
         """
         Given "archive"
         """

--- a/server/features/steps/steps.py
+++ b/server/features/steps/steps.py
@@ -1382,11 +1382,6 @@ def get_unspiked_content(context, id):
     # assert_equal(response_data['expiry'], None)
 
 
-@then('we get global spike expiry')
-def get_global_spike_expiry(context):
-    get_desk_spike_expiry(context, context.app.config['SPIKE_EXPIRY_MINUTES'])
-
-
 @then('we get global content expiry')
 def get_global_content_expiry(context):
     get_desk_spike_expiry(context, context.app.config['CONTENT_EXPIRY_MINUTES'])
@@ -1857,12 +1852,12 @@ def validate_published_item_expiry(context, publish_expiry_in_desk):
 
     if response_data.get('_meta') and response_data.get('_items'):
         for item in response_data.get('_items'):
-            assert_expiry(context, item, publish_expiry_in_desk)
+            assert_expiry(item, publish_expiry_in_desk)
     else:
-        assert_expiry(context, response_data, publish_expiry_in_desk)
+        assert_expiry(response_data, publish_expiry_in_desk)
 
 
-def assert_expiry(context, item, publish_expiry_in_desk):
+def assert_expiry(item, publish_expiry_in_desk):
     embargo = item.get('embargo')
     actual = parse_date(item.get('expiry'))
     error_message = 'Published Item Expiry validation fails'

--- a/server/features/tasks.feature
+++ b/server/features/tasks.feature
@@ -158,7 +158,7 @@ Feature: Tasks
     Scenario: Filter out tasks for spiked items
         Given "desks"
         """
-        [{"name": "Sports Desk", "spike_expiry": 60}]
+        [{"name": "Sports Desk", "content_expiry": 60}]
         """
         And "archive"
         """

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -6,5 +6,6 @@ wooper==0.4.2
 pymongo==2.8
 Eve==0.6.0
 
+
 -e git+git://github.com/superdesk/superdesk-core@b5de22a3#egg=Superdesk-Core==0.0.1-dev
 

--- a/server/settings.py
+++ b/server/settings.py
@@ -280,20 +280,13 @@ DEFAULT_TIMEZONE = env('DEFAULT_TIMEZONE', 'Europe/Prague')
 # The number of minutes since the last update of the Mongo auth object after which it will be deleted
 SESSION_EXPIRY_MINUTES = int(env('SESSION_EXPIRY_MINUTES', 240))
 
-# The number of minutes before spiked items purged
-SPIKE_EXPIRY_MINUTES = int(env('SPIKE_EXPIRY_MINUTES', 300))
-
 # The number of minutes before content items purged
 # akin.tolga 06/01/2014: using a large value (30 days) for the time being
-CONTENT_EXPIRY_MINUTES = int(env('CONTENT_EXPIRY_MINUTES', 43200))
+CONTENT_EXPIRY_MINUTES = int(env('CONTENT_EXPIRY_MINUTES', 4320))
 
 # The number of minutes before ingest items purged
 # 2880 = 2 days in minutes
 INGEST_EXPIRY_MINUTES = int(env('INGEST_EXPIRY_MINUTES', 2880))
-
-# The number of minutes before published items purged
-# 4320 = 3 days in minutes
-PUBLISHED_ITEMS_EXPIRY_MINUTES = int(env('PUBLISHED_ITEMS_EXPIRY_MINUTES', 4320))
 
 # This setting can be used to apply a limit on the elastic search queries, it is a limit per shard.
 # A value of -1 indicates that no limit will be applied.


### PR DESCRIPTION
This PR involves following changes to Content Expiry:
- Removed SPIKE_EXPIRY_MINUTES. Spike expiry will be based on Content Expiry.
- Remove PUBLISHED_ITEM_MINUTES. Published Item Minutes will be base on Content Expiry.
- Modified Desk Settings for content expiry
- There will be following settings for content expiry.
 - Content Expiry setting globally (in settings.py)
 - Content Expiry setting on the desk
 - Content Expiry setting on the stage.
- Order of Precedence of content expiry is:
 - Stage Content Expiry
 - Desk Content Expiry
 - Global Content Expiry
 
The actual process to expire the content will be a separate PR.

To merge this changes run following commands on mongodb:
`db.desks.update({}, {$set: {'content_expiry': NumberInt(4320)}}, false, true);`
`db.desks.update({}, {$unset: {'spike_expiry': 1, 'published_item_expiry': 1}}, false, true);`
