### PR TITLE
Updated start.sh for docker container to modify init

### DIFF
--- a/client/docker/start.sh
+++ b/client/docker/start.sh
@@ -11,6 +11,13 @@ sed -i \
  -e 's/iframely:{key:""}/iframely:{key:"'$IFRAMELY_KEY'"}/g' \
  app*.js
 
+sed -i \
+ -e "s/http:\/\/localhost:5000\/api/$(echo $SUPERDESK_URL | sed 's/\//\\\//g')/g" \
+ -e "s/ws:\/\/localhost:5100/$(echo $SUPERDESK_WS_URL | sed 's/\//\\\//g')/g" \
+ -e "s/ws:\/\/0.0.0.0:5100/$(echo $SUPERDESK_WS_URL | sed 's/\//\\\//g')/g" \
+ -e 's/iframely:{key:""}/iframely:{key:"'$IFRAMELY_KEY'"}/g' \
+ init*.js 
+
 which nginx
 
 exec "$@"


### PR DESCRIPTION
client/docker/start.sh in the develop branch apparently does not include the addition to include init*.js that is in sourcefabricoss/superdesk-client:latest. This creates problems as the client then attempts to load from default URLs when building without this correction.