### PR TITLE
[FEED PARSER] [NITF] remove abstract from body_html

### DIFF
--- a/server/ntb/tests/io/feed_parsers/nitf_tests.py
+++ b/server/ntb/tests/io/feed_parsers/nitf_tests.py
@@ -18,6 +18,11 @@ from superdesk.etree import etree
 from superdesk.io.feed_parsers.nitf import NITFFeedParser
 from superdesk.vocabularies.command import VocabulariesPopulateCommand
 
+ABSTRACT = ("København /ritzau/: "
+            "En 41-årig mand, der onsdag blev anholdt og sat i forbindelse "
+            "med en mulig skudepisode nær en børnehave i Hvidovre ved København, "
+            "er blevet løsladt.")
+
 
 class NITFTestCase(TestCase):
 
@@ -62,10 +67,10 @@ class NTBTestCase(NITFTestCase):
     def test_abstract(self):
         self.assertEqual(
             self.item.get('abstract'),
-            "København /ritzau/: "
-            "En 41-årig mand, der onsdag blev anholdt og sat i forbindelse "
-            "med en mulig skudepisode nær en børnehave i Hvidovre ved København, "
-            "er blevet løsladt.")
+            ABSTRACT)
+
+    def test_body_html(self):
+        self.assertNotIn(ABSTRACT, self.item.get('body_html'))
 
     def test_keywords(self):
         self.assertNotIn('keywords', self.item)

--- a/server/settings.py
+++ b/server/settings.py
@@ -13,6 +13,7 @@
 import os
 import json
 import superdesk
+from xml.etree import ElementTree as ET
 
 
 try:
@@ -224,6 +225,15 @@ def build_service(elem):
         service[0]['qcode'] = elem.get('content')
     return service
 
+
+def build_body_html(xml):
+    elements = []
+    for elem in xml.find('body/body.content'):
+        if elem.tag == 'p' and elem.get('class') == 'lead':
+            continue
+        elements.append(ET.tostring(elem, encoding='unicode'))
+    return ''.join(elements)
+
 NITF_MAPPING = {
     'anpa_category': {'xpath': "head/meta/[@name='NTBTjeneste']",
                       'filter': build_service,
@@ -243,6 +253,7 @@ NITF_MAPPING = {
     'subject': {'update': True,  # we use default subjects parsing
                 'filter_value': add_subjects_scheme,  # and add NTB scheme
                 'key_hook': lambda item, value: item.setdefault('subject', []).extend(value)},
+    'body_html': build_body_html,
     'slugline': 'head/docdata/du-key/@key',
     'abstract': "body/body.content/p[@class='lead']",
     'keywords': '',  # keywords are ignored on purpose


### PR DESCRIPTION
abstract is taken from first paragraph (<p> element with class "lead")
of body.content, this was resulting in a duplicate abstract (in
abstract and in body_html).

This commit ignore <p> element with class "lead" when parsing
body.content to generate body_html.

SDNTB-312