### PR TITLE
[NTB] [FORMATTER] fixed version/update numbers

### DIFF
--- a/server/ntb/publish/ntb_nitf.py
+++ b/server/ntb/publish/ntb_nitf.py
@@ -74,7 +74,7 @@ class NTBNITFFormatter(NITFFormatter):
         return category
 
     def _get_ntb_subject(self, article):
-        update = article['_current_version'] - 1
+        update = article.get('rewrite_sequence', 0)
         subject_prefix = "ny{}-".format(update) if update else ""
         return subject_prefix + article.get('slugline', '')
 
@@ -90,7 +90,7 @@ class NTBNITFFormatter(NITFFormatter):
     def _format_docdata_doc_id(self, article, docdata):
         doc_id = "NTB{item_id}_{version:02}".format(
             item_id=article['item_id'],
-            version=article['_current_version'] - 1)
+            version=article.get('rewrite_sequence', 0))
         ET.SubElement(docdata, 'doc-id', attrib={'regsrc': 'NTB', 'id-string': doc_id})
 
     def _format_date_expire(self, article, docdata):
@@ -105,7 +105,7 @@ class NTBNITFFormatter(NITFFormatter):
             ET.SubElement(
                 docdata,
                 'du-key',
-                attrib={'version': str(article['_current_version']), 'key': article['slugline']})
+                attrib={'version': str(article.get('rewrite_sequence', 0) + 1), 'key': article['slugline']})
         for place in article.get('place', []):
             evloc = ET.SubElement(docdata, 'evloc')
             for key, att in (('parent', 'state-prov'), ('qcode', 'county-dist')):

--- a/server/ntb/tests/publish/ntb_nitf_test.py
+++ b/server/ntb/tests/publish/ntb_nitf_test.py
@@ -55,8 +55,9 @@ ARTICLE = {
     "slugline": "this is the slugline œ:?–",
     'urgency': 2,
     'versioncreated': NOW,
-    '_current_version': 2,
-    'version': 2,
+    '_current_version': 5,
+    'version': 5,
+    'rewrite_sequence': 1,
     'language': 'nb-NO',
     # if you change place, please keep a test with 'parent': None
     # cf SDNTB-290


### PR DESCRIPTION
"_current_version" was used to determine version and update numbers, but
this metadata actually change which saved versions, not with publication version which is what is requested.

This commit change this to use "rewrite_sequence" which actually
correspond to the desired information.

fix SDNTB-303