### PR TITLE
Wrap $SCRIPT_DIR in quotes

### DIFF
--- a/scripts/docker-local-create-user.sh
+++ b/scripts/docker-local-create-user.sh
@@ -4,7 +4,7 @@ set -ue
 
 SCRIPT_DIR="$(echo $(cd -P -- "$(dirname -- "$0")" && pwd -P))"
 
-cd $SCRIPT_DIR/../docker
+cd "$SCRIPT_DIR"/../docker
 
 docker-compose -p sddemo -f ./docker-compose-prebuilt.yml run superdesk ./scripts/fig_wrapper.sh bash -c "\
   python3 manage.py app:initialize_data ;\

--- a/scripts/docker-local-demo.sh
+++ b/scripts/docker-local-demo.sh
@@ -24,7 +24,7 @@ echo '
 |==================================================================|
 '
 
-cd $SCRIPT_DIR/../docker
+cd "$SCRIPT_DIR"/../docker
 dcs kill
 dcs pull
 dcs up --timeout 600


### PR DESCRIPTION
In the `scripts` folder there are two scripts, `docker-local-demo.sh` and `docker-local-create-user.sh` that use a variable called `$SCRIPT_DIR`. When running these scripts, I ran into the following errors:

```shell
./scripts/docker-local-demo.sh: line 27: cd: /Users/nathan/Developer/Daily: No such file or directory
```

The location of the superdesk folder on my computer is `/Users/nathan/Developer/Daily Bruin/superdesk`. In order to have $SCRIPT_DIR support folders with whitespace, we need to wrap it in quotes when using it. [This Stack Exchange question](https://unix.stackexchange.com/questions/131766/why-does-my-shell-script-choke-on-whitespace-or-other-special-characters) explains the issue in more detail.

Note: this is my first PR, so please let me know if I'm doing everything correctly! I couldn't find any contributing guidelines so I'm just going off of how I've seen other open-source projects handle contributions.