### PR TITLE
fix(build): Make master a vanilla Superdesk install

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -2,8 +2,6 @@
     "name": "superdesk",
     "license": "GPL-3.0",
     "dependencies": {
-        "superdesk-analytics": "tomaskikutis/superdesk-analytics#next",
-        "superdesk-core": "superdesk/superdesk-client-core#develop",
-        "superdesk-publisher": "superdesk/superdesk-publisher#master"
+        "superdesk-core": "superdesk/superdesk-client-core#develop"
     }
 }

--- a/client/superdesk.config.js
+++ b/client/superdesk.config.js
@@ -7,21 +7,11 @@
 module.exports = function(grunt) {
     return {
         apps: [
-            'superdesk.analytics'
         ],
         importApps: [
             '../index',
-            'superdesk-analytics',
-            'superdesk-publisher'
         ],
         defaultRoute: '/workspace/personal',
-
-        publisher: {
-            protocol: 'https',
-            tenant: process.env.PUBLISHER_API_SUBDOMAIN || '',
-            domain: process.env.PUBLISHER_API_DOMAIN || 'localhost',
-            base: 'api/v1'
-        },
 
         langOverride: {
             'en': {
@@ -43,7 +33,6 @@ module.exports = function(grunt) {
             editorHighlights: true
         },
         workspace: {
-            analytics: true
         },
     };
 };

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -3,4 +3,3 @@ honcho==1.0.1
 newrelic>=2.66,<2.67
 
 -e git+git://github.com/superdesk/superdesk-core.git@develop#egg=superdesk-core
--e git+git://github.com/superdesk/superdesk-analytics.git@master#egg=superdesk-analytics

--- a/server/settings.py
+++ b/server/settings.py
@@ -32,7 +32,6 @@ if init_data.exists():
     INIT_DATA_PATH = init_data
 
 INSTALLED_APPS.extend([
-    'analytics',
     'apps.languages',
 ])
 


### PR DESCRIPTION
Optional Superdesk modules such as Planning, Analytics and Publisher should use separate branches from the Vanilla Superdesk builds