### PR TITLE
skip testing node 20

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['14', '20', '22']
+        node-version: ['14', '22']
     uses: ./.github/workflows/client.yml
     with:
         node-version: ${{ matrix.node-version }}

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,5 +1,5 @@
 # BUILD
-FROM node:20 AS build
+FROM node:22 AS build
 
 # install client
 WORKDIR /tmp/client


### PR DESCRIPTION
we will rather support 22+ moving on, so far
we didn't use 20 so it's an extra step we can avoid