### PR TITLE
SDESK-223: Scanpix search: Display archived-date in search results

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 
-python: 3.4
+python: 3.5
 
 sudo: false
 

--- a/server/ntb/scanpix/scanpix_datalayer.py
+++ b/server/ntb/scanpix/scanpix_datalayer.py
@@ -35,8 +35,8 @@ REND2PREV = {
     'viewImage': ('preview', 'thumbnail_big', 'thumbnail', 'preview_big'),
     'baseImage': ('mp4_preview', 'mp4_thumbnail', 'preview_big', 'preview', 'thumbnail_big', 'thumbnail')}
 logger = logging.getLogger('ntb:scanpix')
-
 SCANPIX_TZ = 'Europe/Oslo'
+
 
 def extract_params(query, names):
     if isinstance(names, str):
@@ -214,7 +214,9 @@ class ScanpixDatalayer(DataLayer):
             new_doc['original_source'] = new_doc['source'] = doc['credit']
         except KeyError:
             pass
-        new_doc['versioncreated'] = new_doc['firstcreated'] = self._datetime(local_to_utc(SCANPIX_TZ, get_date(doc['archivedTime'])))
+        new_doc['versioncreated'] = new_doc['firstcreated'] = self._datetime(
+            local_to_utc(SCANPIX_TZ, get_date(doc['archivedTime']))
+        )
         new_doc['pubstatus'] = 'usable'
         # This must match the action
         new_doc['_type'] = 'externalsource'

--- a/server/ntb/scanpix/scanpix_datalayer.py
+++ b/server/ntb/scanpix/scanpix_datalayer.py
@@ -38,6 +38,7 @@ logger = logging.getLogger('ntb:scanpix')
 # Default timezone used to convert datetimes from scanpix api results to utc
 SCANPIX_TZ = 'Europe/Oslo'
 
+
 def extract_params(query, names):
     if isinstance(names, str):
         names = [names]

--- a/server/ntb/scanpix/scanpix_datalayer.py
+++ b/server/ntb/scanpix/scanpix_datalayer.py
@@ -24,7 +24,7 @@ from superdesk.errors import SuperdeskApiError, ProviderError
 from superdesk.media.media_operations import process_file_from_stream, decode_metadata
 from superdesk.media.renditions import generate_renditions, delete_file_on_error, get_renditions_spec
 from superdesk.metadata.item import ITEM_TYPE, CONTENT_TYPE
-from superdesk.utc import utcnow
+from superdesk.utc import utcnow, get_date, local_to_utc
 import mimetypes
 
 
@@ -36,6 +36,7 @@ REND2PREV = {
     'baseImage': ('mp4_preview', 'mp4_thumbnail', 'preview_big', 'preview', 'thumbnail_big', 'thumbnail')}
 logger = logging.getLogger('ntb:scanpix')
 
+SCANPIX_TZ = 'Europe/Oslo'
 
 def extract_params(query, names):
     if isinstance(names, str):
@@ -213,7 +214,7 @@ class ScanpixDatalayer(DataLayer):
             new_doc['original_source'] = new_doc['source'] = doc['credit']
         except KeyError:
             pass
-        new_doc['versioncreated'] = new_doc['firstcreated'] = self._datetime(doc['archivedTime'])
+        new_doc['versioncreated'] = new_doc['firstcreated'] = self._datetime(local_to_utc(SCANPIX_TZ, get_date(doc['archivedTime'])))
         new_doc['pubstatus'] = 'usable'
         # This must match the action
         new_doc['_type'] = 'externalsource'

--- a/server/ntb/scanpix/scanpix_datalayer.py
+++ b/server/ntb/scanpix/scanpix_datalayer.py
@@ -19,7 +19,6 @@ from io import BytesIO
 from eve.io.base import DataLayer
 from eve_elastic.elastic import ElasticCursor
 from superdesk.upload import url_for_media
-from settings import SCANPIX_TZ
 
 from superdesk.errors import SuperdeskApiError, ProviderError
 from superdesk.media.media_operations import process_file_from_stream, decode_metadata
@@ -36,7 +35,8 @@ REND2PREV = {
     'viewImage': ('preview', 'thumbnail_big', 'thumbnail', 'preview_big'),
     'baseImage': ('mp4_preview', 'mp4_thumbnail', 'preview_big', 'preview', 'thumbnail_big', 'thumbnail')}
 logger = logging.getLogger('ntb:scanpix')
-
+# Default timezone used to convert datetimes from scanpix api results to utc
+SCANPIX_TZ = 'Europe/Oslo'
 
 def extract_params(query, names):
     if isinstance(names, str):

--- a/server/ntb/scanpix/scanpix_datalayer.py
+++ b/server/ntb/scanpix/scanpix_datalayer.py
@@ -19,6 +19,7 @@ from io import BytesIO
 from eve.io.base import DataLayer
 from eve_elastic.elastic import ElasticCursor
 from superdesk.upload import url_for_media
+from settings import SCANPIX_TZ
 
 from superdesk.errors import SuperdeskApiError, ProviderError
 from superdesk.media.media_operations import process_file_from_stream, decode_metadata
@@ -35,7 +36,6 @@ REND2PREV = {
     'viewImage': ('preview', 'thumbnail_big', 'thumbnail', 'preview_big'),
     'baseImage': ('mp4_preview', 'mp4_thumbnail', 'preview_big', 'preview', 'thumbnail_big', 'thumbnail')}
 logger = logging.getLogger('ntb:scanpix')
-SCANPIX_TZ = 'Europe/Oslo'
 
 
 def extract_params(query, names):

--- a/server/settings.py
+++ b/server/settings.py
@@ -251,6 +251,3 @@ NITF_MAPPING = {
 ENABLE_PROFILING = False
 
 NO_TAKES = True
-
-# Default timezone used to convert datetimes from scanpix api results to utc
-SCANPIX_TZ = 'Europe/Oslo'

--- a/server/settings.py
+++ b/server/settings.py
@@ -251,3 +251,6 @@ NITF_MAPPING = {
 ENABLE_PROFILING = False
 
 NO_TAKES = True
+
+# Default timezone used to convert datetimes from scanpix api results to utc
+SCANPIX_TZ = 'Europe/Oslo'


### PR DESCRIPTION
converts scanpix archiveTime dates to UTC for proper display in client