### PR TITLE
Listing all cvs in content types to make sure they show up in PA.

### DIFF
--- a/server/data/content_types.json
+++ b/server/data/content_types.json
@@ -10,14 +10,42 @@
             "slugline": {"required": true},
             "ednote": {},
 
-            "body_html": {"required": true}
+            "body_html": {"required": true},
+
+            "topics_real_life": {},
+            "topics_motoring": {},
+            "topics_sport": {},
+            "topics_news": {},
+            "age_range": {},
+            "credit_level": {},
+            "territory_long": {},
+            "territory_short": {},
+            "reader_type": {},
+            "desired_response": {},
+            "assets": {},
+            "featured": {},
+            "credit_level": {}
         },
         "editor": {
             "anpa_category": {"order": 2, "sdWidth": "full"},
             "cvs": {"order": 3, "sdWidth": "full"},
             "subject": {"order": 4, "sdWidth": "full"},
             "slugline": {"order": 5, "sdWidth": "full"},
-            "ednote": {"order": 6, "sdWidth": "full"}
+            "ednote": {"order": 6, "sdWidth": "full"},
+
+            "topics_real_life": {"sdWidth": "half"},
+            "topics_motoring": {"sdWidth": "half"},
+            "topics_sport": {"sdWidth": "half"},
+            "topics_news": {"sdWidth": "half"},
+            "age_range": {"sdWidth": "half"},
+            "credit_level": {"sdWidth": "half"},
+            "territory_long": {"sdWidth": "half"},
+            "territory_short": {"sdWidth": "half"},
+            "reader_type": {"sdWidth": "half"},
+            "desired_response": {"sdWidth": "half"},
+            "assets": {"sdWidth": "half"},
+            "featured": {"sdWidth": "half"},
+            "credit_level": {"sdWidth": "half"}
         }
     },
     {
@@ -31,14 +59,42 @@
             "slugline": {"required": true},
             "ednote": {},
 
-            "body_html": {"required": true}
+            "body_html": {"required": true},
+
+            "topics_real_life": {},
+            "topics_motoring": {},
+            "topics_sport": {},
+            "topics_news": {},
+            "age_range": {},
+            "credit_level": {},
+            "territory_long": {},
+            "territory_short": {},
+            "reader_type": {},
+            "desired_response": {},
+            "assets": {},
+            "featured": {},
+            "credit_level": {}
         },
         "editor": {
             "anpa_category": {"order": 2, "sdWidth": "full"},
             "cvs": {"order": 3, "sdWidth": "full"},
             "subject": {"order": 4, "sdWidth": "full"},
             "slugline": {"order": 5, "sdWidth": "full"},
-            "ednote": {"order": 6, "sdWidth": "full"}
+            "ednote": {"order": 6, "sdWidth": "full"},
+
+            "topics_real_life": {"sdWidth": "half"},
+            "topics_motoring": {"sdWidth": "half"},
+            "topics_sport": {"sdWidth": "half"},
+            "topics_news": {"sdWidth": "half"},
+            "age_range": {"sdWidth": "half"},
+            "credit_level": {"sdWidth": "half"},
+            "territory_long": {"sdWidth": "half"},
+            "territory_short": {"sdWidth": "half"},
+            "reader_type": {"sdWidth": "half"},
+            "desired_response": {"sdWidth": "half"},
+            "assets": {"sdWidth": "half"},
+            "featured": {"sdWidth": "half"},
+            "credit_level": {"sdWidth": "half"}
         }
     },
     {
@@ -57,7 +113,21 @@
             "body_html": {"required": true},
             "abstract": {},
             "byline": {},
-            "feature_image": {"type": "picture"}
+            "feature_image": {"type": "picture"},
+
+            "topics_real_life": {},
+            "topics_motoring": {},
+            "topics_sport": {},
+            "topics_news": {},
+            "age_range": {},
+            "credit_level": {},
+            "territory_long": {},
+            "territory_short": {},
+            "reader_type": {},
+            "desired_response": {},
+            "assets": {},
+            "featured": {},
+            "credit_level": {}
         },
         "editor": {
             "ranking": {"order": 1, "sdWidth": "full"},
@@ -68,7 +138,21 @@
             "ednote": {"order": 6, "sdWidth": "full"},
 
             "body_html": {"formatOptions": ["h1", "h2", "bold", "italic", "underline", "quote", "anchor"]},
-            "abstract": {"formatOptions": ["h1", "h2", "bold", "italic", "underline", "quote", "anchor"]}
+            "abstract": {"formatOptions": ["h1", "h2", "bold", "italic", "underline", "quote", "anchor"]},
+
+            "topics_real_life": {"sdWidth": "half"},
+            "topics_motoring": {"sdWidth": "half"},
+            "topics_sport": {"sdWidth": "half"},
+            "topics_news": {"sdWidth": "half"},
+            "age_range": {"sdWidth": "half"},
+            "credit_level": {"sdWidth": "half"},
+            "territory_long": {"sdWidth": "half"},
+            "territory_short": {"sdWidth": "half"},
+            "reader_type": {"sdWidth": "half"},
+            "desired_response": {"sdWidth": "half"},
+            "assets": {"sdWidth": "half"},
+            "featured": {"sdWidth": "half"},
+            "credit_level": {"sdWidth": "half"}
         }
     },
     {
@@ -86,7 +170,21 @@
             "body_html": {"required": true},
             "abstract": {},
             "byline": {},
-            "feature_image": {"type": "picture"}
+            "feature_image": {"type": "picture"},
+
+            "topics_real_life": {},
+            "topics_motoring": {},
+            "topics_sport": {},
+            "topics_news": {},
+            "age_range": {},
+            "credit_level": {},
+            "territory_long": {},
+            "territory_short": {},
+            "reader_type": {},
+            "desired_response": {},
+            "assets": {},
+            "featured": {},
+            "credit_level": {}
         },
         "editor": {
             "anpa_category": {"order": 2, "sdWidth": "full"},
@@ -96,7 +194,21 @@
             "ednote": {"order": 6, "sdWidth": "full"},
 
             "body_html": {"formatOptions": ["h1", "h2", "bold", "italic", "underline", "quote", "anchor"]},
-            "abstract": {"formatOptions": ["h1", "h2", "bold", "italic", "underline", "quote", "anchor"]}
+            "abstract": {"formatOptions": ["h1", "h2", "bold", "italic", "underline", "quote", "anchor"]},
+
+            "topics_real_life": {"sdWidth": "half"},
+            "topics_motoring": {"sdWidth": "half"},
+            "topics_sport": {"sdWidth": "half"},
+            "topics_news": {"sdWidth": "half"},
+            "age_range": {"sdWidth": "half"},
+            "credit_level": {"sdWidth": "half"},
+            "territory_long": {"sdWidth": "half"},
+            "territory_short": {"sdWidth": "half"},
+            "reader_type": {"sdWidth": "half"},
+            "desired_response": {"sdWidth": "half"},
+            "assets": {"sdWidth": "half"},
+            "featured": {"sdWidth": "half"},
+            "credit_level": {"sdWidth": "half"}
         }
     }
 ]


### PR DESCRIPTION
Service metadata needs to be listed here to show up now. It's all lumped together in each content type. I'm not sure of the ordering required. There doesn't exist a good way to make metadata marked for only a particular service to be required when needed.