### PR TITLE
[NITF Formatter] fixed featuremedia and body_html handling

### DIFF
--- a/server/ntb/tests/publish/ntb_nitf_test.py
+++ b/server/ntb/tests/publish/ntb_nitf_test.py
@@ -15,6 +15,24 @@ from superdesk.publish.formatters import Formatter
 from superdesk.publish import init_app
 import xml.etree.ElementTree as etree
 
+TEST_BODY = """
+<p class="lead" lede="true">test lead</p>
+<p class="txt">line 1</p>
+<p class="txt-ind">line 2</p>
+<p class="txt-ind">line 3</p>
+<!-- EMBED START Image {id: "embedded18237840351"} --><figure>
+<img src="http://scanpix.no/spWebApp/previewimage/sdl/preview/tb42bf43.jpg" alt="alt text" />
+<figcaption>New parliament speaker Ana Pastor speaks on her phone during the first session of parliament\
+following a general election in Madrid, Spain, July 19, 2016. REUTERS/Andrea Comas</figcaption>
+</figure><!-- EMBED END Image {id: "embedded18237840351"} -->
+<p><h3>intermediate line</h3></p>
+<!-- EMBED START Video {id: "embedded10005446043"} --><figure>
+<video controls="controls">
+</video>
+<figcaption>SCRIPT TO FOLLOW</figcaption>
+</figure><!-- EMBED END Video {id: "embedded10005446043"} -->
+"""
+
 
 @mock.patch('superdesk.publish.subscribers.SubscribersService.generate_sequence_number', lambda self, subscriber: 1)
 class NTBNITFFormatterTest(TestCase):
@@ -25,55 +43,49 @@ class NTBNITFFormatterTest(TestCase):
         init_app(self.app)
         self.article = {
             'headline': 'test headline',
-            "body_html": "<p class=\"lead\" lede=\"true\">United Nations, United States, July 15, 2016 (AFP) - "
-                         "A new round of talks to end the war in Yemen has been delayed by a day and is now exp"
-                         "ected to start on Saturday, the UN spokesman said.</p><p class=\"txt\">The talks were"
-                         " pushed back while UN envoy Ismail Ould Cheikh Ahmed was in Riyadh to try to persuade"
-                         " Yemen's President Abedrabbo Mansour Hadi to come to the negotiating table.</p><p cla"
-                         "ss=\"txt-ind\">Negotiators from the Huthi rebels and former president Ali Abdullah Sa"
-                         "leh's political party were already in Kuwait awaiting the arrival of the government d"
-                         "elegation.</p><p class=\"txt-ind\">\"We will see whether we can get both delegations "
-                         "so that we can get the talks started,\" UN spokesman Farhan Haq said on Friday.</p><p"
-                         " class=\"txt-ind\">\"If there is any further delay, we can let you know at that time,"
-                         " but right now what we are anticipating is a start tomorrow,\" he added.</p><p class="
-                         "\"txt-ind\">Yemen's president on Sunday warned that his government would boycott the "
-                         "talks if the UN envoy insists on a peace deal that would provide for a unity governme"
-                         "nt that includes the insurgents.</p><p class=\"txt-ind\">Hadi accused the Iran-backed"
-                         " Huthis of trying to \"legitimize their coup d'etat\" and warned he would not allow Y"
-                         "emen to be \"turned into a Persian state.\"</p><p class=\"txt-ind\">More than 6,400 p"
-                         "eople have died in Yemen since a Saudi-led coalition intervened in support of Hadi's "
-                         "government in March last year.</p><p class=\"txt-ind\">The coalition launched an air "
-                         "campaign to push back Huthi rebels after they seized the capital Sanaa and many other"
-                         " parts of the country.</p><p class=\"txt-ind\">There has been growing international a"
-                         "larm over the heavy civilian toll in Yemen, where 80 percent of the population is in "
-                         "urgent need of humanitarian aid.</p><p class=\"txt-ind\">cml/grf</p>\n<!-- EMBED STAR"
-                         "T Image {id: \"embedded18237840351\"} -->\n<figure><img src=\"http://scanpix.no/spWeb"
-                         "App/previewimage/sdl/preview/tb42bf43.jpg\" alt=\"New parliament speaker Ana Pastor s"
-                         "peaks on her phone during the first session of parliament following a general electio"
-                         "n in Madrid, Spain, July 19, 2016. REUTERS/Andrea Comas\" /><figcaption>New parliamen"
-                         "t speaker Ana Pastor speaks on her phone during the first session of parliament follo"
-                         "wing a general election in Madrid, Spain, July 19, 2016. REUTERS/Andrea Comas</figcap"
-                         "tion></figure>\n<!-- EMBED END Image {id: \"embedded18237840351\"} -->\n<!-- EMBED ST"
-                         "ART Video {id: \"embedded10005446043\"} -->\n<figure><video controls=\"controls\"></v"
-                         "ideo><figcaption>\n\nSCRIPT TO FOLLOW\n</figcaption></figure>\n<!-- EMBED END Video {"
-                         "id: \"embedded10005446043\"} -->",
+            "body_html": TEST_BODY,
             'type': 'text',
             'priority': '2',
             '_id': 'urn:localhost.abc',
             "slugline": "this is the slugline",
             'urgency': 2,
-            'subject': [{
-                         "scheme": "category",
-                         "qcode": "Forskning",
-                         "service": {
-                             "f": 1,
-                             "i": 1},
-                         "name": "Forskning"},
-                        {"scheme": "subject_custom",
-                         "qcode": "02001003",
-                         "parent": "02000000",
-                         "name": "tyveri og innbrudd"}],
+            'subject': [
+                {"scheme": "category",
+                 "qcode": "Forskning",
+                 "service": {
+                     "f": 1,
+                     "i": 1},
+                 "name": "Forskning"},
+                {"scheme": "subject_custom",
+                 "qcode": "02001003",
+                 "parent": "02000000",
+                 "name": "tyveri og innbrudd"}],
             "associations": {
+
+                "featuremedia": {
+                    "_id": "test_id",
+                    "guid": "test_id",
+                    "headline": "feature headline",
+                    "ingest_provider": "fdsfdsfsdfs",
+                    "original_source": "feature_source",
+                    "pubstatus": "usable",
+                    "renditions": {
+                        "baseImage": {
+                            "href": "http://scanpix.no/spWebApp/previewimage/sdl/preview_big/test_id.jpg"
+                        },
+                        "thumbnail": {
+                            "href": "http://preview.scanpix.no/thumbs/tb/4/33/test_id.jpg"
+                        },
+                        "viewImage": {
+                            "href": "http://scanpix.no/spWebApp/previewimage/sdl/preview/test_id.jpg"
+                        }},
+                    "source": "feature_source",
+                    "fetch_endpoint": "scanpix",
+                    "type": "picture",
+                    "versioncreated": "2016-07-20T07:11:37+0000",
+                    "description_text": "test feature media"
+                },
+
                 "embedded01": None,
                 "embedded10005446043": {
                     "firstcreated": "2016-07-19T16:23:11+0000",
@@ -96,20 +108,18 @@ class NTBNITFFormatterTest(TestCase):
                     "source": "Reuters DV",
                     "versioncreated": "2016-07-19T14:25:57+0000",
                     "_created": "1970-01-01T00:00:00+0000",
-                                "byline": None,
-                                "fetch_endpoint": "scanpix",
-                                "type": "video",
-                                "guid": "tb42bf38",
-                                "_id": "tb42bf38",
-                                "description_text": "\n\nSCRIPT TO FOLLOW\n",
-                                "_type": "externalsource",
-                                "ingest_provider": "577148e1cc3a2d5ab90f5d9c",
-                                "_links": {
-                                    "self": {
-                                        "href": "scanpix(desk)/tb42bf38",
-                                        "title": "Scanpix(desk)"
-                                    }
-                                },
+                    "byline": None,
+                    "fetch_endpoint": "scanpix",
+                    "type": "video",
+                    "guid": "tb42bf38",
+                    "_id": "tb42bf38",
+                    "description_text": "\n\nSCRIPT TO FOLLOW\n",
+                    "_type": "externalsource",
+                    "ingest_provider": "577148e1cc3a2d5ab90f5d9c",
+                    "_links": {
+                        "self": {
+                            "href": "scanpix(desk)/tb42bf38",
+                            "title": "Scanpix(desk)"}},
                     "headline": "Hollande meets Portugal president"
                 },
                 "embedded18237840351": {
@@ -132,23 +142,21 @@ class NTBNITFFormatterTest(TestCase):
                     "source": "Reuters",
                     "versioncreated": "2016-07-19T14:25:57+0000",
                     "_created": "1970-01-01T00:00:00+0000",
-                                "byline": "Andrea Comas",
-                                "fetch_endpoint": "scanpix",
-                                "type": "picture",
-                                "guid": "tb42bf43",
-                                "_id": "tb42bf43",
-                                "description_text": "New parliament speaker Ana Pastor speaks on her"
-                                " phone during the first "
-                                "session of parliament following a general election in Madrid, Spain,"
-                                " July 19, 2016. REUTERS/Andrea Comas",
-                                "_type": "externalsource",
-                                "ingest_provider": "577148e1cc3a2d5ab90f5d9c",
-                                "_links": {
-                                    "self": {
-                                        "href": "scanpix(desk)/tb42bf43",
-                                        "title": "Scanpix(desk)"
-                                    }
-                                },
+                    "byline": "Andrea Comas",
+                    "fetch_endpoint": "scanpix",
+                    "type": "picture",
+                    "guid": "tb42bf43",
+                    "_id": "tb42bf43",
+                    "description_text": "New parliament speaker Ana Pastor speaks on her"
+                    " phone during the first "
+                    "session of parliament following a general election in Madrid, Spain,"
+                    " July 19, 2016. REUTERS/Andrea Comas",
+                    "_type": "externalsource",
+                    "ingest_provider": "577148e1cc3a2d5ab90f5d9c",
+                    "_links": {
+                        "self": {
+                            "href": "scanpix(desk)/tb42bf43",
+                            "title": "Scanpix(desk)"}},
                     "headline": "New parliament speaker Ana Pastor speaks on her phone during the first session o"
                                 "f parliament following a general election in Madrid"
                 },
@@ -180,14 +188,41 @@ class NTBNITFFormatterTest(TestCase):
     def test_body(self):
         seq, doc = self.formatter.format(self.article, {'name': 'Test NTBNITF'})[0]
         nitf_xml = etree.fromstring(doc)
-        medias = nitf_xml.findall("body/body.content/media")
-        image = medias[0]
+
+        # body content
+
+        body_content = nitf_xml.find("body/body.content")
+        p_elems = iter(body_content.findall('p'))
+        lead = next(p_elems)
+        self.assertEqual(lead.get("class"), "lead")
+        self.assertEqual(lead.text, "test lead")
+
+        for i in range(1, 4):
+            p = next(p_elems)
+            self.assertEqual(p.text, "line {}".format(i))
+
+        h3 = next(p_elems).find('h3')
+        self.assertEqual(h3.text, "intermediate line")
+
+        # all embedded must be removed from body's HTML,
+        # they are put in <media/> elements
+        self.assertNotIn(b'EMBED', etree.tostring(body_content))
+
+        # medias
+
+        medias = body_content.findall("media")
+        feature = medias[0]
+        self.assertEqual(feature.get("media_type"), "image")
+        self.assertEqual(feature.find("media-reference").get("source"), "test_id")
+        self.assertEqual(feature.find("media-caption").text, "test feature media")
+
+        image = medias[1]
         self.assertEqual(image.get("media_type"), "image")
         self.assertEqual(image.find("media-reference").get("source"), "tb42bf43")
         self.assertEqual(image.find("media-caption").text,
                          "New parliament speaker Ana Pastor speaks on her phone during the first session of parliament"
                          " following a general election in Madrid, Spain, July 19, 2016. REUTERS/Andrea Comas")
-        video = medias[1]
+        video = medias[2]
         self.assertEqual(video.get("media_type"), "video")
         self.assertEqual(video.find("media-reference").get("mime-type"), "video/mpeg")
         self.assertEqual(video.find("media-reference").get("source"), "tb42bf38")


### PR DESCRIPTION
only "featureimage" was used, now "featuremedia" is checked too if
"featureimage" is not found

body_html was added to NITF's <body.content/> using the inherited
method from core's NITF Formatter, but this was not getting all the
elements.
To work around this, the inherited method is not used anymore, and
BeautifulSoup is used to transform the HTML to XML, which is then added
to body.content

This commit fixes the issues related in feedback of SDNTB-229 (in the
comments)