### PR TITLE
SDESK-223: Scanpix search: Display archived-date in search results

### DIFF
--- a/server/ntb/scanpix/scanpix_datalayer.py
+++ b/server/ntb/scanpix/scanpix_datalayer.py
@@ -213,7 +213,7 @@ class ScanpixDatalayer(DataLayer):
             new_doc['original_source'] = new_doc['source'] = doc['credit']
         except KeyError:
             pass
-        new_doc['versioncreated'] = utcnow()
+        new_doc['versioncreated'] = self._datetime(doc['archivedTime'])
         new_doc['firstcreated'] = self._datetime(doc['archivedTime'])
         new_doc['pubstatus'] = 'usable'
         # This must match the action

--- a/server/ntb/scanpix/scanpix_datalayer.py
+++ b/server/ntb/scanpix/scanpix_datalayer.py
@@ -213,8 +213,7 @@ class ScanpixDatalayer(DataLayer):
             new_doc['original_source'] = new_doc['source'] = doc['credit']
         except KeyError:
             pass
-        new_doc['versioncreated'] = self._datetime(doc['archivedTime'])
-        new_doc['firstcreated'] = self._datetime(doc['archivedTime'])
+        new_doc['versioncreated'] = new_doc['firstcreated'] = self._datetime(doc['archivedTime'])
         new_doc['pubstatus'] = 'usable'
         # This must match the action
         new_doc['_type'] = 'externalsource'


### PR DESCRIPTION
update scanpix datalayer to use archivedTime as versioncreated