### PR TITLE
chore(PA config): add default required media metatadata fields

### DIFF
--- a/client/superdesk.config.js
+++ b/client/superdesk.config.js
@@ -47,6 +47,8 @@ module.exports = function(grunt) {
                 'Urgency': 'Ranking',
                 '\'SLUGLINE is a required field\'': 'Keyword is a required field'
             }
-        }
+        },
+
+        requiredMediaMetadata: ['headline', 'description_text', 'alt_text']
     };
 };


### PR DESCRIPTION
config changes to specify previously hardcoded required media metadata fields.