### PR TITLE
Potential fix for code scanning alert no. 15: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,9 @@ name: "CI"
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   server:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/superdesk/superdesk/security/code-scanning/15](https://github.com/superdesk/superdesk/security/code-scanning/15)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function. Since the specific permissions required by the jobs are not detailed, we will start with a minimal configuration of `contents: read`. This can be adjusted later if additional permissions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
