### PR TITLE
(fix) [SD-2097] Locking issue when item is published/sent

### DIFF
--- a/client/app/scripts/superdesk-archive/directives.js
+++ b/client/app/scripts/superdesk-archive/directives.js
@@ -7,7 +7,7 @@
         'superdesk.ingest',
         'superdesk.workflow'
     ])
-        .directive('sdItemLock', ['api', 'lock', 'privileges', function(api, lock, privileges) {
+        .directive('sdItemLock', ['api', 'lock', 'privileges', 'desks', function(api, lock, privileges, desks) {
             return {
                 templateUrl: 'scripts/superdesk-archive/views/item-lock.html',
                 scope: {item: '='},
@@ -42,7 +42,15 @@
                     };
 
                     scope.can_unlock = function() {
-                        return lock.can_unlock(scope.item);
+                        if (lock.can_unlock(scope.item)) {
+                            if (scope.item.task && scope.item.task.desk && desks.userDesks) {
+                                return _.find(desks.userDesks._items, {_id: scope.item.task.desk});
+                            }
+
+                            return true;
+                        }
+
+                        return false;
                     };
 
                     scope.$on('item:lock', function(_e, data) {

--- a/client/app/scripts/superdesk-monitoring/monitoring.js
+++ b/client/app/scripts/superdesk-monitoring/monitoring.js
@@ -260,9 +260,9 @@
     }
 
     MonitoringGroupDirective.$inject = ['cards', 'api', 'authoringWorkspace', '$timeout', 'superdesk',
-        'activityService', 'workflowService', 'keyboardManager', 'desks', 'search', 'multi'];
+        'activityService', 'workflowService', 'keyboardManager', 'desks', 'search', 'multi', 'archiveService'];
     function MonitoringGroupDirective(cards, api, authoringWorkspace, $timeout, superdesk, activityService,
-            workflowService, keyboardManager, desks, search, multi) {
+            workflowService, keyboardManager, desks, search, multi, archiveService) {
 
         var ITEM_HEIGHT = 57,
             ITEMS_COUNT = 5,
@@ -467,7 +467,7 @@
                         } else if (item.type === 'composite' && item.package_type === 'takes') {
                             authoringWorkspace.view(item);
                             monitoring.preview(null);
-                        } else if (item.state === 'killed') {
+                        } else if (archiveService.isPublished(item)) {
                             authoringWorkspace.view(item);
                             monitoring.preview(null);
                         } else {


### PR DESCRIPTION
Also covers PR https://github.com/superdesk/superdesk/pull/1541

Resolves: 
1. [SD-2097](https://dev.sourcefabric.org/browse/SD-2097): Locking issue when item is published/sent
2. [SD-3557](https://dev.sourcefabric.org/browse/SD-3557): Unusual behavior for published items in monitoring view
3. [SD-3497](https://dev.sourcefabric.org/browse/SD-3497): Unlock button present when opening items from desks where the user is not a member of
4. [SD-3546](https://dev.sourcefabric.org/browse/SD-3546): Unlock issue when accessing item created in custom workspace
5. [SD-3263](https://dev.sourcefabric.org/browse/SD-3263): Edit button should be present if item is unlocked by the lock holder