### PR TITLE
SD-5528 - Associated item <item_name>: RENDITIONS is a required field

### DIFF
--- a/server/data/validators.json
+++ b/server/data/validators.json
@@ -512,11 +512,7 @@
             },
             "renditions": {
                 "type": "dict",
-                "required": true,
-                "schema": {
-                    "4-3": {"type": "dict", "required": true},
-                    "16-9": {"type": "dict", "required": true}
-                }
+                "required": true
             }
         }
     },


### PR DESCRIPTION
Thanks to @petrjasek here is the fix.

This error appears when the "Image Crop Sizes" names are changed in the vocabulary and Superdesk still tries to validate renditions using the hardcoded renditions names.

Related ticket: https://dev.sourcefabric.org/browse/SD-5528