### PR TITLE
chore(NTB config): add default required media metatadata fields

### DIFF
--- a/client/superdesk.config.js
+++ b/client/superdesk.config.js
@@ -102,6 +102,8 @@ module.exports = function(grunt) {
 
         langOverride: {
             'de': {'My Profile': 'DE - My profile'}
-        }
+        },
+
+        requiredMediaMetadata: ['headline', 'description_text', 'alt_text']
     };
 };


### PR DESCRIPTION
config changes to specify previously hardcoded required media metadata fields.