### PR TITLE
chore(client):  add old hard coded media item required metadata fields

### DIFF
--- a/client/superdesk.config.js
+++ b/client/superdesk.config.js
@@ -6,6 +6,7 @@
  */
 module.exports = function(grunt) {
     return {
-        defaultRoute: '/workspace/personal'
+        defaultRoute: '/workspace/personal',
+        requiredMediaMetadata: ['headline', 'description_text', 'alt_text']
     };
 };


### PR DESCRIPTION
currently no fields are marked as required for media metadata.