### PR TITLE
[NITF] [formatter] added new elements

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -3,4 +3,4 @@ honcho==0.6.6
 Eve==0.6.3
 newrelic>=2.66,<2.67
 
--e git+git://github.com/superdesk/superdesk-core@f8f07d6#egg=Superdesk-Core
+-e git+git://github.com/superdesk/superdesk-core@3c7eb1e64d02fb3951ea57d306c19921dd94e3c4#egg=Superdesk-Core


### PR DESCRIPTION
the following elements have been added:
	- meta timestamp, ntb-dato, NTBUtDato, NTBStikkord, NTBBilderAntall, NTBDistribusjonsKode, NTBKanal, NTBID, NTBIPTCSequence, NTBEditor
	- date.issue now follows NTB format
	- added key-list/keyword in docdata
	- added tagline/a in body.end
	- added distributor/org in body.head
	- added baselang in <nitf> root element
	- doc-id follow new NTB specifications

following elements have been removed:
	- NTBPrioritet
	- date.expire

abstract in <p class="lead" lede="true"> element now use text with HTML
elements stripped.

if there is a paragraph in body_html using class="lead", it's changed
    for "txt", and lede attribute is removed if it exists.

mime_type had default values of "image/jpeg" for images and
"video/mpeg" for videos.

date has been removed from body.head/dateline

mimetype guessing in Scanpix search provider has been fixed and is now based on originalFileName
then fileFormat

requested in SDNTB-254