### PR TITLE
Update README.md & scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Use [docker-compose](http://docs.docker.com/compose/ "") and the config from the
 ##### install system-wide dependencies
 
 ```sh
-$ sudo apt-get install python2.7 python-virtualenv git
+$ sudo apt-get install python-virtualenv git
 ```
 and install [the newest docker](https://docs.docker.com/installation/).
 and make sure you can run [docker without sudo](http://askubuntu.com/questions/477551/how-can-i-use-docker-without-sudo).

--- a/docker/container_build.sh
+++ b/docker/container_build.sh
@@ -24,7 +24,7 @@ RUN_FRONTEND_UNIT=${bamboo_RUN_FRONTEND_UNIT:=1}
 RUN_E2E=${bamboo_RUN_E2E:=1}
 
 # install script requirements
-virtualenv -p python2 $SCRIPT_DIR/env
+virtualenv $SCRIPT_DIR/env
 set +u
 . $SCRIPT_DIR/env/bin/activate
 set -u

--- a/scripts/docker-local-create-user.sh
+++ b/scripts/docker-local-create-user.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
-SCRIPT_DIR=$(readlink -e $(dirname "$0"))
-(test -d $SCRIPT_DIR/env || virtualenv -p python2 $SCRIPT_DIR/env ) &&
+SCRIPT_DIR="$(echo $(cd -P -- "$(dirname -- "$0")" && pwd -P))"
+(test -d $SCRIPT_DIR/env || virtualenv $SCRIPT_DIR/env ) &&
 . $SCRIPT_DIR/env/bin/activate
 set -ue
 pip install -r $SCRIPT_DIR/../docker/requirements.txt

--- a/scripts/docker-local-demo.sh
+++ b/scripts/docker-local-demo.sh
@@ -6,10 +6,8 @@ function dcs() {
 	docker-compose -p sddemo -f ./docker-compose-prebuilt.yml $@
 }
 
-
-WORK_DIR=$(readlink -e $(dirname "$0"))
-
-(test -d $WORK_DIR/env || virtualenv -p python2 $WORK_DIR/env )
+WORK_DIR="$(echo $(cd -P -- "$(dirname -- "$0")" && pwd -P))"
+(test -d $WORK_DIR/env || virtualenv $WORK_DIR/env )
 set +u
 . $WORK_DIR/env/bin/activate
 set -u


### PR DESCRIPTION
Replaced `$(readlink -e $(dirname "$0"))` with `$(echo $(cd -P -- "$(dirname -- "$0")" && pwd -P))"` so we can run `scripts/docker-local-create-user.sh` and `scripts/docker-local-demo.sh` on OSX. (readlink with -e param causes some issues on mac)

When running Superdesk on Docker from OSX, Docker Toolbox needs to be installed. I may create the install guide on how to install superdesk locally and on docker using OSX, but that will go into separate PR.