### PR TITLE
Fix WebSocket url for dev.superdesk.org instances

### DIFF
--- a/docker/start.sh
+++ b/docker/start.sh
@@ -3,6 +3,7 @@ cd /opt/superdesk/client/dist &&
 sed -i \
  -e "s/http:\/\/localhost:5000\/api/$(echo $SUPERDESK_URL | sed 's/\//\\\//g')/g" \
  -e "s/ws:\/\/localhost:5100/$(echo $SUPERDESK_WS_URL | sed 's/\//\\\//g')/g" \
+ -e "s/ws:\/\/0.0.0.0:5100/$(echo $SUPERDESK_WS_URL | sed 's/\//\\\//g')/g" \
  -e 's/iframely:{key:""}/iframely:{key:"'$IFRAMELY_KEY'"}/g' \
  app*.js &&
 nginx &


### PR DESCRIPTION
Seems something changes and instead of `localhost` in app.bundle.js we have `0.0.0.0`.