### PR TITLE
Update cores, gunicorn and honcho

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -3,6 +3,6 @@
     "license": "GPL-3.0",
     "dependencies": {
         "superdesk-analytics": "superdesk/superdesk-analytics#f856be7",
-        "superdesk-core": "superdesk/superdesk-client-core#c68b559"
+        "superdesk-core": "superdesk/superdesk-client-core#8f4a12212"
     }
 }

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,6 +1,6 @@
-gunicorn==19.6.0
-honcho==0.6.6
+gunicorn==19.7.1
+honcho==1.0.1
 newrelic>=2.66,<2.67
 
-git+git://github.com/superdesk/superdesk-core.git@6fdb582#egg=Superdesk-Core
+git+git://github.com/superdesk/superdesk-core.git@3e4f3fce1#egg=Superdesk-Core
 git+git://github.com/superdesk/superdesk-analytics.git@f856be7#egg=superdesk-analytics


### PR DESCRIPTION
It's time to update `gunicorn` and `honcho` too, new versions have been in use on `*.test.superdesk.org` instances and seems they are working pretty well.