### PR TITLE
[DATA] removed _file_id from dictionaries

### DIFF
--- a/server/data/dictionaries.json
+++ b/server/data/dictionaries.json
@@ -5,7 +5,6 @@
         "content": null,
         "language_id": "en",
         "name": "en",
-        "_file_id": "593e938aab0e4f00de983494",
         "is_active": "true"
     }
 ]


### PR DESCRIPTION
a field linking to a unexistant file was present in dictionaries
collection, resulting in bad behaviour when trying to modify the
dictionary in the settings.

SDTS-54