### PR TITLE
Replaces `values` attribute by `qcode`

### DIFF
--- a/server/data/vocabularies.json
+++ b/server/data/vocabularies.json
@@ -150,12 +150,12 @@
         "type": "unmanageable",
         "items": [
             {"is_active": true, "name": "All", "qcode": "all",
-                "formats": [{"name": "NINJS", "qcode": "ninjs"}, {"name": "AAP NewsML 1.2", "value": "newsml12"}, {"name": "NewsML G2", "value": "newsmlg2"}]},
+                "formats": [{"name": "NINJS", "qcode": "ninjs"}, {"name": "AAP NewsML 1.2", "qcode": "newsml12"}, {"name": "NewsML G2", "qcode": "newsmlg2"}]},
             {"is_active": true, "name": "Digital/Internet", "qcode": "digital",
-                "formats": [{"name": "NINJS", "qcode": "ninjs"}, {"name": "AAP NewsML 1.2", "value": "newsml12"}, {"name": "NewsML G2", "value": "newsmlg2"},
+                "formats": [{"name": "NINJS", "qcode": "ninjs"}, {"name": "AAP NewsML 1.2", "qcode": "newsml12"}, {"name": "NewsML G2", "qcode": "newsmlg2"},
                             {"name": "AAP Bulletin Builder", "qcode": "AAP BULLETIN BUILDER"}]},
             {"is_active": true, "name": "Wire/Paper", "qcode": "wire",
-                "formats": [{"name": "AAP ANPA", "qcode": "AAP ANPA"}, {"name": "NITF", "value": "nitf"}, {"name": "AAP IPNEWS", "value": "AAP IPNEWS"},
+                "formats": [{"name": "AAP ANPA", "qcode": "AAP ANPA"}, {"name": "NITF", "qcode": "nitf"}, {"name": "AAP IPNEWS", "qcode": "AAP IPNEWS"},
                             {"name": "AAP SMS", "qcode": "AAP SMS"}]}
         ]
     },


### PR DESCRIPTION
Related issue https://dev.sourcefabric.org/browse/SDPA-368

Mainstream updates to controlled vocabularies expect a `qcode` attribute instead of `value`