### PR TITLE
fix(docker): use debian as base image instead of ubuntu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # import base image
-FROM ubuntu:trusty
+FROM debian:jessie
 
 # install system-wide dependencies,
 # python3 and the build-time dependencies for c modules
@@ -7,21 +7,20 @@ RUN apt-get update && \
 DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
 python3 python3-dev python3-pip python3-lxml \
 build-essential libffi-dev git \
-libtiff5-dev libjpeg8-dev zlib1g-dev \
+libtiff5-dev libjpeg62-turbo-dev zlib1g-dev \
 libfreetype6-dev liblcms2-dev libwebp-dev \
 curl libfontconfig nodejs npm nginx \
 && echo "\ndaemon off;" >> /etc/nginx/nginx.conf \
 && rm /etc/nginx/sites-enabled/default \
 && ln --symbolic /usr/bin/nodejs /usr/bin/node
 
-RUN npm install -g npm
-RUN npm -g install grunt-cli bower
-
 # Set the locale
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
+
+RUN npm -g install grunt-cli bower
 
 # setup the environment
 WORKDIR /opt/superdesk/


### PR DESCRIPTION
there is some issue on ubuntu when doing npm install,
seems to work fine on debian