### PR TITLE
SDNTB-135 Rename SERVICE back to CATEGORY

### DIFF
--- a/client/app/translations.js
+++ b/client/app/translations.js
@@ -3,6 +3,7 @@ angular.module('gettext').run(['gettextCatalog', function (gettextCatalog) {
         "URGENCY": "NEWS VALUE",
         "Urgency": "News Value",
         "urgency": "news value",
-        "Urgency stats": "News Value stats"
+        "Urgency stats": "News Value stats",
+        "SERVICE": "CATEGORY"
     });
 }]);


### PR DESCRIPTION
when https://github.com/superdesk/superdesk-client-core/pull/272 is
merged, the CATEGORY label will be changed to SERVICE( there is another
'Category' label in that header and it's confusing) so this is to make
sure that everything looks the same for AAP