### PR TITLE
[SD-3627][SD-3196] Separating task to different queues.

### DIFF
--- a/server/Procfile
+++ b/server/Procfile
@@ -1,4 +1,7 @@
 rest: gunicorn -c gunicorn_config.py wsgi
 wamp: python3 -u ws.py
-work: celery -A worker worker
+work: celery -A worker -Q default  worker
+expiry: celery -A worker -Q expiry  worker
+legal: celery -A worker -Q legal  worker
+publish: celery -A worker -Q publish  worker
 beat: celery -A worker beat --pid=


### PR DESCRIPTION
This PR separates tasks based as below:
- Expiry related tasks to expiry queue
- Publish related tasks to publish queue
- Legal Archive related tasks to legal queue
- Ingest related task and any other task will go to default queue
- Rest of the tasks to default queue
