### PR TITLE
Handles Vidible embed codes SDPA-454

### DIFF
--- a/client/app/index.html
+++ b/client/app/index.html
@@ -261,6 +261,20 @@
         config.shortWeekFormat = 'dddd, HH:mm';
         config.shortDateFormat = 'DD/MM';
 
+        config.editorEmbedCodeParsers = ['EMBED_PROVIDERS', 'api', function(EMBED_PROVIDERS, api) {
+            return [
+                {
+                    pattern: /src=".*vidible\.tv.*pid=(.+)\/(.+).js/g,
+                    name: EMBED_PROVIDERS.vidible,
+                    callback: function(match) {
+                        return api.get('vidible/bcid/' + match[2] + '/pid/' + match[1])
+                        .then(function(data) {
+                            return {association: data};
+                        });
+                    }
+                }
+            ];
+        }];
         config.ui = {
             italicAbstract: false
         };

--- a/server/pa/vidible.py
+++ b/server/pa/vidible.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013, 2014 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+from eve.render import send_response
+from flask import Blueprint
+from superdesk.utc import utcnow
+import superdesk
+import requests
+import re
+import json
+
+
+bp = Blueprint('vidible', __name__)
+
+
+def get_vidible_metadata(bcid, pid):
+    """
+    Retrieve the metadata for a given vidible embed
+    """
+    vidible_metadata = {}
+    # first we fetch a javascript file which contains some data and the video id
+    embed_meta_resp = requests.get('http://delivery.vidible.tv/jsonp/pid={pid}/{bcid}.js'.format(pid=pid, bcid=bcid))
+    embed_meta = re.search('({.*})', embed_meta_resp.text)
+    if embed_meta:
+        embed_meta = json.loads(embed_meta.group(0))
+        vidible_metadata.update({
+            'type': 'video',
+            'bcid': embed_meta['wlcid'],
+            'uri': embed_meta['bid']['id'],
+            'thumbnail': embed_meta['bid']['videos'][0]['thumbnail'],
+            'url': embed_meta['bid']['videos'][0]['videoUrls'][0],
+            'company': embed_meta['bid']['videos'][0]['studioName'],
+            'duration': embed_meta['bid']['videos'][0]['metadata']['duration'],
+        })
+        for video in embed_meta['bid']['videos'][:1]:
+            video_id = video['videoId']
+            # we use the video id in order to get additional metadata, like width, height, mimeType and more...
+            video_meta_resp = requests.get('http://api.vidible.tv/search?bcid={bcid}&query={video_id}'.format(
+                                           video_id=video_id, bcid=bcid))
+            vidible_metadata.update(video_meta_resp.json()[0])
+    return vidible_metadata
+
+
+@bp.route('/vidible/bcid/<bcid>/pid/<pid>', methods=['GET', 'OPTIONS'])
+def vidible(**kwargs):
+    meta = get_vidible_metadata(**kwargs)
+    if meta:
+        return send_response(None, (meta, utcnow(), None, 200))
+    else:
+        return send_response(None, ({'error': 'not found'}, utcnow(), None, 404))
+
+
+def init_app(app):
+    superdesk.blueprint(bp)

--- a/server/pa/vidible_test.py
+++ b/server/pa/vidible_test.py
@@ -1,0 +1,15 @@
+
+import unittest
+from .vidible import get_vidible_metadata
+
+
+class VidibleTestCase(unittest.TestCase):
+
+    def test_get_vidible_metadata(self):
+        meta = get_vidible_metadata(bcid='538612f0e4b00fbb8e898655', pid='56bb474de4b0568f54a23ed7')
+        assert(type(meta) is dict)
+        assert(type(meta['height']) is int)
+        assert(type(meta['width']) is int)
+        assert(meta['mimeType'])
+        assert(meta['url'])
+        assert(meta['thumbnail'])

--- a/server/settings.py
+++ b/server/settings.py
@@ -109,6 +109,7 @@ INSTALLED_APPS.extend([
 
     'pa.topics',
     'pa.pa_img',
+    'pa.vidible',
 ])
 
 DEFAULT_URGENCY_VALUE_FOR_MANUAL_ARTICLES = None


### PR DESCRIPTION
- add in backend an endpoint to fetch Vidible video metadata
- define in frontend a special handler for Vidible embed code

requires https://github.com/superdesk/superdesk-client-core/pull/610

and https://github.com/superdesk/superdesk-core/pull/432 to be fully complete