### PR TITLE
use media references before removing binary

### DIFF
--- a/server/ansa/commands/remove_expired_media.py
+++ b/server/ansa/commands/remove_expired_media.py
@@ -27,7 +27,7 @@ class RemoveExpiredMediaCommand(superdesk.Command):
 
         i = 0
         for item in cursor:
-            if item.get('associations') or item.get('renditions'):
+            if item.get('renditions'):
                 i += 1
                 item['item_id'] = item['_id']
                 remove_expired_media(archived_service, item, dry=dry)


### PR DESCRIPTION
to check if that binary is still in use and
keep it in such case. ansa uses md5 for media
so if same picture is used/uploaded/fetched multiple
times they all have same media id.

SDANSA-401