### PR TITLE
Fix `docker compose` commands.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Find more information about the client configuration in the README file of the r
 
 ## Run Superdesk locally using Docker
 
-You can start superdesk using the `docker compose.yml` file:
+You can start superdesk using the `docker-compose.yml` file:
 
 ```sh
 $ docker compose up -d

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ Find more information about the client configuration in the README file of the r
 
 ## Run Superdesk locally using Docker
 
-You can start superdesk using the `docker-compose.yml` file:
+You can start superdesk using the `docker compose.yml` file:
 
 ```sh
-$ docker-compose up -d
+$ docker compose up -d
 ```
 
 This will start superdesk on http://localhost:8080. On the first run you also have to initialize
@@ -29,9 +29,9 @@ elastic/mongo and create a user:
 
 ```sh
 # Initialize data
-$ docker-compose run superdesk-server run python manage.py app:initialize_data
+$ docker compose exec superdesk-server python manage.py app:initialize_data
 # Create first admin user
-$ docker-compose run superdesk-server run python manage.py users:create -u admin -p admin -e admin@localhost --admin
+$ docker compose exec superdesk-server python manage.py users:create -u admin -p admin -e admin@localhost --admin
 ```
 
 Then you can login with admin:admin credentials.


### PR DESCRIPTION
- `compose` is now a sub-command of `docker`, so `docker compose` should be used instead of `docker-compose`.

- The initialization commands used `docker-compose run` which starts a new container, while at this point the container should be already running, so `exec` should be used instead.

- Removed erroneous `run` commands used before `python manage.py`.