### PR TITLE
(fix) [SD-3761] [SD-3459]

### DIFF
--- a/client/app/scripts/superdesk-archive/related-item-widget/relatedItem.js
+++ b/client/app/scripts/superdesk-archive/related-item-widget/relatedItem.js
@@ -17,7 +17,7 @@ define([
                 template: require.toUrl('./widget-relatedItem.html'),
                 order: 7,
                 side: 'right',
-                display: {authoring: true, packages: false, legalArchive: false}
+                display: {authoring: true, packages: false, killedItem: true, legalArchive: false}
             });
         }])
         .controller('relatedItemController',

--- a/client/app/scripts/superdesk-authoring/comments/comments.js
+++ b/client/app/scripts/superdesk-authoring/comments/comments.js
@@ -134,7 +134,7 @@ angular.module('superdesk.authoring.comments', ['superdesk.authoring.widgets', '
                 template: 'scripts/superdesk-authoring/comments/views/comments-widget.html',
                 order: 3,
                 side: 'right',
-                display: {authoring: true, packages: true, legalArchive: false}
+                display: {authoring: true, packages: true, killedItem: true, legalArchive: false}
             });
     }])
 

--- a/client/app/scripts/superdesk-authoring/editor/find-replace.js
+++ b/client/app/scripts/superdesk-authoring/editor/find-replace.js
@@ -80,7 +80,7 @@ angular.module('superdesk.authoring.find-replace', ['superdesk.editor', 'superde
                 order: 2,
                 side: 'right',
                 needUnlock: true,
-                display: {authoring: true, packages: false, legalArchive: false}
+                display: {authoring: true, packages: false, killedItem: false, legalArchive: false}
             });
     }]);
 

--- a/client/app/scripts/superdesk-authoring/macros/macros.js
+++ b/client/app/scripts/superdesk-authoring/macros/macros.js
@@ -84,7 +84,7 @@ angular.module('superdesk.authoring.macros', [])
                 order: 6,
                 needEditable: true,
                 side: 'right',
-                display: {authoring: true, packages: true, legalArchive: false}
+                display: {authoring: true, packages: true, killedItem: false, legalArchive: false}
             });
     }]);
 })();

--- a/client/app/scripts/superdesk-authoring/metadata/metadata.js
+++ b/client/app/scripts/superdesk-authoring/metadata/metadata.js
@@ -575,7 +575,7 @@ angular.module('superdesk.authoring.metadata', ['superdesk.authoring.widgets'])
                 template: 'scripts/superdesk-authoring/metadata/views/metadata-widget.html',
                 order: 1,
                 side: 'right',
-                display: {authoring: true, packages: true, legalArchive: true}
+                display: {authoring: true, packages: true, killedItem: true, legalArchive: true}
             });
     }])
 

--- a/client/app/scripts/superdesk-authoring/metadata/metadata.less
+++ b/client/app/scripts/superdesk-authoring/metadata/metadata.less
@@ -223,3 +223,9 @@
 
 
 }
+
+button[disabled] {
+  background-color: @inputDisabledBackground;
+  border-color: #ddd;
+  cursor: not-allowed;
+}

--- a/client/app/scripts/superdesk-authoring/metadata/views/metadata-dropdown.html
+++ b/client/app/scripts/superdesk-authoring/metadata/views/metadata-dropdown.html
@@ -1,13 +1,13 @@
 <div class="dropdown" ng-class="{'dropright': icon, 'dropdown-noarrow': !icon}" dropdown sd-dropdown-focus sd-dropdown-position>
-    <button class="dropdown-toggle line-input" dropdown-toggle ng-if="(field !== 'place' && field !== 'genre') && !icon">
+    <button ng-disabled="disabled" class="dropdown-toggle line-input" dropdown-toggle ng-if="(field !== 'place' && field !== 'genre') && !icon">
         {{ item[field].name || item[field] ? item[field].name || item[field] : "none" | translate }}
         <b class="caret"></b>
     </button>
-    <button class="dropdown-toggle line-input" dropdown-toggle ng-if="(field === 'place' || field === 'genre') && !icon">
+    <button ng-disabled="disabled" class="dropdown-toggle line-input" dropdown-toggle ng-if="(field === 'place' || field === 'genre') && !icon">
         {{ item[field].length > 0 ? item[field][0].name : "none" | translate }}
         <b class="caret"></b>
     </button>
-    <button class="dropdown-toggle line-input" dropdown-toggle ng-if="icon">
+    <button ng-disabled="disabled" class="dropdown-toggle line-input" dropdown-toggle ng-if="icon">
         <span class="{{icon}}-{{item[field]}}">{{item[field] ? item[field] : 0}}</span>
          <b class="caret"></b>
     </button>

--- a/client/app/scripts/superdesk-authoring/packages/packages.js
+++ b/client/app/scripts/superdesk-authoring/packages/packages.js
@@ -39,7 +39,7 @@
             template: 'scripts/superdesk-authoring/packages/views/packages-widget.html',
             order: 5,
             side: 'right',
-            display: {authoring: true, packages: true, legalArchive: false}
+            display: {authoring: true, packages: true, killedItem: true, legalArchive: false}
         });
     }])
     .controller('PackagesWidgetCtrl', PackagesCtrl);

--- a/client/app/scripts/superdesk-authoring/versioning/versioning.js
+++ b/client/app/scripts/superdesk-authoring/versioning/versioning.js
@@ -12,7 +12,7 @@ angular.module('superdesk.authoring.versioning', [])
                 template: 'scripts/superdesk-authoring/versioning/views/versioning.html',
                 order: 4,
                 side: 'right',
-                display: {authoring: true, packages: true, legalArchive: true}
+                display: {authoring: true, packages: true, killedItem: true, legalArchive: true}
             });
     }]);
 

--- a/client/app/scripts/superdesk-authoring/widgets/widgets.js
+++ b/client/app/scripts/superdesk-authoring/widgets/widgets.js
@@ -31,7 +31,7 @@ function WidgetsManagerCtrl($scope, $routeParams, authoringWidgets, archiveServi
         if (archiveService.isLegal(item)) {
             display = 'legalArchive';
         } else {
-            display = item.type === 'composite' ? 'packages' : 'authoring';
+            display = item.type === 'composite' ? 'packages' : item.state === 'killed' ? 'killedItem' : 'authoring';
         }
 
         $scope.widgets = authoringWidgets.filter(function(widget) {

--- a/client/app/scripts/superdesk-monitoring/monitoring.js
+++ b/client/app/scripts/superdesk-monitoring/monitoring.js
@@ -441,6 +441,9 @@
                         } else if (item.type === 'composite' && item.package_type === 'takes') {
                             authoringWorkspace.view(item);
                             monitoring.preview(null);
+                        } else if (item.state === 'killed') {
+                            authoringWorkspace.view(item);
+                            monitoring.preview(null);
                         } else {
                             authoringWorkspace.edit(item, !lock);
                             monitoring.preview(null);


### PR DESCRIPTION
Resolves:
[SD-3761](https://dev.sourcefabric.org/browse/SD-3761) Disable "find/replace" for killed items
[SD-3459](https://dev.sourcefabric.org/browse/SD-3459) Place field on authoring screen is editable when item is locked