### PR TITLE
[SD-4323] updated docker images for third party containers

### DIFF
--- a/docker/common.yml
+++ b/docker/common.yml
@@ -1,15 +1,15 @@
 mongodb:
-  image: mongo:2.6
+  image: mongo:3.2
   volumes:
    - ../data/mongodb:/data/db
 
 redis:
-  image: redis:2.8
+  image: redis:3.0
   volumes:
    - ../data/redis:/data
 
 logstash:
-  image: logstash:1.5
+  image: logstash:2.3
   command: logstash -f /usr/share/logstash/logstash.conf
   volumes:
   - ./logstash:/usr/share/logstash
@@ -19,7 +19,7 @@ kibana:
   restart: always
 
 elastic:
-  image: elasticsearch:1.5
+  image: elasticsearch:2.3
   volumes:
    - ../data/elastic:/usr/share/elasticsearch/data
 

--- a/docker/logstash/logstash.conf
+++ b/docker/logstash/logstash.conf
@@ -30,5 +30,5 @@ filter {
 }
 
 output {
-  elasticsearch { host => elastic port => 9200 protocol => "http" }
+  elasticsearch { hosts => "elastic:9200" }
 }


### PR DESCRIPTION
superdesk-core, superdesk-client-core and eve-elastic need to be updated before using the new images, and extensive review/testing need to be done to track regressions.
