### PR TITLE
SDESK-200: FILTERS in advanced search do not work for Search Providers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ include/
 .idea/
 .vagrant/
 /client/.tern-project
+/client/index.html
+/client/templates-cache.js
 /server/.project
 /server/.pydevproject
 /server/.settings/org.eclipse.core.resources.prefs

--- a/server/ntb/scanpix/scanpix_datalayer.py
+++ b/server/ntb/scanpix/scanpix_datalayer.py
@@ -13,7 +13,6 @@ import logging
 import re
 import requests
 import json
-from datetime import datetime
 from os.path import splitext
 
 from io import BytesIO

--- a/server/ntb/scanpix/scanpix_datalayer.py
+++ b/server/ntb/scanpix/scanpix_datalayer.py
@@ -54,12 +54,6 @@ def extract_params(query, names):
     return params
 
 
-# Images API is looking for param like dd-mm-yyyy
-def extract_date(date):
-    date_object = datetime.strptime(date, '%d/%m/%Y')
-    return date_object.strftime('%d-%m-%Y')
-
-
 class ScanpixDatalayer(DataLayer):
     def set_credentials(self, user, password):
         self._user = user
@@ -94,7 +88,13 @@ class ScanpixDatalayer(DataLayer):
         :return:
         """
         url = self._app.config['SCANPIX_SEARCH_URL'] + '/search'
-        data = {'mainGroup': 'any'}
+        data = {
+            'mainGroup': 'any',
+            'archived': {
+                'max': '',
+                'min': ''
+            }
+        }
 
         if 'query' in req['query']['filtered']:
             query = req['query']['filtered']['query']['query_string']['query'] \
@@ -166,9 +166,9 @@ class ScanpixDatalayer(DataLayer):
                         data['timeLimit'] = 'lastmonth '
                 elif start or end:
                     if start:
-                        data['archived']['min'] = extract_date(start)
+                        data['archived']['min'] = start
                     if end:
-                        data['archived']['max'] = extract_date(end)
+                        data['archived']['max'] = end
 
             if 'terms' in criterion:
                 if 'type' in criterion.get('terms', {}):

--- a/server/ntb/scanpix/scanpix_datalayer_tests.py
+++ b/server/ntb/scanpix/scanpix_datalayer_tests.py
@@ -34,7 +34,3 @@ class ScanpixDatalayer(TestCase):
         result = extract_params(query, names)
         self.assertDictEqual(result, {'q': 'all', 'headline': 'head one'},
                              msg='Fail to parse text query all end')
-
-    def test_date_param_format_is_correct(self):
-        date = '29/02/2016'
-        self.assertEqual('29-02-2016', extract_date(date))

--- a/server/ntb/scanpix/scanpix_datalayer_tests.py
+++ b/server/ntb/scanpix/scanpix_datalayer_tests.py
@@ -7,7 +7,7 @@
 # For the full copyright and license information, please see the
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
-from ntb.scanpix.scanpix_datalayer import extract_params, extract_date
+from ntb.scanpix.scanpix_datalayer import extract_params
 from superdesk.tests import TestCase
 
 


### PR DESCRIPTION
fixed date filters to use scanpix archived parameters and remove unnecessary extract_date function (http://api.scanpix.no/doc/ date - uses standard datetime format) 