### PR TITLE
Update image crop size names by removing blank spaces

### DIFF
--- a/server/data/vocabularies.json
+++ b/server/data/vocabularies.json
@@ -196,11 +196,11 @@
         "type": "manageable",
         "items": [
             {"is_active": true, "name": "thumbnail", "width": 300, "height": 300},
-            {"is_active": true, "name": "preview 3x2", "width": 1440, "height": 960},
-            {"is_active": true, "name": "preview 4x3", "width": 1440, "height": 1080},
-            {"is_active": true, "name": "wide 360", "width": 640, "height": 360},
-            {"is_active": true, "name": "wide 720", "width": 1280, "height": 720},
-            {"is_active": true, "name": "wide 1080", "width": 1920, "height": 1080}
+            {"is_active": true, "name": "preview3x2", "width": 1440, "height": 960},
+            {"is_active": true, "name": "preview4x3", "width": 1440, "height": 1080},
+            {"is_active": true, "name": "wide360", "width": 640, "height": 360},
+            {"is_active": true, "name": "wide720", "width": 1280, "height": 720},
+            {"is_active": true, "name": "wide1080", "width": 1920, "height": 1080}
         ]
     },
     {


### PR DESCRIPTION
https://dev.sourcefabric.org/browse/SDPA-344
Image rendition names are used in the ninjs output. Using blank spaces breaks the spec.