### PR TITLE
added expected argument to -a option

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -104,5 +104,5 @@ This will give you list of available commands.
 This command will create an administrator user.
 
 ```sh
-$ python manage.py users:create -u <username> -p <password> -e <email> -a
+$ python manage.py users:create -u <username> -p <password> -e <email> -a true
 ```


### PR DESCRIPTION
added `true` to `-a/--admin` option as it expects one argument

```
usage: manage.py users:create [-?] --username USERNAME --password PASSWORD
                              --email EMAIL [--admin ADMIN]
manage.py users:create: error: argument --admin/-a: expected one argument
```

btw I think its a bug in the command as it should not accept any argument, it should create an admin account when u put `-a` or `--admin`