### PR TITLE
Removes 2x1 and 5x4 from the Image Crops Size controlled vocabulary

### DIFF
--- a/server/data/vocabularies.json
+++ b/server/data/vocabularies.json
@@ -196,10 +196,8 @@
         "type": "manageable",
         "items": [
             {"is_active": true, "name": "1x1", "ratio": "1:1"},
-            {"is_active": true, "name": "2x1", "ratio": "2:1"},
             {"is_active": true, "name": "3x2", "ratio": "3:2"},
             {"is_active": true, "name": "4x3", "ratio": "4:3"},
-            {"is_active": true, "name": "5x4", "ratio": "5:4"},
             {"is_active": true, "name": "16x9", "ratio": "16:9"},
             {"is_active": true, "name": "small", "width": 360},
             {"is_active": true, "name": "medium", "width": 720},


### PR DESCRIPTION
… Those renditions are not longer used
Related issue https://dev.sourcefabric.org/browse/SDPA-447