### PR TITLE
[NITF] [Formatter] fixed formatting of articles with top-level places

### DIFF
--- a/server/ntb/publish/ntb_nitf.py
+++ b/server/ntb/publish/ntb_nitf.py
@@ -109,9 +109,12 @@ class NTBNITFFormatter(NITFFormatter):
             evloc = ET.SubElement(docdata, 'evloc')
             for key, att in (('parent', 'state-prov'), ('qcode', 'county-dist')):
                 try:
-                    evloc.attrib[att] = place[key]
+                    value = place[key]
                 except KeyError:
                     pass
+                else:
+                    if value is not None:
+                        evloc.attrib[att] = value
 
     def _format_pubdata(self, article, head):
         pub_date = article['versioncreated'].astimezone(tz).strftime("%Y%m%dT%H%M%S")

--- a/server/ntb/tests/publish/ntb_nitf_test.py
+++ b/server/ntb/tests/publish/ntb_nitf_test.py
@@ -56,6 +56,9 @@ ARTICLE = {
     '_current_version': 2,
     'version': 2,
     'language': 'nb-NO',
+    # if you change place, please keep a test with 'parent': None
+    # cf SDNTB-290
+    'place': [{'scheme': 'place_custom', 'parent': None, 'name': 'Global', 'qcode': 'Global'}],
     'dateline': {
         'located': {
             'dateline': 'city',
@@ -282,6 +285,10 @@ class NTBNITFFormatterTest(TestCase):
         formatted = self.doc
         header = formatted[:formatted.find('>') + 1]
         self.assertIn('encoding="{}"'.format(ENCODING), header)
+
+    def test_place(self):
+        evloc = self.nitf_xml.find('head/docdata/evloc')
+        self.assertEqual(evloc.get('county-dist'), "Global")
 
     def test_meta(self):
         head = self.nitf_xml.find('head')


### PR DESCRIPTION
formatting was failing when parent == None in place (i.e. with top-level
place), this commit fix it.

SDNTB-290