### PR TITLE
[NITF] [FORMATTER] replace forbidden characters by "-"

### DIFF
--- a/server/ntb/publish/ntb_nitf.py
+++ b/server/ntb/publish/ntb_nitf.py
@@ -25,6 +25,7 @@ tz = None
 
 EMBED_RE = re.compile(r"<!-- EMBED START ([a-zA-Z]+ {id: \"(?P<id>.+?)\"}) -->.*"
                       r"<!-- EMBED END \1 -->", re.DOTALL)
+FILENAME_FORBIDDEN_RE = re.compile(r"[^a-zA-Z0-9._-]")
 ENCODING = 'iso-8859-1'
 assert ENCODING is not 'unicode'  # use e.g. utf-8 for unicode
 
@@ -149,9 +150,10 @@ class NTBNITFFormatter(NITFFormatter):
             metadata['service'] = ""
         metadata['category'] = self._get_ntb_category(article)
         metadata['subject'] = self._get_ntb_subject(article)
-        return "{date}_{service}_{category}_{subject}.{ext}".format(
+        filename_raw = "{date}_{service}_{category}_{subject}.{ext}".format(
             ext="xml",
-            **metadata).replace(':', '-')
+            **metadata)
+        return FILENAME_FORBIDDEN_RE.sub('-', filename_raw)
 
     def _format_meta(self, article, head, destination, pub_seq_num):
         super()._format_meta(article, head, destination, pub_seq_num)

--- a/server/ntb/tests/publish/ntb_nitf_test.py
+++ b/server/ntb/tests/publish/ntb_nitf_test.py
@@ -51,7 +51,8 @@ ARTICLE = {
     'priority': '2',
     '_id': 'urn:localhost.abc',
     'item_id': ITEM_ID,
-    "slugline": "this is the slugline",
+    # we use non latin1 chars in slugline to test encoding
+    "slugline": "this is the slugline œ:?–",
     'urgency': 2,
     'versioncreated': NOW,
     '_current_version': 2,
@@ -219,7 +220,7 @@ class NTBNITFFormatterTest(TestCase):
 
     def test_slugline(self):
         du_key = self.nitf_xml.find('head/docdata/du-key')
-        self.assertEqual(du_key.get('key'), 'this is the slugline')
+        self.assertEqual(du_key.get('key'), 'this is the slugline œ:?–')
 
     def test_pubdata(self):
         pubdata = self.nitf_xml.find('head/pubdata')
@@ -289,9 +290,14 @@ class NTBNITFFormatterTest(TestCase):
         nitf_xml = etree.fromstring(doc)
         self.assertEqual(nitf_xml.find('body/body.head/dateline'), None)
 
+    def test_filenmae(self):
+        filename = self.nitf_xml.find('head/meta[@name="filename"]')
+        datetime = NOW.astimezone(self.tz).strftime("%Y-%m-%d_%H-%M-%S")
+        self.assertEqual(filename.get('content'), datetime + "__Forskning_ny1-this-is-the-slugline-----.xml")
+
     def test_encoding(self):
         encoded = self.formatter_output[0]['encoded_item']
-        manually_encoded = self.doc.replace('–', '&#8211;').encode(ENCODING)
+        manually_encoded = self.doc.encode(ENCODING, 'xmlcharrefreplace')
         self.assertEqual(encoded, manually_encoded)
         formatted = self.doc
         header = formatted[:formatted.find('>') + 1]


### PR DESCRIPTION
Following charaters only are allowed in filename: a-z, A-Z, 0-9, ".", "_" and "-", all others are replaced.

SDNTB-291