### PR TITLE
feat(workspace): enable ingest/content views

### DIFF
--- a/client/app/index.html
+++ b/client/app/index.html
@@ -231,6 +231,13 @@
 
     <script>
         var config = <%= grunt.toJSON(config) %>;
+
+        // enable ingest/content view in workspace sidebar
+        config.workspace = {
+            ingest: 1,
+            content: 1
+        };
+
         var modules = [
             'superdesk',
             'superdesk.settings',


### PR DESCRIPTION
this should be enable for aap, by default it's off

will make more sense once https://github.com/superdesk/superdesk-client-core/pull/337 is merged, but can be merged upfront