### PR TITLE
[NITF] [FORMATTER] use new specification for subject

### DIFF
--- a/server/ntb/publish/ntb_nitf.py
+++ b/server/ntb/publish/ntb_nitf.py
@@ -143,7 +143,7 @@ class NTBNITFFormatter(NITFFormatter):
         self._format_datetimes(article, head)
         if 'slugline' in article:
             ET.SubElement(head, 'meta', {'name': 'NTBStikkord', 'content': article['slugline']})
-            ET.SubElement(head, 'meta', {'name': 'subject', 'content': article['slugline']})
+        ET.SubElement(head, 'meta', {'name': 'subject', 'content': self._get_ntb_subject(article)})
 
         ET.SubElement(head, 'meta', {'name': 'NTBID', 'content': 'NTB{}'.format(article['item_id'])})
 


### PR DESCRIPTION
"subject" meta element now uses the new specifications with a nyX-
prefix for article updates.

SDNTB-254