### PR TITLE
Editor: reorder blocks

### DIFF
--- a/client/app/scripts/superdesk-authoring/styles/themes.less
+++ b/client/app/scripts/superdesk-authoring/styles/themes.less
@@ -261,7 +261,6 @@ body, html {
 	border: 1px solid #cacaca;
 	border-width:0 1px;
 	position:relative;
-	z-index:1;
 	padding: @main-article-padding;
 	margin:0 auto;
 	min-height:100%;

--- a/client/app/scripts/superdesk/editor/add-embed.ctrl.js
+++ b/client/app/scripts/superdesk/editor/add-embed.ctrl.js
@@ -118,8 +118,8 @@ function SdAddEmbedController (embedService, $element, $timeout, $q, _, EMBED_PR
             if (extended) {
                 $timeout(function() {
                     angular.element($element).find('input').focus();
-                });
-                // on leave, clear field
+                }, 500, false); // positive timeout because of a chrome issue
+            // on leave, clear field
             } else {
                 vm.input = '';
                 vm.onClose();

--- a/client/app/scripts/superdesk/editor/editor.ctrl.js
+++ b/client/app/scripts/superdesk/editor/editor.ctrl.js
@@ -3,8 +3,8 @@
 
 angular.module('superdesk.editor').controller('SdTextEditorController', SdTextEditorController);
 
-SdTextEditorController.$inject = ['lodash', 'EMBED_PROVIDERS'];
-function SdTextEditorController(_, EMBED_PROVIDERS) {
+SdTextEditorController.$inject = ['lodash', 'EMBED_PROVIDERS', '$timeout', '$element'];
+function SdTextEditorController(_, EMBED_PROVIDERS, $timeout, $element) {
     var vm = this;
     function Block(attrs) {
         angular.extend(this, {
@@ -45,6 +45,78 @@ function SdTextEditorController(_, EMBED_PROVIDERS) {
         }
         return newBlocks;
     }
+    function splitIntoBlock(bodyHtml) {
+        var blocks = [], block;
+        /**
+        * push the current block into the blocks collection if it is not empty
+        */
+        function commitBlock() {
+            if (block !== undefined && block.body.trim() !== '') {
+                blocks.push(block);
+                block = undefined;
+            }
+        }
+        $('<div>' + bodyHtml + '</div>')
+        .contents()
+        .toArray()
+        .forEach(function(element) {
+            // if we get a <p>, we push the current block and create a new one
+            // for the paragraph content
+            if (element.nodeName === 'P') {
+                commitBlock();
+                if (angular.isDefined(element.innerHTML) && element.textContent !== '' && element.textContent !== '\n') {
+                    blocks.push(new Block({body: element.outerHTML.trim()}));
+                }
+                // detect if it's an embed
+            } else if (element.nodeName === '#comment') {
+                if (element.nodeValue.indexOf('EMBED START') > -1) {
+                    commitBlock();
+                    // retrieve the embed type following the comment
+                    var embed_type = angular.copy(element.nodeValue).replace(' EMBED START ', '').trim();
+                    if (embed_type === '') {
+                        embed_type = EMBED_PROVIDERS.custom;
+                    }
+                    // create the embed block
+                    block = new Block({blockType: 'embed', embedType: embed_type});
+                }
+                if (element.nodeValue.indexOf('EMBED END') > -1) {
+                    commitBlock();
+                }
+                // if it's not a paragraph or an embed, we update the current block
+            } else {
+                if (block === undefined) {
+                    block = new Block();
+                }
+                // we want the outerHTML (ex: '<b>text</b>') or the node value for text and comment
+                block.body += (element.outerHTML || element.nodeValue || '').trim();
+            }
+        });
+        // at the end of the loop, we push the last current block
+        if (block !== undefined && block.body.trim() !== '') {
+            blocks.push(block);
+        }
+        // extract body and caption from embed block
+        blocks.forEach(function(block) {
+            if (block.blockType === 'embed') {
+                var original_body = angular.element(angular.copy(block.body));
+                if (original_body.get(0).nodeName === 'FIGURE') {
+                    block.body = '';
+                    original_body.contents().toArray().forEach(function(element) {
+                        if (element.nodeName === 'FIGCAPTION') {
+                            block.caption = element.innerHTML;
+                        } else {
+                            block.body += element.outerHTML || element.nodeValue || '';
+                        }
+                    });
+                }
+            }
+        });
+        // if no block, create an empty one to start
+        if (blocks.length === 0) {
+            blocks.push(new Block());
+        }
+        return blocks;
+    }
     angular.extend(vm, {
         blocks: [],
         initEditorWithOneBlock: function(model) {
@@ -52,87 +124,19 @@ function SdTextEditorController(_, EMBED_PROVIDERS) {
             vm.blocks = [new Block({body: model.$modelValue})];
         },
         initEditorWithMultipleBlock: function(model) {
-            var blocks = [], block;
-            /**
-             * push the current block into the blocks collection if it is not empty
-             */
-            function commitBlock() {
-                if (block !== undefined && block.body.trim() !== '') {
-                    blocks.push(block);
-                    block = undefined;
-                }
-            }
             // save the model to update it later
             vm.model = model;
             // parse the given model and create blocks per paragraph and embed
             var content = model.$modelValue || '';
-            $('<div>' + content + '</div>')
-            .contents()
-            .toArray()
-            .forEach(function(element) {
-                // if we get a <p>, we push the current block and create a new one
-                // for the paragraph content
-                if (element.nodeName === 'P') {
-                    commitBlock();
-                    if (angular.isDefined(element.innerHTML) && element.textContent !== '' && element.textContent !== '\n') {
-                        blocks.push(new Block({body: element.outerHTML.trim()}));
-                    }
-                // detect if it's an embed
-                } else if (element.nodeName === '#comment') {
-                    if (element.nodeValue.indexOf('EMBED START') > -1) {
-                        commitBlock();
-                        // retrieve the embed type following the comment
-                        var embed_type = angular.copy(element.nodeValue).replace(' EMBED START ', '').trim();
-                        if (embed_type === '') {
-                            embed_type = EMBED_PROVIDERS.custom;
-                        }
-                        // create the embed block
-                        block = new Block({blockType: 'embed', embedType: embed_type});
-                    }
-                    if (element.nodeValue.indexOf('EMBED END') > -1) {
-                        commitBlock();
-                    }
-                // if it's not a paragraph or an embed, we update the current block
-                } else {
-                    if (block === undefined) {
-                        block = new Block();
-                    }
-                    // we want the outerHTML (ex: '<b>text</b>') or the node value for text and comment
-                    block.body += (element.outerHTML || element.nodeValue || '').trim();
-                }
-            });
-            // at the end of the loop, we push the last current block
-            if (block !== undefined && block.body.trim() !== '') {
-                blocks.push(block);
-            }
-            // extract body and caption from embed block
-            blocks.forEach(function(block) {
-                if (block.blockType === 'embed') {
-                    var original_body = angular.element(angular.copy(block.body));
-                    if (original_body.get(0).nodeName === 'FIGURE') {
-                        block.body = '';
-                        original_body.contents().toArray().forEach(function(element) {
-                            if (element.nodeName === 'FIGCAPTION') {
-                                block.caption = element.innerHTML;
-                            } else {
-                                block.body += element.outerHTML || element.nodeValue || '';
-                            }
-                        });
-                    }
-                }
-            });
-            // if no block, create an empty one to start
-            if (blocks.length === 0) {
-                blocks.push(new Block());
-            }
             // update the actual blocks value at the end to prevent more digest cycle as needed
-            vm.blocks = blocks;
+            vm.blocks = splitIntoBlock(content);
             vm.renderBlocks();
         },
-        commitChanges: function() {
+        serializeBlock: function(blocks) {
+            blocks = angular.isDefined(blocks) ? blocks : vm.blocks;
             var new_body = '';
             if (vm.config.multiBlockEdition) {
-                vm.blocks.forEach(function(block) {
+                blocks.forEach(function(block) {
                     if (angular.isDefined(block.body) && block.body.trim() !== '') {
                         if (block.blockType === 'embed') {
                             new_body += [
@@ -150,12 +154,15 @@ function SdTextEditorController(_, EMBED_PROVIDERS) {
                     }
                 });
             } else {
-                if (vm.blocks[0].body.trim() === '<br>') {
-                    vm.blocks[0].body = '';
+                if (blocks[0].body.trim() === '<br>') {
+                    blocks[0].body = '';
                 }
-                new_body = vm.blocks[0].body;
+                new_body = blocks[0].body;
             }
-            vm.model.$setViewValue(new_body);
+            return new_body;
+        },
+        commitChanges: function() {
+            vm.model.$setViewValue(vm.serializeBlock());
         },
         getBlockPosition: function(block) {
             return _.indexOf(vm.blocks, block);
@@ -174,7 +181,7 @@ function SdTextEditorController(_, EMBED_PROVIDERS) {
             if (!unprocess) {
                 vm.renderBlocks();
             }
-            vm.commitChanges();
+            $timeout(vm.commitChanges);
             return this;
         },
         /**
@@ -193,7 +200,7 @@ function SdTextEditorController(_, EMBED_PROVIDERS) {
                 block.body = '';
             }
             vm.renderBlocks();
-            vm.commitChanges();
+            $timeout(vm.commitChanges);
         },
         getPreviousBlock: function(block) {
             var pos = vm.getBlockPosition(block);
@@ -201,6 +208,77 @@ function SdTextEditorController(_, EMBED_PROVIDERS) {
             if (pos > 0) {
                 return vm.blocks[pos - 1];
             }
+        },
+        reorderingMode: false,
+        hideHeader: function(hide) {
+            hide = angular.isDefined(hide) ? hide : true;
+            var prop;
+            if (hide) {
+                prop = {
+                    opacity: 0.4,
+                    pointerEvents: 'none'
+                };
+            } else {
+                prop = {
+                    opacity: 1,
+                    pointerEvents: 'auto'
+                };
+            }
+            angular.element('.authoring-header, .preview-modal-control, .theme-controls').css(prop);
+        },
+        enableReorderingMode: function(position, event) {
+            var blockToMove = vm.blocks[position];
+            var before = vm.serializeBlock(vm.blocks.slice(0, position));
+            var after = vm.serializeBlock(vm.blocks.slice(position + 1));
+            // split into blocks what is before the selected block
+            var newBlocks = splitIntoBlock(before);
+            // add the selected block in one piece
+            newBlocks.push(blockToMove);
+            // split into blocks what is after the selected block
+            newBlocks = newBlocks.concat(splitIntoBlock(after));
+            // save the vertical scroll position
+            var offsetTop = angular.element(event.currentTarget).offset().top;
+            // hide the header
+            vm.hideHeader();
+            // update the view model
+            angular.extend(vm, {
+                // save the new blocks (texts are a splited per paragraph)
+                blocks: newBlocks,
+                // save the index of the selected block
+                blockToMoveIndex: newBlocks.indexOf(blockToMove),
+                // used in template to show the reordering UI
+                reorderingMode: true
+            });
+            // restore the scroll postion at the new element level
+            $timeout(function() {
+                var el = $element.find('.block__container').get(vm.blockToMoveIndex);
+                var container = angular.element('.page-content-container');
+                var offset = container.scrollTop() + angular.element(el).offset().top - offsetTop;
+                container.scrollTop(offset);
+            }, 200, false); // wait after transitions
+        },
+        reorderToPosition: function(position) {
+            // adjust the position. Remove one if the moved element was before the wanted position
+            position = position > vm.blockToMoveIndex ? position - 1 : position;
+            // move the selected block to the given position
+            vm.blocks.splice(position, 0, vm.blocks.splice(vm.blockToMoveIndex, 1)[0]);
+            // save new position
+            vm.blockToMoveIndex = position;
+            // exit the reordering mode
+            vm.disableReorderingMode();
+        },
+        disableReorderingMode: function() {
+            // reset reorder mode state in vm
+            angular.extend(vm, {
+                blockToMoveIndex: undefined,
+                reorderingMode: false
+            });
+            // show the header
+            vm.hideHeader(false);
+            // merge the text blocks together
+            vm.renderBlocks();
+            // save changes
+            $timeout(vm.commitChanges);
         }
     });
 }

--- a/client/app/scripts/superdesk/editor/editor.js
+++ b/client/app/scripts/superdesk/editor/editor.js
@@ -881,9 +881,10 @@ angular.module('superdesk.editor', ['superdesk.editor.spellcheck', 'angular-embe
                         },
                         // Called when user hits the defined shortcut (CTRL / COMMAND + e)
                         handleKeydown: function(event) {
-                            if (window.MediumEditor.util.isKey(event, 69) &&
+                            if (window.MediumEditor.util.isKey(event, 'E'.charCodeAt(0)) &&
                                 window.MediumEditor.util.isMetaCtrlKey(event) && !event.shiftKey) {
                                 this.handleClick(event);
+                                event.preventDefault();
                             }
                         }
                     });

--- a/client/app/scripts/superdesk/editor/styles.less
+++ b/client/app/scripts/superdesk/editor/styles.less
@@ -2,17 +2,17 @@
 @import 'mixins.less';
 
 [contenteditable=true] {
-	&:before{
-		display: block; /* For Firefox */
-	}
-	&:empty:before{
-  		content: attr(placeholder);
-  		display: block; /* For Firefox */
-  		color: #ccc;
-	}
-	&:focus:before{
-		display: none;
-	}
+    &:before{
+        display: block; /* For Firefox */
+    }
+    &:empty:before{
+          content: attr(placeholder);
+          display: block; /* For Firefox */
+          color: #ccc;
+    }
+    &:focus:before{
+        display: none;
+    }
 }
 .medium-editor-toolbar {
     z-index: 10;
@@ -24,6 +24,9 @@
     }
 }
 .block {
+    &--selected {
+        border: 1px solid #5EA9C8;
+    }
     &__container {
         position: relative;
         .text-editor {
@@ -43,14 +46,52 @@
         .editor--embed {
             min-height: 200px;
         }
-        &:hover .block__remove {opacity: 1;}
+        &:hover .block__actions {opacity: 1;}
     }
-    &__remove {
+    &__actions {
         position: absolute;
-        right: -17px;
+        right: -38px;
         top: 0;
         cursor: pointer;
         opacity: .1;
+        & > div {
+            display: inline-block;
+        }
+    }
+    &__move {
+        i {
+            width: 15px;
+            height: 15px;
+        }
+        &__cancel {
+            padding-left: 32px;
+            position: fixed;
+            right: 80px;
+            z-index: 4;
+            .transition(top 0.25s ease 1s);
+            top: 60px;
+            &.ng-hide { // shows the button (reversed in order to have it hidden as initial state)
+                top: 120px;
+                display: block !important;
+            }
+            i {
+                position: absolute;
+                left: 6px;
+                top: 4px;
+            }
+        }
+        &__dropzone {
+            border: 1px dashed #CFCFCF;
+            background-color: #F7F7F7;
+            color: #666;
+            text-align: center;
+            cursor: pointer;
+            margin: 10px 0;
+            padding: 10px 0;
+            &:hover {
+                background-color: #F0F0F0;
+            }
+        }
     }
 }
 .add-embed {

--- a/client/app/scripts/superdesk/editor/views/editor.html
+++ b/client/app/scripts/superdesk/editor/views/editor.html
@@ -1,29 +1,57 @@
-<div ng-repeat="block in vm.blocks" class="block__container">
-    <div ng-if="vm.config.multiBlockEdition" class="block__remove" ng-click="vm.removeBlock(block)">
-        <i class="icon-close-small"></i>
-    </div>
-    <sd-add-embed ng-if="vm.config.multiBlockEdition && $first"
-                  add-to-position="$index"
-                  class="block__add-embed">
-    </sd-add-embed>
-    <div ng-switch="block.blockType">
-        <div ng-switch-when="embed"
-             sd-text-editor-block-embed="block"
-             on-block-change="vm.commitChanges()">
+<div dragula="'blocks'"
+     dragula-model="vm.blocks">
+    <a class="btn btn-default block__move__cancel ng-cloak"
+       ng-click="vm.disableReorderingMode()"
+       ng-show="!vm.reorderingMode"
+       trans>
+        <i class="svg-icon-move"></i> Cancel reordering
+    </a>
+    <div ng-repeat="block in vm.blocks"
+         class="block__container"
+         ng-class="{'block--selected': vm.blockToMoveIndex === $index}">
+        <div class="block__actions" ng-if="vm.config.multiBlockEdition && !vm.reorderingMode">
+            <div class="block__remove" ng-click="vm.removeBlock(block)">
+                <i class="icon-close-small"></i>
+            </div>
+            <div class="block__move" ng-click="vm.enableReorderingMode($index, $event)">
+                <i class="svg-icon-move"></i>
+            </div>
         </div>
-        <div ng-switch-when="text"
-             sd-text-editor-block-text="block"
-             type="vm.type"
-             config="vm.config"
-             language="vm.language"
-             ng-change="vm.commitChanges()"
-             ng-model="block.body">
+        <div ng-if="$first && vm.reorderingMode && vm.blockToMoveIndex !== $index"
+             ng-click="vm.reorderToPosition($index)"
+             class="block__move__dropzone"
+             trans>
+            Click to move the block here
+        </div>
+        <sd-add-embed ng-if="vm.config.multiBlockEdition && $first && !vm.reorderingMode"
+                      add-to-position="$index"
+                      class="block__add-embed">
+        </sd-add-embed>
+        <div ng-switch="block.blockType">
+            <div ng-switch-when="embed"
+                 sd-text-editor-block-embed="block"
+                 on-block-change="vm.commitChanges()">
+            </div>
+            <div ng-switch-when="text"
+                 sd-text-editor-block-text="block"
+                 type="vm.type"
+                 config="vm.config"
+                 language="vm.language"
+                 ng-change="vm.commitChanges()"
+                 ng-model="block.body">
+            </div>
+        </div>
+        <sd-add-embed ng-if="vm.config.multiBlockEdition && !vm.reorderingMode"
+                      extended="block.lowerAddEmbedIsExtented"
+                      add-to-position="$index + 1"
+                      on-close="vm.renderBlocks()"
+                      class="block__add-embed">
+        </sd-add-embed>
+        <div ng-if="vm.reorderingMode && vm.blockToMoveIndex !== ($index + 1) && vm.blockToMoveIndex !== $index"
+             ng-click="vm.reorderToPosition($index + 1)"
+             class="block__move__dropzone"
+             trans>
+            Click to move the block here
         </div>
     </div>
-    <sd-add-embed ng-if="vm.config.multiBlockEdition"
-                  extended="block.lowerAddEmbedIsExtented"
-                  add-to-position="$index + 1"
-                  on-close="vm.renderBlocks()"
-                  class="block__add-embed">
-    </sd-add-embed>
 </div>

--- a/client/app/styles/less/buttons.less
+++ b/client/app/styles/less/buttons.less
@@ -3,7 +3,7 @@
 /* new button colors */
 
 
-@btnDefaultColor : rgba(0,0,0,15%);
+@btnDefaultColor : #bdbdbd;
 @btnInfoColor : @sd-blue;
 @btnGreenColor : #169f70;
 @btnSuccessColor: #53a93f;


### PR DESCRIPTION
Reverts superdesk/superdesk#1737

- [x] Reordering mode can be activated by the ![selection_090](https://cloud.githubusercontent.com/assets/180617/12751563/26b2c060-c9be-11e5-826f-ce207cf1a2b3.png) button
- [x] On reorder mode:
  - Others text blocks paragraphs (except selected one) are split into new blocks
  - Placeholders appear between each block, except around the selected block
  - Remove and reorder block buttons disappear
  - A link to exit the reorder mode appears
- [x] On a placeholder click
  - the selected block moves to the chosen new position
  - the following text blocks are merged
  - the reordering mode closes

This PR already [get reviews](https://github.com/superdesk/superdesk/pull/1707). It is now waiting for PA feedback