### PR TITLE
[NITF] [FORMATTER] sign_off are now splitted with "/"

### DIFF
--- a/server/ntb/publish/ntb_nitf.py
+++ b/server/ntb/publish/ntb_nitf.py
@@ -352,13 +352,15 @@ class NTBNITFFormatter(NITFFormatter):
 
     def _format_body_end(self, article, body_end):
         try:
-            emails = article['sign_off'].split()
+            emails = [s.strip() for s in article['sign_off'].split('/')]
         except KeyError:
             return
         if emails:
             tagline = ET.SubElement(body_end, 'tagline')
             previous = None
             for email in emails:
+                if not email:
+                    continue
                 a = ET.SubElement(tagline, 'a', {'href': 'mailto:{}'.format(email)})
                 a.text = email
                 if previous is not None:

--- a/server/ntb/tests/publish/ntb_nitf_test.py
+++ b/server/ntb/tests/publish/ntb_nitf_test.py
@@ -61,7 +61,7 @@ ARTICLE = {
     'version': 5,
     'rewrite_sequence': 1,
     'language': 'nb-NO',
-    'sign_off': ' '.join(TEST_EMAILS),
+    'sign_off': '/'.join(TEST_EMAILS),
     # if you change place, please keep a test with 'parent': None
     # cf SDNTB-290
     'place': [{'scheme': 'place_custom', 'parent': None, 'name': 'Global', 'qcode': 'Global'}],


### PR DESCRIPTION
sign_off were splitted using " " (space), but a slash is actually used
in superdesk. This commit fix it, but it's not a proper solution as "/"
could be used in email addresses, so a new ticket has been opened
(SD-5546) and this is a temporary solution

SDNTB-305