### PR TITLE
[NITF] [FORMATTER] use _current_version instead of version

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -2,7 +2,7 @@
   "name": "superdesk-client",
   "license": "GPL-3.0",
   "dependencies": {
-    "superdesk-core": "superdesk/superdesk-client-core#394cf01",
+    "superdesk-core": "superdesk/superdesk-client-core#265a8d8",
     "btoa": "1.1.2",
     "babel-core": "^6.10.4",
     "babel-loader": "^6.2.4",

--- a/server/ntb/publish/ntb_nitf.py
+++ b/server/ntb/publish/ntb_nitf.py
@@ -63,7 +63,7 @@ class NTBNITFFormatter(NITFFormatter):
         return category
 
     def _get_ntb_subject(self, article):
-        update = article['version'] - 1
+        update = article['_current_version'] - 1
         subject_prefix = "ny{}-".format(update) if update else ""
         return subject_prefix + article.get('slugline', '')
 
@@ -79,7 +79,7 @@ class NTBNITFFormatter(NITFFormatter):
     def _format_docdata_doc_id(self, article, docdata):
         doc_id = "NTB{item_id}_{version:02}".format(
             item_id=article['item_id'],
-            version=article['version'] - 1)
+            version=article['_current_version'] - 1)
         ET.SubElement(docdata, 'doc-id', attrib={'regsrc': 'NTB', 'id-string': doc_id})
 
     def _format_date_expire(self, article, docdata):
@@ -91,7 +91,10 @@ class NTBNITFFormatter(NITFFormatter):
         if 'slugline' in article:
             key_list = ET.SubElement(docdata, 'key-list')
             ET.SubElement(key_list, 'keyword', attrib={'key': article['slugline']})
-            ET.SubElement(docdata, 'du-key', attrib={'version': str(article['version']), 'key': article['slugline']})
+            ET.SubElement(
+                docdata,
+                'du-key',
+                attrib={'version': str(article['_current_version']), 'key': article['slugline']})
         for place in article.get('place', []):
             evloc = ET.SubElement(docdata, 'evloc')
             for key, att in (('parent', 'state-prov'), ('qcode', 'county-dist')):

--- a/server/ntb/tests/publish/ntb_nitf_test.py
+++ b/server/ntb/tests/publish/ntb_nitf_test.py
@@ -51,6 +51,7 @@ ARTICLE = {
     "slugline": "this is the slugline",
     'urgency': 2,
     'versioncreated': NOW,
+    '_current_version': 2,
     'version': 2,
     'language': 'nb-NO',
     'dateline': {


### PR DESCRIPTION
version doesn't seems to work as expected (it doesn't change after an
update), but _current_version do the job, so version as been replaced
by _current_version where it's needed

SDNTB-280