### PR TITLE
[Scanpix] fixed video preview in editor

### DIFF
--- a/server/ntb/scanpix/scanpix_datalayer.py
+++ b/server/ntb/scanpix/scanpix_datalayer.py
@@ -33,7 +33,7 @@ import mimetypes
 REND2PREV = {
     'thumbnail': ('generated_jpg', 'thumbnail', 'thumbnail_big'),
     'viewImage': ('preview', 'thumbnail_big', 'thumbnail', 'preview_big'),
-    'baseImage': ('preview_big', 'preview', 'thumbnail_big', 'thumbnail')}
+    'baseImage': ('mp4_preview', 'mp4_thumbnail', 'preview_big', 'preview', 'thumbnail_big', 'thumbnail')}
 logger = logging.getLogger('ntb:scanpix')
 
 


### PR DESCRIPTION
Changes made for SDNTB-210 have caused a regression as video were not
visible anymore in editor.

This commit fix the issue by using mp4 preview if available for baseImage