### PR TITLE
[scanpix] change subscription behaviour for ntbtema

### DIFF
--- a/server/ntb/scanpix/scanpix_datalayer.py
+++ b/server/ntb/scanpix/scanpix_datalayer.py
@@ -123,6 +123,11 @@ class ScanpixDatalayer(DataLayer):
                 data['subscription'] = extract_params(query, 'subscription')['subscription']
             except KeyError:
                 data['subscription'] = 'subscription'  # this is requested as a default value
+
+            if 'ntbtema' in resource and data['subscription'] == 'subscription':
+                # small hack for SDNTB-250
+                data['subscription'] = 'punchcard'
+
             if data['subscription'] == 'all':
                 del data['subscription']
 


### PR DESCRIPTION
as requested by NTB (see linked ticket), "subscription" filter is
replaced by "punchcard" if set to "subscription" ("inside subscription"
in the frontend) only for ntbtema resource.

fix SDNTB-250