### PR TITLE
Add local frontend dev tooling with optional AI agent integration

### DIFF
--- a/.claude/commands/superdesk-down.md
+++ b/.claude/commands/superdesk-down.md
@@ -1,0 +1,20 @@
+---
+description: Stop the local Superdesk dev stack. Data is preserved unless --volumes is passed.
+---
+
+If the user passed `--volumes` (or said something equivalent like "wipe
+everything", "clean reset", "fresh start"), confirm with them first
+using `AskUserQuestion`:
+
+> Running with `--volumes` will drop the MongoDB and Elasticsearch
+> volumes — all your local data is gone, and the next setup will re-run
+> the first-time DB init (5–10 min). Continue?
+
+Only proceed if they confirm. For a normal stop (no `--volumes`),
+proceed directly — it's idempotent and non-destructive.
+
+Run `./scripts/dev/down.sh $ARGUMENTS` and relay its output.
+
+**Always relay the Docker Desktop reminder the script prints at the end**
+— designers tend to forget Docker keeps running as a separate process
+after the compose stack stops.

--- a/.claude/commands/superdesk-ext.md
+++ b/.claude/commands/superdesk-ext.md
@@ -1,0 +1,26 @@
+---
+description: Manage in-tree Superdesk extensions. Usage: list | enable NAME | disable NAME.
+---
+
+Run `./scripts/dev/extension.sh $ARGUMENTS` and relay its output.
+
+Common usages:
+- `/superdesk-ext list` — show what's available and what's currently enabled.
+- `/superdesk-ext enable <name>` — turn on an in-tree extension.
+- `/superdesk-ext disable <name>` — turn off an in-tree extension.
+
+If the user invoked this without arguments, default to `list` so they
+can see their options.
+
+Known refusals (the script names them — relay verbatim):
+- `auto-tagging-widget` is on the legacy build path; the script refuses
+  to enable it. Don't argue with the script's refusal.
+- `planning-extension` and `broadcasting` live outside the managed
+  region (they have custom-load logic). The script will refuse to
+  toggle them with an INFO message. If the user really needs to change
+  them, point them at `client/index.ts` and the section above the
+  `// extensions:start` marker.
+
+After a successful enable/disable, tell the user grunt's watch picks up
+the `client/index.ts` change automatically — they should refresh the
+browser after a few seconds to see the result. No restart needed.

--- a/.claude/commands/superdesk-setup.md
+++ b/.claude/commands/superdesk-setup.md
@@ -1,0 +1,40 @@
+---
+description: Set up the local Superdesk dev environment (first-time install + link siblings + first-run DB init).
+---
+
+**Before running anything**, check that both required sibling repos
+exist:
+
+```bash
+ls ../superdesk-client-core/package.json ../superdesk-planning/package.json
+```
+
+If either is missing, STOP and tell the user exactly which one is
+missing, with the exact git clone command to copy-paste from the
+parent directory:
+
+```
+cd ..
+git clone https://github.com/superdesk/superdesk-client-core.git
+git clone https://github.com/superdesk/superdesk-planning.git
+```
+
+Don't run setup.sh until both are present — it will error out after
+some work has already started. (Optional repos: superdesk-analytics,
+superdesk-publisher. Skip unless the user explicitly wants them.)
+
+If both siblings exist, run `./scripts/dev/setup.sh $ARGUMENTS` and
+relay its output to the user.
+
+The script accepts these flags (pass them through verbatim if the user
+specified any): `--only <names>`, `--skip <names>`, `--link <abs-path>`,
+`--reinit`.
+
+If the script reports other known failure modes (Docker not running,
+Volta missing, first-run init failure), refer to
+`.claude/skills/superdesk-dev/SKILL.md` for how to communicate them.
+Do not try to fix the underlying issue yourself.
+
+On success: tell the user the backend is now running and they can start
+the client with `/superdesk-up` (or by asking Claude to "start
+superdesk"). Mention the admin credentials (admin / admin).

--- a/.claude/commands/superdesk-up.md
+++ b/.claude/commands/superdesk-up.md
@@ -1,0 +1,17 @@
+---
+description: Start the local Superdesk dev stack (backend in Docker, client native via grunt watch).
+---
+
+Run `./scripts/dev/up.sh $ARGUMENTS` and relay its output.
+
+The script accepts `--rebuild-server` to force a docker compose rebuild
+of the server image — pass it through if the user mentioned needing a
+rebuild.
+
+If the script tells the user to run `setup.sh` first, route to
+`/superdesk-setup`. Other failure modes (port conflicts, slow first
+build): see `.claude/skills/superdesk-dev/SKILL.md`.
+
+On success: tell the user the app is at `http://localhost:9000`, login
+admin / admin. Mention that grunt watch is active — edits to sibling
+checkouts auto-reload the browser.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": [
+      "Bash(./scripts/dev/setup.sh*)",
+      "Bash(./scripts/dev/up.sh*)",
+      "Bash(./scripts/dev/down.sh*)",
+      "Bash(./scripts/dev/extension.sh*)",
+      "Bash(docker info*)",
+      "Bash(docker compose -f docker-compose.dev.yml ps*)",
+      "Bash(docker compose -f docker-compose.dev.yml logs*)",
+      "Bash(lsof -i :5000*)",
+      "Bash(lsof -i :5001*)",
+      "Bash(lsof -i :9000*)",
+      "Bash(volta --version*)",
+      "Bash(node --version*)",
+      "Bash(curl -sS http://localhost:*)",
+      "Bash(curl -sS http://127.0.0.1:*)",
+      "Bash(curl -s -o /dev/null*http://localhost:*)",
+      "Bash(curl -s -o /dev/null*http://127.0.0.1:*)",
+      "Bash(cat scripts/dev/.run/*)",
+      "Bash(tail scripts/dev/.run/*)"
+    ]
+  }
+}

--- a/.claude/skills/superdesk-dev/SKILL.md
+++ b/.claude/skills/superdesk-dev/SKILL.md
@@ -1,0 +1,336 @@
+---
+name: superdesk-dev
+description: |
+  Run a local Superdesk development environment. Works only inside the
+  `superdesk/` host repo, with sibling repos (superdesk-client-core,
+  superdesk-planning, optionally superdesk-analytics / superdesk-publisher)
+  cloned into the same parent directory. Wraps the dev scripts under
+  `scripts/dev/` (setup, up, down, extension enable/disable) so non-experts
+  don't have to remember Docker / npm / grunt commands.
+
+  Invoke when the user wants to do any of:
+  — "set up the local env", "first-time setup", "I just cloned the repo, get me running"
+  — "start the app", "run superdesk locally", "spin up the dev environment"
+  — "stop the app", "shut down the local environment"
+  — "enable the X extension", "add the helloWorld extension", "turn on usageMetrics"
+  — "disable the X extension", "remove the markForUser extension"
+  — "list extensions", "which extensions are available", "what's enabled"
+
+  Do not invoke for: the fully-containerised workflow (just `docker compose
+  up` against the existing `docker-compose.yml` — no skill needed), running
+  the e2e test suite (that lives in superdesk-client-core), Python/server
+  code changes, production deploys, or work in any repo other than
+  `superdesk/`.
+---
+
+# Running Superdesk locally
+
+You are helping someone bring up a local Superdesk dev environment, or
+toggle in-tree extensions in their running setup. The user may be a UI
+designer (often without strong CLI experience) or a developer iterating
+on the frontend. Communicate concretely: no Docker / npm / Volta jargon
+unless they bring it up first. Explain what's happening at each step, and
+hand control back at clear stopping points.
+
+The skill does not write code, does not commit, does not open PRs. Its
+output is a running stack (or a stopped one) and a short summary.
+
+## Pre-approved commands
+
+The project ships `.claude/settings.json` with an allow-list for the four
+dev scripts (`setup.sh`, `up.sh`, `down.sh`, `extension.sh`) and a small
+set of diagnostic helpers (`docker info`, `docker compose ... ps`,
+`docker compose ... logs`, `lsof -i :5000` / `lsof -i :5001`, `lsof -i :9000`,
+`volta --version`, `node --version`, `curl` for health checks, `cat`/
+`tail` on the grunt log). Those commands run without per-command
+approval — the user gave consent once when first opening the project.
+
+If you find yourself wanting to run something that's not on that list
+(e.g. `npm install` directly, `docker compose down -v` outside the
+script's `--volumes` path, modifying files in `scripts/dev/`), STOP and
+ask the user. The allowlist is deliberately narrow; broadening it is the
+user's decision, not yours.
+
+## Workflow
+
+You arrived here because the user's natural-language phrasing matched
+the skill description. That's the forgiving entry point — but it also
+means there's a non-zero chance the matcher fired on something the user
+didn't actually intend. Confirmation comes before action.
+
+(If the user instead typed an explicit slash command —
+`/superdesk-setup`, `/superdesk-up`, `/superdesk-down`,
+`/superdesk-ext` — they bypassed this skill entirely and the command's
+own prompt is running. Slash commands skip confirmation by design;
+typing the command name *is* the confirmation.)
+
+### 1. Identify the requested mode
+
+The user's message implies one of five modes — pick one:
+
+- **setup** — first-time or after a fresh clone / reset. Runs
+  `scripts/dev/setup.sh`.
+- **up** — start the stack day-to-day (after setup has been done at least
+  once). Runs `scripts/dev/up.sh`.
+- **down** — stop the running stack. Runs `scripts/dev/down.sh`.
+- **extension** — enable / disable / list in-tree extensions. Runs
+  `scripts/dev/extension.sh`.
+- **status** — check what's currently running (no script; use `docker
+  compose ps` against `docker-compose.dev.yml` and `lsof -i :9000`).
+
+If the user's intent is ambiguous (e.g. "get me set up" right after they
+ran setup last week — do they want setup again or just up?), use
+`AskUserQuestion` with concrete options to disambiguate before going on.
+
+### 2. Confirm intent before running anything
+
+Before invoking any script, confirm with the user using
+`AskUserQuestion` — even when the matched mode seems obvious. The cost
+of one extra round-trip is small; the cost of running setup (slow), down
+(stops things), or extension changes (modifies code) when the user
+didn't intend it is much higher.
+
+Format the confirmation concretely. State the action and the exact
+command you're about to run, e.g.:
+
+> "I think you want to set up the local dev environment. That means
+> running `./scripts/dev/setup.sh` — `npm install`, link sibling repos,
+> bring up Docker, init the database on first run. It takes a few
+> minutes on first run. Continue?"
+
+For **status** mode this confirmation step is unnecessary — it's read-
+only. For everything else, confirm first.
+
+If the user is doing something especially impactful — `down --volumes`,
+`setup --reinit` against an existing DB, disabling an extension — spell
+out the impact in plain language. Don't bury it in flag names.
+
+If the user wants the explicit-command path going forward (less back-
+and-forth), mention that the slash commands exist:
+`/superdesk-setup`, `/superdesk-up`, `/superdesk-down`, `/superdesk-ext`.
+They skip this confirmation step.
+
+### 3. Verify the preconditions
+
+Before running, three checks:
+
+**3a. You're inside the `superdesk/` host repo.**
+
+- `docker-compose.dev.yml` exists at the repo root, and
+- `client/package.json`'s `name` field is `"superdesk"`.
+
+If not, stop and tell the user: "This skill only works inside the
+`superdesk/` host repo. The other repos (client-core, planning, analytics,
+publisher) are siblings of it, not where this runs."
+
+**3b. For setup mode only: required siblings exist.**
+
+The dev workflow REQUIRES two sibling repos cloned as siblings of
+this one: `superdesk-client-core` and `superdesk-planning`. Two more
+are optional: `superdesk-analytics` and `superdesk-publisher`.
+
+Before running setup, check:
+
+```bash
+ls ../superdesk-client-core/package.json ../superdesk-planning/package.json
+```
+
+If either is missing, STOP — do not run setup.sh, it will error out
+after some work has already started. Instead, tell the user exactly
+which sibling is missing and give them the exact git clone command
+to copy-paste, e.g.:
+
+> I can't set up the dev environment yet — the required sibling repos
+> aren't cloned. From the parent directory of this repo, run:
+>
+> ```
+> cd <parent>
+> git clone https://github.com/superdesk/superdesk-client-core.git
+> git clone https://github.com/superdesk/superdesk-planning.git
+> ```
+>
+> Then run /superdesk-setup again. (Optional repos:
+> superdesk-analytics, superdesk-publisher — skip those unless you
+> know you need them.)
+
+Use `AskUserQuestion` to ask the user whether they want you to wait
+for them to clone, or whether they want to abort.
+
+**3c. For up / down / extension modes:** the sibling check is not
+required at the skill level — `up.sh` / `down.sh` are independent of
+sibling state, and `extension.sh enable` will check that
+`superdesk-client-core` exists itself.
+
+### 4. Run the script for the chosen mode
+
+#### setup mode
+
+Run `./scripts/dev/setup.sh` (or with `--only` / `--skip` / `--link` /
+`--reinit` if the user specified preferences — translate their phrasing).
+
+Watch for these patterns in the output:
+
+- **"Docker is installed but not running"** — tell the user to start Docker
+  Desktop and re-run. Don't try to start it yourself.
+- **"Volta is not installed"** — point them at https://volta.sh. The Node
+  version is pinned through it; the dev stack will not work without it.
+- **"Need at least superdesk-client-core linked"** — they haven't cloned
+  client-core as a sibling. Tell them where it should go
+  (`<parent>/superdesk-client-core/`) and stop.
+
+On success, the script leaves the backend running and prints next steps
+(run `up.sh`). Relay those to the user.
+
+#### up mode
+
+Run `./scripts/dev/up.sh`. Watch for:
+
+- **"Run ./scripts/dev/setup.sh first"** — they haven't done setup. Route
+  to setup mode.
+- **"Something is already listening on port 5000/5001/9000"** — port conflict;
+  the script names the holder. Tell the user; do not kill processes
+  yourself.
+- **Long wait on the client URL** — grunt's cold build is ~60–120s. Tell
+  the user this is normal; if it exceeds 5 minutes, point them at the log
+  file the script printed.
+
+On success, hand off with the URL (`http://localhost:9000`, login admin /
+admin) and a note that grunt's watch is active — they can edit sibling
+checkouts and reload the browser to see changes.
+
+#### down mode
+
+Run `./scripts/dev/down.sh`. The only thing to relay is the Docker Desktop
+reminder the script prints at the end — designers tend to forget Docker
+keeps running as a separate process after the compose stack stops.
+
+If the user asked for a full reset ("wipe everything", "fresh start"), run
+`./scripts/dev/down.sh --volumes`. Warn them first that this drops all DB
+state.
+
+#### extension mode
+
+For "what's available": `./scripts/dev/extension.sh list`.
+
+For enable / disable: `./scripts/dev/extension.sh <enable|disable> <name>`.
+
+Watch for:
+
+- **"is on the legacy compile-and-correct build path"** — auto-tagging-
+  widget. The script refuses; relay the reason as-is.
+- **"is not an in-tree extension"** — typo or unknown name. Show the list
+  output so the user picks a real name.
+- **"is not in the managed region"** — they're trying to disable
+  planning-extension or broadcasting, which live outside the script's
+  region. Tell them this and offer to walk them through manual editing if
+  they really need to.
+
+Grunt watch picks up the `client/index.ts` change automatically; no
+restart needed. Tell the user to refresh the browser after a few seconds.
+
+## Failure modes
+
+The script-level errors above cover most cases. Beyond those:
+
+### The user has multiple Superdesk stacks running
+
+E2E and dev both publish a Superdesk backend on the same default host
+port (5000 on Linux, 5001 on macOS). If the user has the e2e stack from
+`superdesk-client-core/e2e/scripts/e2e-up.sh` running, the dev stack will
+fail to bind. The dev script's preflight names the conflict; tell the user
+to stop the other stack first.
+
+### npm install fails during setup
+
+Usually one of: the wrong Node version (Volta not active in this shell),
+corrupted `node_modules` from a previous half-done install, or a network
+hiccup. Don't try fancy recovery — tell the user to:
+
+1. Confirm Volta is active (`node --version` should show 22.x).
+2. Delete `client/node_modules` and re-run setup.
+
+If that fails, escalate to a developer; this skill doesn't debug npm.
+
+### dev-link fails: "Missing script: devlink" or "unknown command"
+
+setup.sh runs `npm run devlink -- <siblings>`, which delegates to
+`@superdesk/build-tools dev-link`. Two distinct failure shapes:
+
+- **"Missing script: devlink"** — the host repo's `client/package.json`
+  does not have a `devlink` script registered. The script was added
+  as part of the dev-tooling PR; if the user's host checkout pre-dates
+  that PR, they need to `git pull` (or merge develop). This is the
+  expected failure shape on stale checkouts, not a tooling bug.
+- **"unknown command: dev-link"** from `@superdesk/build-tools` itself —
+  the installed build-tools is older than 1.1.0 (where the command was
+  added by superdesk-client-core PR #5180). The host's pinned range
+  `^1.0.19` permits anything up to 2.0, so a clean reinstall normally
+  fixes it:
+
+  ```
+  rm -rf client/node_modules client/package-lock.json
+  ./scripts/dev/setup.sh
+  ```
+
+  If after a clean reinstall the command still isn't found, the host's
+  build-tools dep range needs bumping — that's a developer task, not
+  something this skill should attempt.
+
+### "data-test-id"-style extension that needs more than a config change
+
+If the user asks to enable an extension that isn't in `client-core/scripts/
+extensions/` at all — for example, an extension that lives in
+`superdesk-planning/client/<x>-extension` or in a sibling repo entirely —
+that's outside scope. Tell them: "This skill only handles in-tree
+extensions from superdesk-client-core. For external extensions, edit
+`client/index.ts` manually or ask a developer."
+
+### First-run init fails
+
+If `python manage.py app:initialize_data` errors, it usually means MongoDB
+or Elasticsearch didn't fully start before init ran. Wait 30s and run
+setup with `--reinit`. If it still fails, dump `docker compose -f
+docker-compose.dev.yml logs superdesk-server` for the user and stop.
+
+## What to communicate at hand-off
+
+A short, plain-language status:
+
+- What's running (server + client URLs).
+- What credentials to use (admin / admin).
+- If applicable, what extensions are now enabled.
+- How to stop everything (`./scripts/dev/down.sh`) and what Docker Desktop
+  will be doing afterwards.
+
+No need to summarise the script output verbatim; the user saw it. Focus on
+"here's where you can click now."
+
+## Pitfalls — avoid without being told
+
+- **Do not edit `client/index.ts` directly.** Always go through
+  `scripts/dev/extension.sh`. Hand-edits inside the markers will be undone
+  by the next script invocation; hand-edits outside the markers are fine
+  but the user shouldn't need to make any.
+- **Do not run `docker compose down -v` casually.** It drops the named
+  volumes and forces a re-run of the first-time DB init (5–10 minutes).
+  Use `down.sh` (without `--volumes`) for normal stops.
+- **Do not start Docker Desktop on the user's behalf.** Some users have
+  Docker permissioned in ways that make automated startup fail silently.
+  Always ask them to start it.
+- **Do not skip Volta.** "I'll just use my system Node" produces hard-to-
+  diagnose errors in grunt builds.
+- **Do not modify the existing `docker-compose.yml`.** It's the fully-
+  containerised path that other users rely on. The dev stack lives in
+  `docker-compose.dev.yml`, always.
+
+## When to ask the user vs proceed
+
+- Ambiguous mode (setup vs up vs status) → ask once with
+  `AskUserQuestion`.
+- Unknown extension name → don't guess; show the list and let the user
+  pick.
+- Conflicting port that looks like another Superdesk stack → tell the user
+  and stop; don't try to identify which other stack it is.
+- Setup wants to do first-run DB init → just do it; that's why it's there.
+- A real bug in the underlying scripts (script crash, unexpected output)
+  → relay the error verbatim and stop. Don't paper over it.

--- a/DEVSETUP.md
+++ b/DEVSETUP.md
@@ -282,10 +282,17 @@ rm -rf client/node_modules client/package-lock.json
 If that doesn't pull a newer build-tools, the host's pinned range
 needs bumping — escalate to a developer.
 
-**Step 5 returns 200 instead of 401/403.** Something else (often macOS
-AirPlay Receiver on :5000, or a leftover container) is on the port. Run
-`lsof -i :<port> -sTCP:LISTEN` (where `<port>` is the one the setup
-script printed) to identify, then stop the holder.
+**Step 5 returns nothing / a timeout / a 5xx.** No real HTTP service is
+answering on that port yet (server still starting, or it crashed). Wait
+60s; if still no response, check
+`docker compose -f docker-compose.dev.yml logs superdesk-server` for
+the actual error.
+
+**Step 5 returns 200, but the browser sees a non-Superdesk page.** Rare,
+but possible if you've overridden `SUPERDESK_PORT` to a port held by
+another HTTP service (e.g. setting `SUPERDESK_PORT=5000` on macOS where
+AirPlay Receiver answers). Use `lsof -i :<port> -sTCP:LISTEN` to
+identify the holder, then either stop it or pick a different port.
 
 **Step 6 hangs longer than 5 minutes.** The grunt cold build is slow but
 should not exceed 3 minutes on a recent machine. Check

--- a/DEVSETUP.md
+++ b/DEVSETUP.md
@@ -1,69 +1,314 @@
-## How to run a fully containerize superdesk development environment
+# Local development setup
 
-Go to your local code folder (here I'm using `~/code`), and clone your fork of superdesk and superdesk-client-core:
+This document covers the two supported local development workflows. For
+the bare-minimum quick-start (single `docker compose up`), see
+[README.md](./README.md) — that's the "I want to see Superdesk running"
+path and doesn't require cloning any other repos.
 
-```shell
-cd ~/code
-git clone git@github.com:lnogues/superdesk.git
-git clone git@github.com:lnogues/superdesk-client-core.git
-git clone git@github.com:lnogues/superdesk-content-api.git
+This document is for development work, where you need your edits to a
+sibling checkout (e.g. `superdesk-client-core`) to take effect.
+
+## Prerequisites
+
+Install / set up these before running anything:
+
+- **Docker Desktop installed and running.** All backend services run in
+  containers.
+- **[Volta](https://volta.sh) installed.** Node version is pinned via
+  Volta from `client/package.json`; this skips the "which Node?" question
+  entirely.
+- **Sibling repos cloned in the same parent directory as this one.**
+  `superdesk-client-core` and `superdesk-planning` are **required**;
+  `superdesk-analytics` and `superdesk-publisher` are optional.
+
+  ```
+  ~/code/
+    superdesk/                  <-- this repo
+    superdesk-client-core/      (required)
+    superdesk-planning/         (required)
+    superdesk-analytics/        (optional)
+    superdesk-publisher/        (optional)
+  ```
+
+  The dev tooling discovers siblings by name in the parent dir.
+
+## First-run validation checklist
+
+Once the prerequisites above are in place, walk through these steps in
+order to confirm everything works end to end. Each step has a single
+clear success signal; if one fails, stop and fix it before moving on.
+
+1. **Docker is running.** `docker info` exits 0 and prints daemon details.
+   If it errors, start Docker Desktop and wait for the whale icon to stop
+   animating.
+
+2. **Volta is installed.** `volta --version` prints a version. If not,
+   install from [volta.sh](https://volta.sh) — Node version is pinned
+   through it, and `npm run start` will use the wrong Node without it.
+
+3. **Sibling layout is right.** From this repo's root,
+   `ls ../superdesk-client-core/package.json ../superdesk-planning/package.json`
+   both exist. (Optional siblings:
+   `superdesk-analytics`, `superdesk-publisher`.)
+
+4. **Setup runs clean.** `./scripts/dev/setup.sh` completes with the
+   "setup complete" banner. The script prints the exact server URL it
+   chose — default `http://localhost:5000/api/` on Linux, or
+   `http://localhost:5001/api/` on macOS (auto-picked to avoid AirPlay
+   Receiver which holds :5000). To override either default:
+   `SUPERDESK_PORT=5070 ./scripts/dev/setup.sh`. First run is slow
+   (cold-cache `npm install`, image pulls, DB init). Re-runs are fast.
+
+5. **Server responds correctly.** `curl -s -o /dev/null -w '%{http_code}'`
+   against the URL setup printed should return `200`, `401`, or `403`
+   — any of those means a real Superdesk server is answering. Anything
+   else (timeout, 5xx) means it hasn't come up yet.
+
+6. **Client comes up.** `./scripts/dev/up.sh` waits, then prints
+   `client: http://localhost:9000/`. Open it in a browser. The Superdesk
+   login screen renders.
+
+7. **Login works.** Sign in with `admin` / `admin`. You land on the
+   monitoring view.
+
+8. **Watch picks up sibling edits.** In `../superdesk-client-core`, make a
+   trivial visible change (e.g. edit a label in
+   `scripts/apps/dashboard/...`). Wait ~5–10s; the browser auto-reloads
+   and your change is visible. This is the whole point of the workflow.
+
+9. **Extension toggle works.** `./scripts/dev/extension.sh enable
+   helloWorld` succeeds. The browser reloads after a few seconds and the
+   helloWorld extension's UI shows up. Disable it with
+   `./scripts/dev/extension.sh disable helloWorld` to leave the repo in
+   the state you found it.
+
+10. **Down is clean.** `./scripts/dev/down.sh` stops both grunt and the
+    compose stack, and prints the Docker Desktop reminder. Quit Docker
+    Desktop from the menu bar.
+
+If you got through all ten, your dev environment is real. If something
+broke at step N, the [Troubleshooting](#troubleshooting) section at the
+bottom covers the most common causes.
+
+## Choosing a workflow
+
+| Workflow | Best for | Iteration speed | Setup complexity |
+|---|---|---|---|
+| **A. Fully containerised** | Showing the app to someone, occasional changes | Slow (container rebuild on every edit) | Low |
+| **B. Server in Docker, client native** | Daily frontend / extension work | Fast (grunt watch picks up edits instantly) | Medium (one-time setup) |
+
+If you're a UI designer or you'll be editing the client / extensions
+frequently, use workflow B. Otherwise A is simpler.
+
+---
+
+## Workflow A — fully containerised
+
+The existing `docker-compose.yml` runs everything (server + client + DBs)
+in containers. The client image is rebuilt on each `up`.
+
+```sh
+docker compose up -d
 ```
 
-Create symlinkis between superdesk-client-core and superdesk-content-api to superdesk
+App available at `http://localhost:8080`. First-run admin / data init per
+the README. Stop with `docker compose stop`.
 
-```shell
-ln -s ~/code/superdesk-client-core ~/code/superdesk/superdesk-client-core
-ln -s ~/code/superdesk-content-api ~/code/superdesk/superdesk-content-api
+This workflow does **not** pick up edits to sibling checkouts. If you need
+that, use workflow B.
+
+---
+
+## Workflow B — server in Docker, client native
+
+Backend services (server + MongoDB + Redis + Elasticsearch) run via
+`docker-compose.dev.yml`. The client runs natively on your host through
+`npm run start` (grunt with file watch), and your sibling checkouts of
+`superdesk-client-core` / `superdesk-planning` are symlinked into
+`node_modules` via `npm run devlink` so edits take effect immediately.
+
+Three scripts under `scripts/dev/` cover the lifecycle:
+
+```sh
+./scripts/dev/setup.sh   # first-time install + link siblings + init DB
+./scripts/dev/up.sh      # start the stack (daily)
+./scripts/dev/down.sh    # stop the stack (data preserved)
 ```
 
-Then run the docker-compose script
+A fourth script toggles in-tree extensions in / out of the running stack:
 
-```shell
-cd ~/code/superdesk
-docker-compose -f docker/docker-compose-dev.yml up
+```sh
+./scripts/dev/extension.sh list                  # see what's available / enabled
+./scripts/dev/extension.sh enable <name>         # add an in-tree extension
+./scripts/dev/extension.sh disable <name>        # remove one
 ```
 
-Once everything is up and running, quit docker (with Ctrl+C) and run:
+After setup, the app is available at `http://localhost:9000`. Login with
+admin / admin. The server API defaults to `http://localhost:5000/api/`
+on Linux, or `http://localhost:5001/api/` on macOS (where :5000 is
+reserved for AirPlay Receiver — auto-detected). Override with
+`SUPERDESK_PORT=<port>` before invoking the scripts.
 
-```shell
-cd ~/code/superdesk/docker
-docker-compose run superdesk ./scripts/fig_wrapper.sh python3 manage.py users:create -u admin -p admin -e 'admin@example.com' --admin
+### Setup details
+
+`setup.sh` does, in order:
+
+1. Validates Docker is running and Volta is installed.
+2. Auto-discovers sibling repos under the parent directory.
+3. Runs `npm install` in `./client`.
+4. Runs `npm run devlink` against the discovered siblings (replaces
+   the GitHub-pulled copies in `node_modules` with symlinks). The
+   [`dev-link` command](https://github.com/superdesk/superdesk-client-core/pull/5180)
+   in `@superdesk/build-tools` handles this idempotently.
+5. Starts `docker-compose.dev.yml` and waits for the server to be ready.
+6. On first run, executes `python manage.py app:initialize_data` and
+   creates the admin / admin user. A sentinel at
+   `scripts/dev/.run/.setup-done` records that this is done so subsequent
+   runs skip it.
+
+Flags:
+
+- `--only NAME[,NAME]` — link only the specified siblings.
+- `--skip NAME[,NAME]` — link all discovered siblings except these.
+- `--link /abs/path` — link an explicit path (e.g. a fork outside the
+  parent dir). Repeatable.
+- `--reinit` — force re-run of the first-run DB init.
+
+### Extensions
+
+In-tree extensions live under `superdesk-client-core/scripts/extensions/`.
+[PR #5177](https://github.com/superdesk/superdesk-client-core/pull/5177)
+migrated 11 of them to a source-build path that works with symlinked
+local development. One (`auto-tagging-widget`) is still on the legacy
+compile path and is not yet safe to enable in a dev-link setup —
+`extension.sh` refuses with a clear message.
+
+The script edits a marked region in `client/index.ts`:
+
+```ts
+// extensions:start (managed by scripts/dev/extension.sh — do not edit by hand)
+{
+    id: 'NAME',
+    load: () => import('superdesk-core/scripts/extensions/NAME'),
+},
+// ...
+// extensions:end
 ```
 
-Now, you can re run your docker compose and your local server is up and running
+Entries outside that region (`planning-extension`, `broadcasting`,
+anything with custom `load` logic) are manually managed; the script does
+not touch them.
 
-```shell
-cd ~/code/superdesk
-docker-compose -f docker/docker-compose-dev.yml up
+### Stopping
+
+`down.sh` runs `docker compose stop` — the named volumes for MongoDB and
+Elasticsearch are preserved, so your test data survives restarts.
+
+If you want a clean wipe: `./scripts/dev/down.sh --volumes`. This drops
+the volumes and resets the setup sentinel; the next `setup.sh` will
+re-run the first-time DB init.
+
+**Important:** stopping the compose stack does NOT stop Docker Desktop
+itself. Docker keeps running in the background until you quit it
+manually from the menu bar (Cmd-Q on the Docker icon). The script
+reminds you of this on each stop.
+
+### Using Claude Code
+
+The scripts have two Claude Code wrappers, both shipped in this repo.
+
+**Slash commands** (explicit, fast — no confirmation roundtrip):
+
+- `/superdesk-setup` → `scripts/dev/setup.sh` (supports `--only`, `--skip`, `--link`, `--reinit`)
+- `/superdesk-up` → `scripts/dev/up.sh` (supports `--rebuild-server`)
+- `/superdesk-down` → `scripts/dev/down.sh` (supports `--volumes`)
+- `/superdesk-ext list | enable NAME | disable NAME` → `scripts/dev/extension.sh`
+
+Slash commands run the underlying script directly. The only confirmation
+prompt is `/superdesk-down --volumes`, which is destructive (drops DB
+state).
+
+**Natural-language skill** (forgiving, catches phrasings):
+
+The [`superdesk-dev` skill](./.claude/skills/superdesk-dev/SKILL.md)
+catches phrasings like "set up the dev environment", "start Superdesk",
+"enable helloWorld", etc. It confirms intent with you before running
+anything — useful as a safety net when the matcher might fire on
+something you didn't intend.
+
+Pick whichever fits how you work. Both invoke the same scripts and the
+underlying behaviour is identical. The scripts also work standalone
+without Claude.
+
+---
+
+## End-to-end tests
+
+The Playwright e2e suite lives in `superdesk-client-core` and has its own
+stack (`e2e/scripts/e2e-up.sh` in that repo). The dev compose here and
+the e2e compose there both publish a Superdesk backend on a host port
+(by default :5000, or :5001 on macOS), so they cannot run at the same
+time without explicit `SUPERDESK_PORT` overrides — stop one before
+bringing up the other.
+
+## Troubleshooting
+
+Quick lookup for the most common failures, cross-referenced with the
+[first-run checklist](#first-run-validation-checklist).
+
+**"Docker is installed but not running" (step 1).** Open Docker Desktop
+and wait for the whale icon to stop animating. On Apple Silicon, the first
+launch after a reboot can take 30–60s.
+
+**`npm run devlink` fails with "Missing script: devlink" (step 4).**
+The host repo's `client/package.json` doesn't have the `devlink`
+script registered yet — your checkout pre-dates the dev-tooling
+addition. Pull the latest `develop` and try again.
+
+**`npm run devlink` fails with "no such file or directory" (step 4).**
+A sibling repo path doesn't exist or is misspelled. Re-check the
+parent directory layout — siblings live next to this repo, not inside
+it.
+
+**`devlink` fails with "unknown command" or similar (step 4).** The
+installed `@superdesk/build-tools` is older than 1.1.0 (where the
+`dev-link` command was added). Clean reinstall:
+
+```sh
+rm -rf client/node_modules client/package-lock.json
+./scripts/dev/setup.sh
 ```
 
-## Run e2e server from docker
+If that doesn't pull a newer build-tools, the host's pinned range
+needs bumping — escalate to a developer.
 
-For this setup, only the end to end server will run in docker.
-The client part will run on your local machine.
+**Step 5 returns 200 instead of 401/403.** Something else (often macOS
+AirPlay Receiver on :5000, or a leftover container) is on the port. Run
+`lsof -i :<port> -sTCP:LISTEN` (where `<port>` is the one the setup
+script printed) to identify, then stop the holder.
 
-Assuming you already have a superdesk development environment set up:
+**Step 6 hangs longer than 5 minutes.** The grunt cold build is slow but
+should not exceed 3 minutes on a recent machine. Check
+`scripts/dev/.run/grunt-server.log` for the actual error.
 
-```shell
-cd ~/code/superdesk
-docker-compose -f docker/docker-compose-e2e.yml up
-```
+**Step 7 fails with "invalid credentials".** First-run init didn't run, or
+ran against a different DB. Run `./scripts/dev/setup.sh --reinit` to
+force re-init. If you nuked the volumes with `down.sh --volumes` since
+setup, `--reinit` is required anyway.
 
-Then the client specific setup:
+**Step 8 doesn't reload after edits.** Grunt's watch is running but the
+file isn't in a watched path. Confirm the edit is inside a sibling
+checkout that was actually dev-linked (run `./scripts/dev/setup.sh` with
+no flags to see the link summary). Symlinks: if your shell follows them
+strangely, the issue may be that grunt is watching the original path,
+not the symlinked one.
 
-```shell
-cd ~/code/superdesk-client-core
-npm install
-./node_modules/.bin/webdriver-manager update
-```
+**Step 9 reports "is on the legacy compile-and-correct build path".** You
+tried to enable `auto-tagging-widget`. That extension isn't yet on the
+source-build path (PR #5177); enabling it will break the build. Leave it
+alone until the underlying migration lands.
 
-On the dependencies have been installed and `docker-compose-e2e.yml` is running, you can run the tests:
-
-```shell
-./node_modules/.bin/protractor protractor.conf.js \
-  --stackTrace --verbose \
-  --baseUrl 'http://localhost:9000' \
-  --params.baseBackendUrl 'http://localhost:5000/api' \
-  --params.username 'admin' \
-  --params.password 'admin'
-```
+**Anything else.** Capture the error verbatim and ask in
+#superdesk-frontend, or open a developer ticket. Don't guess at fixes —
+the underlying tooling (`@superdesk/build-tools`, grunt, Volta) is doing
+real work and band-aid fixes pile up.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,67 @@ Then you can login with admin:admin credentials.
 
 The Docker images are hosted on Dockerhub for the [client](https://hub.docker.com/r/sourcefabricoss/superdesk-client) and [server](https://hub.docker.com/r/sourcefabricoss/superdesk-server).
 
+## Local development (frontend / extension work)
+
+For editing the client or extensions and seeing changes immediately, use
+the server-in-Docker / client-native workflow described in
+[DEVSETUP.md](./DEVSETUP.md).
+
+### Prerequisites
+
+- **Docker Desktop** installed and running.
+- **[Volta](https://volta.sh)** installed (Node version is pinned through it).
+- **Sibling repos cloned in the same parent directory as this one**:
+  `superdesk-client-core` and `superdesk-planning` are required;
+  `superdesk-analytics` and `superdesk-publisher` are optional.
+
+See [DEVSETUP.md#prerequisites](./DEVSETUP.md#prerequisites) for the full
+layout diagram and rationale.
+
+### Running it
+
+Once the prerequisites are in place:
+
+1. Run the setup script.
+2. Open `http://localhost:9000` and log in with `admin` / `admin`.
+
+There are two ways to drive step 1.
+
+### Option 1 — let Claude Code do it (recommended for new contributors)
+
+If you have Claude Code installed, the project ships four slash commands
+that wrap the dev scripts. Open Claude inside this repo and type:
+
+- `/superdesk-setup` — first-time install + link siblings + init DB
+- `/superdesk-up` — start the stack day-to-day
+- `/superdesk-down` — stop the stack (data preserved)
+- `/superdesk-ext list | enable NAME | disable NAME` — toggle in-tree extensions
+
+These are explicit and fast — typing one runs the corresponding script
+directly. Use them once you know what you want.
+
+If you don't remember the command name, the
+[`superdesk-dev` skill](./.claude/skills/superdesk-dev/SKILL.md) catches
+plain-language phrasings ("set up the dev environment", "start
+Superdesk", "enable helloWorld"…). It confirms intent with you before
+running anything, so the worst case of a misfire is one extra question,
+not an unwanted setup.
+
+The project ships a `.claude/settings.json` that pre-approves the dev
+scripts, so you won't be asked to approve each Bash command one by one.
+
+### Option 2 — run the scripts directly
+
+```sh
+./scripts/dev/setup.sh    # first time
+./scripts/dev/up.sh       # daily
+./scripts/dev/down.sh     # stop
+```
+
+See [DEVSETUP.md](./DEVSETUP.md) for the first-run validation checklist,
+flags (`--only`, `--skip`, `--link`, `--reinit`), extension toggling, and
+troubleshooting.
+
 ## Manual installation
 
 ### Requirements
@@ -47,7 +108,7 @@ These services must be installed, configured and running:
 - MongoDB
 - ElasticSearch (7+)
 - Redis
-- Python (3.8)
+- Python (3.10)
 - Node.js (with `npm`)
 
 On macOS, if you have [homebrew](https://brew.sh/) installed, simply run: `brew install mongodb elasticsearch redis python3 node`.
@@ -85,20 +146,6 @@ using the `pyvenv` command:
 - Run `. ~/pyvenv/bin/activate` to start the virtual environment in the current terminal session.
 
 Now you may run the installation steps from above.
-
-### Local development with linked packages
-
-To link a local copy of `superdesk-client-core` or `superdesk-planning` into this client, use [`npx link`](https://github.com/privatenumber/link):
-
-```sh
-cd client
-npx link /path/to/superdesk-client-core
-npx link /path/to/superdesk-planning
-```
-
-Do not use `npm link` — it has a [known regression in npm 7+](https://hirok.io/posts/avoid-npm-link) that removes packages from `node_modules` and breaks the build.
-
-A fresh `npm install` will restore the published versions.
 
 ### Questions and issues
 

--- a/client/index.ts
+++ b/client/index.ts
@@ -3,18 +3,10 @@ import {startApp} from 'superdesk-core/scripts/index';
 setTimeout(() => {
     startApp(
         [
-            {
-                id: 'annotationsLibrary',
-                load: () => import('superdesk-core/scripts/extensions/annotationsLibrary'),
-            },
-            {
-                id: 'markForUser',
-                load: () => import('superdesk-core/scripts/extensions/markForUser'),
-            },
-            {
-                id: 'datetimeField',
-                load: () => import('superdesk-core/scripts/extensions/datetimeField'),
-            },
+            // Always-on / manually-managed extensions. Entries with custom load
+            // logic (.then, setCustomizations) live here so scripts/dev/extension.sh
+            // can manipulate the standard-template region below without worrying
+            // about them.
             {
                 id: 'planning-extension',
                 load: () => import('superdesk-planning/client/planning-extension'),
@@ -29,10 +21,25 @@ setTimeout(() => {
                     return broadcasting;
                 }),
             },
+
+            // extensions:start (managed by scripts/dev/extension.sh — do not edit by hand)
+            {
+                id: 'annotationsLibrary',
+                load: () => import('superdesk-core/scripts/extensions/annotationsLibrary'),
+            },
+            {
+                id: 'markForUser',
+                load: () => import('superdesk-core/scripts/extensions/markForUser'),
+            },
+            {
+                id: 'datetimeField',
+                load: () => import('superdesk-core/scripts/extensions/datetimeField'),
+            },
             {
                 id: 'availability-manager',
                 load: () => import('superdesk-core/scripts/extensions/availability-manager'),
             },
+            // extensions:end
         ],
         {},
     );

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -14,7 +14,7 @@
                 "superdesk-publisher": "github:superdesk/superdesk-publisher#develop"
             },
             "devDependencies": {
-                "@superdesk/build-tools": "^1.0.19"
+                "@superdesk/build-tools": "^1.2.0"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -1452,9 +1452,9 @@
             }
         },
         "node_modules/@superdesk/build-tools": {
-            "version": "1.0.19",
-            "resolved": "https://registry.npmjs.org/@superdesk/build-tools/-/build-tools-1.0.19.tgz",
-            "integrity": "sha512-ctL0/dZCqWcoxvcCMFLza4aLXP+wfszwkz/HMv25+fEiAJ6oTc33VpmnNcHfEClXoMupig6l1UcMFt98ZqVjOQ==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@superdesk/build-tools/-/build-tools-1.2.0.tgz",
+            "integrity": "sha512-lq27w30VFcs7wedLSJ/W7aiHcObwL9ZjCLECefh+LGhl/XnsEI0ZZ4b9hzuaX07DTFzyj+4L5FLbZ85uIpjI7A==",
             "dev": true,
             "dependencies": {
                 "commander": "^7.2.0",
@@ -1463,19 +1463,11 @@
                 "gettext-extractor": "3.5.3",
                 "gettext.js": "0.9.0",
                 "glob": "7.1.7",
-                "lodash": "4.17.19",
                 "rimraf": "3.0.2"
             },
             "bin": {
                 "build-tools": "src/index.js"
             }
-        },
-        "node_modules/@superdesk/build-tools/node_modules/lodash": {
-            "version": "4.17.19",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-            "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/@superdesk/common": {
             "version": "0.0.28",

--- a/client/package.json
+++ b/client/package.json
@@ -13,7 +13,7 @@
         "start": "npx grunt server"
     },
     "devDependencies": {
-        "@superdesk/build-tools": "^1.0.19"
+        "@superdesk/build-tools": "^1.2.0"
     },
     "volta": {
         "node": "22.22.0"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,100 @@
+# Local development stack: backend services only.
+#
+# This file is for the "server in Docker, client native" workflow: the
+# Python server, MongoDB, Redis, and Elasticsearch run in containers, while
+# the client (`npm run start` in ./client) runs natively on the host. That
+# split gives the fastest frontend iteration — grunt's watch picks up edits
+# in your sibling checkouts of superdesk-client-core / superdesk-planning
+# without any container restart.
+#
+# Usage is wrapped by scripts/dev/up.sh and down.sh, which add health
+# checks and a Docker-Desktop-still-running reminder. Direct usage:
+#
+#   docker compose -f docker-compose.dev.yml up -d   # start
+#   docker compose -f docker-compose.dev.yml stop    # stop (keeps data)
+#   docker compose -f docker-compose.dev.yml down -v # nuclear: drops data
+#
+# Notes:
+#   * Server host port is controlled by SUPERDESK_PORT. Default 5000
+#     (matches upstream Superdesk). On macOS, scripts/dev/setup.sh and
+#     up.sh auto-override to 5001 because :5000 is reserved for AirPlay
+#     Receiver, which silently answers HTTP and would mask a missing
+#     server. To override explicitly: `SUPERDESK_PORT=5070 ./scripts/dev/up.sh`.
+#   * MongoDB / Redis / Elasticsearch are NOT published to the host —
+#     they live on the bridge network and only the server talks to them.
+#     This keeps the host port footprint minimal and avoids conflicts with
+#     other stacks (e.g. superdesk-client-core's e2e compose, which uses
+#     host networking on those same ports).
+#   * Data is persisted in named volumes; `down` (without -v) preserves it.
+
+name: superdesk-dev
+
+services:
+
+  mongodb:
+    image: mongo:6
+    networks:
+      - superdesk-dev
+    volumes:
+      - superdesk-dev-mongo-data:/data/db
+    restart: unless-stopped
+
+  redis:
+    image: redis:8
+    networks:
+      - superdesk-dev
+    restart: unless-stopped
+
+  elastic:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.29
+    environment:
+      - discovery.type=single-node
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    networks:
+      - superdesk-dev
+    volumes:
+      - superdesk-dev-elastic-data:/usr/share/elasticsearch/data
+    restart: unless-stopped
+
+  superdesk-server:
+    image: sourcefabricoss/superdesk-server:latest
+    build: ./server
+    depends_on:
+      - redis
+      - mongodb
+      - elastic
+    ports:
+      - "${SUPERDESK_PORT:-5000}:5000"
+    environment:
+      # Browser-facing URLs (these are what the client running natively on
+      # the host will hit, so they use host-mapped ports).
+      - SUPERDESK_URL=http://localhost:${SUPERDESK_PORT:-5000}/api
+      - SUPERDESK_CLIENT_URL=http://localhost:9000
+      - CONTENTAPI_URL=http://localhost:${SUPERDESK_PORT:-5000}/capi
+      # Demo content seeded on first init — useful for designers who want
+      # something to navigate. Set DEMO_DATA=0 for a clean install.
+      - DEMO_DATA=1
+      - WEB_CONCURRENCY=2
+      # Backend service URIs use the bridge network's service names.
+      - MONGO_URI=mongodb://mongodb/superdesk
+      - CONTENTAPI_MONGO_URI=mongodb://mongodb/superdesk_capi
+      - PUBLICAPI_MONGO_URI=mongodb://mongodb/superdesk_papi
+      - LEGAL_ARCHIVE_URI=mongodb://mongodb/superdesk_legal
+      - ARCHIVED_URI=mongodb://mongodb/superdesk_archive
+      - ELASTICSEARCH_URL=http://elastic:9200
+      - ELASTICSEARCH_INDEX=superdesk
+      - CELERY_BROKER_URL=redis://redis:6379/1
+      - REDIS_URL=redis://redis:6379/1
+      - DEFAULT_TIMEZONE=Europe/Prague
+      - SECRET_KEY=dev-only-not-for-production-*k^&9)byk=8en9n1sg7
+    networks:
+      - superdesk-dev
+    restart: unless-stopped
+
+networks:
+  superdesk-dev:
+    driver: bridge
+
+volumes:
+  superdesk-dev-mongo-data:
+  superdesk-dev-elastic-data:

--- a/scripts/dev/.gitignore
+++ b/scripts/dev/.gitignore
@@ -1,0 +1,2 @@
+# Runtime state written by up.sh / down.sh (pidfiles, log files).
+.run/

--- a/scripts/dev/down.sh
+++ b/scripts/dev/down.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# Tear down the local development stack started by up.sh: kill the grunt
+# server on :9000 and stop the docker compose backend.
+#
+# Usage:
+#   ./down.sh             # stop services (data preserved in named volumes)
+#   ./down.sh --volumes   # also drop named volumes (NUCLEAR: wipes DB state)
+#
+# Always exits 0 even if some pieces were already stopped. Idempotent.
+#
+# Note: stopping the compose stack does NOT stop Docker Desktop itself.
+# This script prints a reminder at the end — designers need to quit Docker
+# Desktop manually to fully free RAM/battery.
+
+set -euo pipefail
+
+VOLUMES=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --volumes) VOLUMES=true ;;
+        *) echo "unknown argument: $arg" >&2; exit 2 ;;
+    esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+COMPOSE_FILE="$REPO_ROOT/docker-compose.dev.yml"
+RUN_DIR="$SCRIPT_DIR/.run"
+GRUNT_PIDFILE="$RUN_DIR/grunt-server.pid"
+SETUP_SENTINEL="$RUN_DIR/.setup-done"
+
+log() { printf '\n[dev-down] %s\n' "$*"; }
+
+# 1. Grunt server. Prefer the pidfile; fall back to lsof on the port if the
+# pidfile is missing or stale (e.g. up.sh was started in another shell or
+# the pidfile got nuked).
+if [ -f "$GRUNT_PIDFILE" ]; then
+    grunt_pid="$(cat "$GRUNT_PIDFILE")"
+    if kill -0 "$grunt_pid" 2>/dev/null; then
+        log "stopping grunt server (pid: $grunt_pid)"
+        kill "$grunt_pid" 2>/dev/null || true
+        # grunt forks; clean up anything still on :9000 just in case.
+        sleep 1
+    else
+        log "grunt pidfile is stale; removing"
+    fi
+    rm -f "$GRUNT_PIDFILE"
+fi
+
+if command -v lsof > /dev/null; then
+    if pids=$(lsof -ti:9000 -sTCP:LISTEN 2>/dev/null); then
+        log "stopping leftover processes on :9000 (pids: $pids)"
+        kill $pids 2>/dev/null || true
+    fi
+fi
+
+# 2. Docker compose backend.
+if [ -f "$COMPOSE_FILE" ]; then
+    if [ "$VOLUMES" = true ]; then
+        log "docker compose down -v (volumes removed; DB state dropped)"
+        (cd "$REPO_ROOT" && docker compose -f "$COMPOSE_FILE" down -v)
+        # The DB is gone; the next setup.sh must re-run init.
+        rm -f "$SETUP_SENTINEL"
+    else
+        log "docker compose stop (data preserved in named volumes)"
+        (cd "$REPO_ROOT" && docker compose -f "$COMPOSE_FILE" stop)
+    fi
+else
+    log "$COMPOSE_FILE not found; nothing to stop"
+fi
+
+log "services stopped"
+log ""
+log "Docker Desktop is still running. To fully free RAM/battery, quit it"
+log "manually from the menu bar (Cmd-Q on the Docker icon)."

--- a/scripts/dev/extension-edit.py
+++ b/scripts/dev/extension-edit.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""
+Edit client/index.ts to enable or disable a standard-template extension.
+
+Operates inside the region delimited by:
+
+    // extensions:start (managed by scripts/dev/extension.sh — do not edit by hand)
+    ...
+    // extensions:end
+
+Standard template per entry:
+
+    {
+        id: 'NAME',
+        load: () => import('superdesk-core/scripts/extensions/NAME'),
+    },
+
+Custom-load entries (with .then / setCustomizations / multi-statement bodies)
+should live OUTSIDE the markers; this script refuses to disable them and
+prints a clear message instead.
+
+Invoked by scripts/dev/extension.sh; not meant to be called directly.
+
+Usage: extension-edit.py <enable|disable> <name> <path-to-index.ts>
+"""
+
+import re
+import sys
+
+
+def main():
+    if len(sys.argv) != 4:
+        print(__doc__, file=sys.stderr)
+        sys.exit(2)
+
+    mode, name, path = sys.argv[1], sys.argv[2], sys.argv[3]
+
+    if mode not in ("enable", "disable"):
+        print(f"ERROR: mode must be 'enable' or 'disable', got '{mode}'", file=sys.stderr)
+        sys.exit(2)
+
+    with open(path) as f:
+        lines = f.readlines()
+
+    start_idx = end_idx = None
+    for i, line in enumerate(lines):
+        if "// extensions:start" in line and start_idx is None:
+            start_idx = i
+        elif "// extensions:end" in line and start_idx is not None:
+            end_idx = i
+            break
+
+    if start_idx is None or end_idx is None:
+        print(
+            f"ERROR: extension markers not found in {path}.\n"
+            "Expected lines containing '// extensions:start' and '// extensions:end'.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Walk the lines between the markers, grouping into object entries.
+    # An entry starts on a line whose stripped content is '{' and ends on
+    # a line whose stripped content is '},'. Anything else (blank lines,
+    # comments) is treated as a passthrough chunk between entries.
+    region = lines[start_idx + 1 : end_idx]
+    entries = []  # list of (kind, value): kind is 'entry' (list of lines) or 'other' (single line)
+    current = None
+    for line in region:
+        stripped = line.strip()
+        if current is None:
+            if stripped == "{":
+                current = [line]
+            else:
+                entries.append(("other", line))
+        else:
+            current.append(line)
+            if stripped == "},":
+                entries.append(("entry", current))
+                current = None
+    if current is not None:
+        print(
+            f"ERROR: unclosed entry inside extension markers in {path}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    def entry_id(entry_lines):
+        for l in entry_lines:
+            m = re.search(r"id:\s*'([^']+)'", l)
+            if m:
+                return m.group(1)
+        return None
+
+    def is_standard_template(entry_lines):
+        body = "".join(entry_lines)
+        # Reject entries with custom-load shapes.
+        forbidden = (".then(", "setCustomizations", "async ", "function")
+        return not any(token in body for token in forbidden)
+
+    if mode == "enable":
+        for kind, value in entries:
+            if kind == "entry" and entry_id(value) == name:
+                print(f"INFO: '{name}' is already enabled — no change.", file=sys.stderr)
+                sys.exit(0)
+        # Build a fresh entry and insert before // extensions:end.
+        new_entry = [
+            "            {\n",
+            f"                id: '{name}',\n",
+            f"                load: () => import('superdesk-core/scripts/extensions/{name}'),\n",
+            "            },\n",
+        ]
+        new_lines = lines[:end_idx] + new_entry + lines[end_idx:]
+
+    else:  # disable
+        found = False
+        new_entries = []
+        for kind, value in entries:
+            if kind == "entry" and entry_id(value) == name:
+                if not is_standard_template(value):
+                    print(
+                        f"ERROR: '{name}' inside the managed region has a custom-load "
+                        f"shape (.then/setCustomizations/etc). Move it outside the "
+                        f"// extensions:start … // extensions:end markers and edit it "
+                        f"manually, then re-run this command.",
+                        file=sys.stderr,
+                    )
+                    sys.exit(1)
+                found = True
+                continue  # drop it
+            new_entries.append((kind, value))
+        if not found:
+            print(
+                f"INFO: '{name}' is not in the managed region — no change.\n"
+                f"  If it's enabled outside the markers (custom load), edit "
+                f"client/index.ts manually.",
+                file=sys.stderr,
+            )
+            sys.exit(0)
+        new_region_lines = []
+        for kind, value in new_entries:
+            if kind == "entry":
+                new_region_lines.extend(value)
+            else:
+                new_region_lines.append(value)
+        new_lines = lines[: start_idx + 1] + new_region_lines + lines[end_idx:]
+
+    with open(path, "w") as f:
+        f.writelines(new_lines)
+    print(f"OK: '{name}' {mode}d in {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dev/extension.sh
+++ b/scripts/dev/extension.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+#
+# Enable or disable an in-tree extension from superdesk-client-core.
+#
+# Usage:
+#   ./extension.sh list
+#   ./extension.sh enable  <name>
+#   ./extension.sh disable <name>
+#
+# This script edits the standard-template region of client/index.ts marked
+# by // extensions:start / // extensions:end. Entries outside that region
+# (planning-extension, broadcasting, anything with custom load logic) are
+# manually managed — not touched by this script.
+#
+# Grunt's watch will pick up the index.ts change automatically; no restart
+# is required if the dev stack is already running via ./up.sh.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+PARENT_DIR="$(cd "$REPO_ROOT/.." && pwd)"
+INDEX_FILE="$REPO_ROOT/client/index.ts"
+EDITOR_PY="$SCRIPT_DIR/extension-edit.py"
+EXTENSIONS_DIR="$PARENT_DIR/superdesk-client-core/scripts/extensions"
+
+# In-tree extensions that PR #5177 migrated to the source-build path. Adding
+# any of these via this script is safe.
+MIGRATED_EXTENSIONS=(
+    "ai-widget"
+    "annotationsLibrary"
+    "availability-manager"
+    "broadcasting"
+    "datetimeField"
+    "helloWorld"
+    "markForUser"
+    "predefinedTextField"
+    "sams"
+    "usageMetrics"
+    "videoEditor"
+)
+
+# Migrated extensions that need custom load logic (e.g. setCustomizations
+# call, .then chain). These live OUTSIDE the // extensions:start /
+# // extensions:end markers in client/index.ts because the script's editor
+# only handles the standard `{id, load: () => import(...)}` template. To
+# enable/disable any of these, edit client/index.ts directly.
+CUSTOM_LOAD_EXTENSIONS=(
+    "broadcasting"
+)
+
+# Still on the legacy compile-and-correct path. Linking these into a
+# dev-link setup breaks the build until they're migrated.
+LEGACY_EXTENSIONS=(
+    "auto-tagging-widget"
+)
+
+fail() { printf '\n[dev-extension] ERROR: %s\n' "$*" >&2; exit 1; }
+
+is_in_list() {
+    local needle="$1"; shift
+    for x in "$@"; do
+        [ "$x" = "$needle" ] && return 0
+    done
+    return 1
+}
+
+print_list() {
+    # Bucket the MIGRATED list: toggleable here vs. requires-manual-edit.
+    local toggleable=() custom=()
+    local m
+    for m in "${MIGRATED_EXTENSIONS[@]}"; do
+        if is_in_list "$m" "${CUSTOM_LOAD_EXTENSIONS[@]}"; then
+            custom+=("$m")
+        else
+            toggleable+=("$m")
+        fi
+    done
+
+    printf '\n[dev-extension] Toggleable via this script (enable/disable):\n'
+    for x in "${toggleable[@]}"; do printf '  - %s\n' "$x"; done
+
+    if [ "${#custom[@]}" -gt 0 ]; then
+        printf '\n[dev-extension] Migrated but require manual editing of client/index.ts\n'
+        printf '[dev-extension] (custom load logic — outside the // extensions:start markers):\n'
+        for x in "${custom[@]}"; do printf '  - %s\n' "$x"; done
+    fi
+
+    printf '\n[dev-extension] On legacy build path (do NOT enable yet):\n'
+    for x in "${LEGACY_EXTENSIONS[@]}"; do printf '  - %s\n' "$x"; done
+
+    printf '\n[dev-extension] Currently enabled in client/index.ts:\n'
+    # Use POSIX [[:space:]] (not \s) — BSD sed on macOS does not support \s.
+    grep -E "id:[[:space:]]*'[^']+'" "$INDEX_FILE" \
+        | sed -E "s/.*id:[[:space:]]*'([^']+)'.*/  - \1/"
+    printf '\n'
+}
+
+# ---- main ----
+
+[ $# -ge 1 ] || fail "usage: $0 <list|enable|disable> [name]"
+
+MODE="$1"
+
+[ -f "$INDEX_FILE" ] || fail "$INDEX_FILE not found — run from inside the superdesk/ host repo."
+
+case "$MODE" in
+    list)
+        print_list
+        exit 0
+        ;;
+    enable|disable) ;;
+    *) fail "mode must be 'list', 'enable', or 'disable' (got '$MODE')" ;;
+esac
+
+[ $# -ge 2 ] || fail "usage: $0 $MODE <name>"
+NAME="$2"
+
+# Sibling check: only required for enable (need to verify the dir exists in
+# client-core). For disable we don't need client-core present.
+if [ "$MODE" = "enable" ]; then
+    [ -d "$EXTENSIONS_DIR" ] || fail "$EXTENSIONS_DIR not found. Run ./setup.sh first."
+    [ -d "$EXTENSIONS_DIR/$NAME" ] || {
+        echo "[dev-extension] ERROR: '$NAME' is not an in-tree extension in $EXTENSIONS_DIR." >&2
+        print_list
+        exit 1
+    }
+fi
+
+if is_in_list "$NAME" "${CUSTOM_LOAD_EXTENSIONS[@]}"; then
+    cat >&2 <<EOF
+
+[dev-extension] '$NAME' has custom load logic in client/index.ts and lives
+[dev-extension] OUTSIDE the // extensions:start markers. This script only
+[dev-extension] manages standard-template entries.
+
+[dev-extension] To toggle '$NAME', edit client/index.ts directly — find
+[dev-extension] the entry above the markers and comment it out (to
+[dev-extension] disable) or restore it (to enable).
+
+EOF
+    exit 1
+fi
+
+if is_in_list "$NAME" "${LEGACY_EXTENSIONS[@]}"; then
+    cat >&2 <<EOF
+
+[dev-extension] ERROR: '$NAME' is on the legacy compile-and-correct build path.
+
+Linking it into a dev-link setup will produce recursive 'dist/superdesk/client/...'
+paths and a broken build (this is the exact class of problem PR #5177 fixed
+for the migrated extensions).
+
+This script refuses to enable it until the underlying migration lands. For
+now, do not enable '$NAME' via the dev skill — coordinate with a developer
+if you genuinely need it locally.
+
+EOF
+    exit 1
+fi
+
+# For enable, validate it's on the known-good list. For disable, allow any
+# name (the user might be cleaning up an entry that's no longer in the list).
+if [ "$MODE" = "enable" ] && ! is_in_list "$NAME" "${MIGRATED_EXTENSIONS[@]}"; then
+    echo "[dev-extension] ERROR: '$NAME' is not on the skill-managed list." >&2
+    echo "If it's a newly-migrated in-tree extension, add it to MIGRATED_EXTENSIONS in this script." >&2
+    exit 1
+fi
+
+command -v python3 > /dev/null || fail "python3 is required."
+
+python3 "$EDITOR_PY" "$MODE" "$NAME" "$INDEX_FILE"

--- a/scripts/dev/setup.sh
+++ b/scripts/dev/setup.sh
@@ -1,0 +1,282 @@
+#!/usr/bin/env bash
+#
+# Set up the local development environment for the first time (or after a
+# fresh clone). Installs client dependencies, links sibling repos that are
+# cloned alongside this one, brings up the backend services in Docker, and
+# initialises the database on first run.
+#
+# Expected layout: this repo (superdesk/) is cloned alongside its siblings
+# under a single parent directory, e.g.
+#
+#   ~/code/
+#     superdesk/                  <-- you are here
+#     superdesk-client-core/
+#     superdesk-planning/
+#     superdesk-analytics/        (optional)
+#     superdesk-publisher/        (optional)
+#
+# Usage:
+#   ./setup.sh                       # auto-discover all siblings
+#   ./setup.sh --only NAME[,NAME]    # link only these (exact directory names)
+#   ./setup.sh --skip NAME[,NAME]    # link all except these
+#   ./setup.sh --link /abs/path      # explicitly link a path (repeatable)
+#   ./setup.sh --reinit              # force first-run DB init even if already done
+#
+# Prerequisites (validated by this script):
+#   * Docker Desktop installed and running.
+#   * Volta installed (Node version is pinned via Volta).
+#   * Sibling repos cloned in the parent directory of this one.
+
+set -euo pipefail
+
+ONLY=""
+SKIP=""
+EXPLICIT_LINKS=()
+REINIT=false
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --only)    ONLY="$2"; shift 2 ;;
+        --skip)    SKIP="$2"; shift 2 ;;
+        --link)    EXPLICIT_LINKS+=("$2"); shift 2 ;;
+        --reinit)  REINIT=true; shift ;;
+        *) echo "unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+PARENT_DIR="$(cd "$REPO_ROOT/.." && pwd)"
+CLIENT_DIR="$REPO_ROOT/client"
+COMPOSE_FILE="$REPO_ROOT/docker-compose.dev.yml"
+RUN_DIR="$SCRIPT_DIR/.run"
+SETUP_SENTINEL="$RUN_DIR/.setup-done"
+
+# Resolve the host port the server binds to. Default 5000 (matches
+# upstream Superdesk). On macOS, auto-override to 5001 because :5000 is
+# reserved for AirPlay Receiver, which silently answers HTTP and would
+# mask a missing server. Explicit SUPERDESK_PORT in the environment
+# overrides both defaults.
+if [ -n "${SUPERDESK_PORT:-}" ]; then
+    SERVER_PORT="$SUPERDESK_PORT"
+elif [ "$(uname -s)" = "Darwin" ]; then
+    SERVER_PORT=5001
+else
+    SERVER_PORT=5000
+fi
+SERVER_URL="http://localhost:${SERVER_PORT}/api/"
+# Export so docker compose substitution sees them and any child process
+# (like grunt during up.sh) inherits the right URL — overriding any stale
+# value the user may have in their shell.
+export SUPERDESK_PORT="$SERVER_PORT"
+export SUPERDESK_URL="${SERVER_URL%/}"
+
+ADMIN_USER="admin"
+ADMIN_PASS="admin"
+ADMIN_EMAIL="admin@example.com"
+
+# Siblings the host links. The first two are REQUIRED — the host can't
+# run meaningfully without them. The rest are optional and skipped
+# silently if not cloned.
+REQUIRED_SIBLINGS=(
+    "superdesk-client-core"
+    "superdesk-planning"
+)
+OPTIONAL_SIBLINGS=(
+    "superdesk-analytics"
+    "superdesk-publisher"
+)
+KNOWN_SIBLINGS=("${REQUIRED_SIBLINGS[@]}" "${OPTIONAL_SIBLINGS[@]}")
+
+mkdir -p "$RUN_DIR"
+
+log()  { printf '\n[dev-setup] %s\n' "$*"; }
+fail() { printf '\n[dev-setup] ERROR: %s\n' "$*" >&2; exit 1; }
+
+server_reachable() {
+    # The dev server returns 200 on /api/ (root listing). 401/403 are also
+    # accepted in case server config tightens up later. Anything else
+    # (connection refused, 5xx, 404 — including macOS AirPlay's 200-but-
+    # not-superdesk) is "not up yet".
+    local status
+    status=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 2 "$1" 2>/dev/null) || return 1
+    case "$status" in
+        2??|401|403) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# Comma-separated list contains a value? (helper for --only / --skip).
+csv_contains() {
+    local csv="$1" needle="$2"
+    [ -z "$csv" ] && return 1
+    case ",$csv," in *",$needle,"*) return 0 ;; esac
+    return 1
+}
+
+# ---- Prerequisite checks ----
+
+[ -f "$COMPOSE_FILE" ] || fail "$COMPOSE_FILE not found — run this from inside the superdesk/ host repo."
+[ -d "$CLIENT_DIR" ]  || fail "$CLIENT_DIR not found — run this from inside the superdesk/ host repo."
+
+command -v docker > /dev/null || fail "Docker is not installed. Install Docker Desktop first."
+docker info > /dev/null 2>&1 || fail "Docker is installed but not running. Start Docker Desktop and try again."
+
+# Surface the port choice so the user knows where to expect the server.
+log "backend will publish on host port $SERVER_PORT (server URL: $SERVER_URL)"
+case "$SERVER_PORT" in
+    5001) log "  (auto-picked 5001 on macOS to avoid AirPlay Receiver on :5000)" ;;
+esac
+
+command -v volta > /dev/null || fail "Volta is not installed. See https://volta.sh — Node version is pinned through it."
+command -v curl  > /dev/null || fail "curl is not installed."
+
+# ---- Discover siblings ----
+
+log "discovering sibling repos under $PARENT_DIR"
+
+declare -a TO_LINK=()
+declare -a SUMMARY_FOUND=()
+declare -a SUMMARY_MISSING=()
+declare -a SUMMARY_SKIPPED=()
+
+for name in "${KNOWN_SIBLINGS[@]}"; do
+    path="$PARENT_DIR/$name"
+    if [ ! -d "$path" ]; then
+        SUMMARY_MISSING+=("$name")
+        continue
+    fi
+    if [ -n "$ONLY" ] && ! csv_contains "$ONLY" "$name"; then
+        SUMMARY_SKIPPED+=("$name (not in --only)")
+        continue
+    fi
+    if [ -n "$SKIP" ] && csv_contains "$SKIP" "$name"; then
+        SUMMARY_SKIPPED+=("$name (in --skip)")
+        continue
+    fi
+    TO_LINK+=("$path")
+    SUMMARY_FOUND+=("$name")
+done
+
+# Add explicit --link paths. Warn if they're outside the parent dir.
+for path in "${EXPLICIT_LINKS[@]+"${EXPLICIT_LINKS[@]}"}"; do
+    if [ ! -d "$path" ]; then
+        fail "--link path does not exist: $path"
+    fi
+    if [ ! -f "$path/package.json" ]; then
+        fail "--link path has no package.json: $path"
+    fi
+    abs_path="$(cd "$path" && pwd)"
+    if [ "$(dirname "$abs_path")" != "$PARENT_DIR" ]; then
+        log "WARNING: --link path is outside the sibling parent ($PARENT_DIR):"
+        log "  $abs_path"
+        log "Linking it anyway (you passed --link explicitly)."
+    fi
+    TO_LINK+=("$abs_path")
+    SUMMARY_FOUND+=("$(basename "$abs_path") (via --link)")
+done
+
+# Print the summary.
+log "link summary:"
+if [ "${#SUMMARY_FOUND[@]}" -gt 0 ]; then
+    printf '  found and will link:\n'
+    for s in "${SUMMARY_FOUND[@]}"; do printf '    - %s\n' "$s"; done
+fi
+if [ "${#SUMMARY_MISSING[@]}" -gt 0 ]; then
+    printf '  not present (skipped):\n'
+    for s in "${SUMMARY_MISSING[@]}"; do printf '    - %s\n' "$s"; done
+fi
+if [ "${#SUMMARY_SKIPPED[@]}" -gt 0 ]; then
+    printf '  excluded by flags:\n'
+    for s in "${SUMMARY_SKIPPED[@]}"; do printf '    - %s\n' "$s"; done
+fi
+
+# Refuse to proceed if any required sibling is not being linked. Without
+# them the host can't run meaningfully.
+missing_required=()
+for req in "${REQUIRED_SIBLINGS[@]}"; do
+    if ! printf '%s\n' "${TO_LINK[@]:-}" | grep -qE "/${req}\$"; then
+        missing_required+=("$req")
+    fi
+done
+
+if [ "${#missing_required[@]}" -gt 0 ]; then
+    cat >&2 <<EOF
+
+[dev-setup] ERROR: Required sibling repo(s) are missing.
+
+[dev-setup] These must be cloned as siblings of this repo (in
+[dev-setup] $PARENT_DIR/):
+
+EOF
+    for m in "${missing_required[@]}"; do
+        echo "[dev-setup]   - $m" >&2
+    done
+    cat >&2 <<EOF
+
+[dev-setup] To clone them, from $PARENT_DIR:
+
+EOF
+    for m in "${missing_required[@]}"; do
+        echo "[dev-setup]   git clone https://github.com/superdesk/$m.git" >&2
+    done
+    cat >&2 <<EOF
+
+[dev-setup] Then re-run this script.
+
+[dev-setup] If you intentionally excluded one via --skip, this script
+[dev-setup] refuses to proceed — both superdesk-client-core and
+[dev-setup] superdesk-planning are required.
+
+EOF
+    exit 1
+fi
+
+# ---- 1. Install host client deps ----
+
+log "installing client dependencies in $CLIENT_DIR (this is the slow step on a cold cache)"
+(cd "$CLIENT_DIR" && npm install)
+
+# ---- 2. dev-link sibling repos ----
+
+log "running dev-link against ${#TO_LINK[@]} sibling(s)"
+(cd "$CLIENT_DIR" && npm run devlink -- "${TO_LINK[@]}")
+
+# ---- 3. Bring up backend services ----
+
+log "starting backend services via docker compose"
+(cd "$REPO_ROOT" && docker compose -f "$COMPOSE_FILE" up -d)
+
+log "waiting for server at $SERVER_URL (cold start can take ~60s)"
+elapsed=0
+until server_reachable "$SERVER_URL"; do
+    if [ "$elapsed" -ge 300 ]; then
+        fail "server didn't come up within 5 minutes — check 'docker compose -f docker-compose.dev.yml logs superdesk-server'"
+    fi
+    sleep 3
+    elapsed=$((elapsed + 3))
+done
+log "server reachable at $SERVER_URL"
+
+# ---- 4. First-run DB init ----
+
+if [ "$REINIT" = true ] || [ ! -f "$SETUP_SENTINEL" ]; then
+    log "running first-run DB init (app:initialize_data + users:create admin/admin)"
+    (cd "$REPO_ROOT" && docker compose -f "$COMPOSE_FILE" exec -T superdesk-server \
+        python manage.py app:initialize_data) || fail "app:initialize_data failed — see compose logs"
+    (cd "$REPO_ROOT" && docker compose -f "$COMPOSE_FILE" exec -T superdesk-server \
+        python manage.py users:create -u "$ADMIN_USER" -p "$ADMIN_PASS" -e "$ADMIN_EMAIL" --admin) || true
+        # users:create returns non-zero if the user already exists; that's
+        # fine if --reinit was passed against an existing DB.
+    touch "$SETUP_SENTINEL"
+    log "DB initialised. Admin user: $ADMIN_USER / $ADMIN_PASS"
+else
+    log "DB already initialised (sentinel at $SETUP_SENTINEL); skipping init"
+    log "Pass --reinit to force re-running app:initialize_data + users:create."
+fi
+
+log "setup complete"
+log ""
+log "  backend running on $SERVER_URL"
+log "  start the client dev server with: ./scripts/dev/up.sh"
+log "  stop everything with:             ./scripts/dev/down.sh"

--- a/scripts/dev/setup.sh
+++ b/scripts/dev/setup.sh
@@ -94,10 +94,17 @@ log()  { printf '\n[dev-setup] %s\n' "$*"; }
 fail() { printf '\n[dev-setup] ERROR: %s\n' "$*" >&2; exit 1; }
 
 server_reachable() {
-    # The dev server returns 200 on /api/ (root listing). 401/403 are also
-    # accepted in case server config tightens up later. Anything else
-    # (connection refused, 5xx, 404 — including macOS AirPlay's 200-but-
-    # not-superdesk) is "not up yet".
+    # Any 2xx / 401 / 403 means "something is answering on this port that
+    # *looks like* a working HTTP service" — good enough as a readiness
+    # signal. Connection refused, timeouts, and 5xx are treated as "not
+    # up yet" and the wait-loop keeps polling.
+    #
+    # Caveat: this does NOT distinguish a real Superdesk server from
+    # another HTTP service that happens to answer on the same port (e.g.
+    # macOS AirPlay Receiver on :5000 returns 200). We accept that risk
+    # because the script's default port choice (5000 on Linux, 5001 on
+    # macOS) avoids the known collision; a user overriding
+    # SUPERDESK_PORT=5000 on macOS is explicitly opting in.
     local status
     status=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 2 "$1" 2>/dev/null) || return 1
     case "$status" in

--- a/scripts/dev/up.sh
+++ b/scripts/dev/up.sh
@@ -111,7 +111,7 @@ preflight_check_port() {
     local name="$2"
     if command -v lsof > /dev/null && lsof -ti:"$port" -sTCP:LISTEN > /dev/null 2>&1; then
         # Skip if our own stack already holds it.
-        if [ "$port" = "$SERVER_PORT" ] && docker compose -p superdesk-dev ps -q 2>/dev/null | grep -q .; then
+        if [ "$port" = "$SERVER_PORT" ] && docker compose -p superdesk-dev -f "$COMPOSE_FILE" ps -q 2>/dev/null | grep -q .; then
             return 0
         fi
         if [ "$port" = "9000" ] && [ -f "$GRUNT_PIDFILE" ] && kill -0 "$(cat "$GRUNT_PIDFILE")" 2>/dev/null; then

--- a/scripts/dev/up.sh
+++ b/scripts/dev/up.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+#
+# Bring up the local development stack: backend services in Docker, client
+# dev server (grunt watch) on the host. Mirrors the workflow B path from
+# DEVSETUP.md, with idempotence and health checks.
+#
+# Usage:
+#   ./up.sh                    # bring up the stack
+#   ./up.sh --rebuild-server   # force `docker compose build` for the server
+#
+# Exits 0 only when both the server (URL printed in the "ready" banner)
+# and the client (http://localhost:9000/) respond. Otherwise exits non-zero
+# with a clear error.
+#
+# Prerequisites (validate before calling this script — usually setup.sh):
+#   * Docker Desktop running.
+#   * Volta installed (Node version is pinned via package.json).
+#   * `npm install` has been run in ./client at least once.
+
+set -euo pipefail
+
+REBUILD_SERVER=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --rebuild-server) REBUILD_SERVER=true ;;
+        *) echo "unknown argument: $arg" >&2; exit 2 ;;
+    esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+CLIENT_DIR="$REPO_ROOT/client"
+COMPOSE_FILE="$REPO_ROOT/docker-compose.dev.yml"
+RUN_DIR="$SCRIPT_DIR/.run"
+GRUNT_PIDFILE="$RUN_DIR/grunt-server.pid"
+GRUNT_LOGFILE="$RUN_DIR/grunt-server.log"
+
+# Resolve the host port the server binds to. Same logic as setup.sh:
+# default 5000, macOS → 5001 (AirPlay), explicit SUPERDESK_PORT overrides.
+if [ -n "${SUPERDESK_PORT:-}" ]; then
+    SERVER_PORT="$SUPERDESK_PORT"
+elif [ "$(uname -s)" = "Darwin" ]; then
+    SERVER_PORT=5001
+else
+    SERVER_PORT=5000
+fi
+SERVER_URL="http://localhost:${SERVER_PORT}/api/"
+CLIENT_URL="http://localhost:9000/"
+
+# Export so docker compose substitution sees them and — critically — the
+# grunt subshell below inherits SUPERDESK_URL. The client's webpack.config
+# reads process.env.SUPERDESK_URL to know where the backend is; without
+# this export it falls back to its built-in default (or worse, picks up a
+# stale value from the user's shell rc).
+export SUPERDESK_PORT="$SERVER_PORT"
+export SUPERDESK_URL="${SERVER_URL%/}"
+
+mkdir -p "$RUN_DIR"
+
+log()  { printf '\n[dev-up] %s\n' "$*"; }
+fail() { printf '\n[dev-up] ERROR: %s\n' "$*" >&2; exit 1; }
+
+# Reachability helpers.
+#
+# - `reachable` accepts any HTTP response. Use for the grunt client server,
+#   which serves a real page on /.
+# - `server_reachable` accepts any 2xx, 401, or 403 — those all mean "a
+#   Superdesk server is answering". 5xx, connection refused, and 404 mean
+#   "not up yet". The dev server returns 200 on /api/ today; 401/403 are
+#   kept in the list in case auth config tightens.
+reachable() {
+    curl -sS --max-time 2 -o /dev/null "$1" 2>/dev/null
+}
+
+server_reachable() {
+    local status
+    status=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 2 "$1" 2>/dev/null) || return 1
+    case "$status" in
+        2??|401|403) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+wait_until_reachable() {
+    local url="$1"
+    local name="$2"
+    local check_fn="${3:-reachable}"
+    local timeout="${4:-240}"
+    local log_hint="${5:-}"
+    local elapsed=0
+
+    until "$check_fn" "$url"; do
+        if [ "$elapsed" -ge "$timeout" ]; then
+            local msg="$name not reachable at $url after ${timeout}s"
+            [ -n "$log_hint" ] && msg="$msg (check $log_hint)"
+            fail "$msg"
+        fi
+        sleep 2
+        elapsed=$((elapsed + 2))
+    done
+
+    log "$name reachable at $url"
+}
+
+# Preflight: warn (don't fail) if something else is on the published ports.
+# The dev stack uses bridge networking, so only the server port and
+# 9000 (client) live on the host.
+preflight_check_port() {
+    local port="$1"
+    local name="$2"
+    if command -v lsof > /dev/null && lsof -ti:"$port" -sTCP:LISTEN > /dev/null 2>&1; then
+        # Skip if our own stack already holds it.
+        if [ "$port" = "$SERVER_PORT" ] && docker compose -p superdesk-dev ps -q 2>/dev/null | grep -q .; then
+            return 0
+        fi
+        if [ "$port" = "9000" ] && [ -f "$GRUNT_PIDFILE" ] && kill -0 "$(cat "$GRUNT_PIDFILE")" 2>/dev/null; then
+            return 0
+        fi
+        local pids
+        pids=$(lsof -ti:"$port" -sTCP:LISTEN 2>/dev/null)
+        cat >&2 <<EOF
+
+[dev-up] WARNING: Something is already listening on port $port ($name).
+[dev-up] PIDs: $pids
+[dev-up] If this is another Superdesk stack (e.g. e2e), stop it first.
+[dev-up] Otherwise the conflict will block our $name.
+
+EOF
+        return 1
+    fi
+    return 0
+}
+
+# Sanity checks
+[ -f "$COMPOSE_FILE" ] || fail "$COMPOSE_FILE not found — are you in the superdesk/ host repo?"
+[ -d "$CLIENT_DIR" ]  || fail "$CLIENT_DIR not found — are you in the superdesk/ host repo?"
+[ -d "$CLIENT_DIR/node_modules" ] || fail "Run ./scripts/dev/setup.sh first — client deps aren't installed."
+
+log "backend port: $SERVER_PORT (server URL: $SERVER_URL)"
+case "$SERVER_PORT" in
+    5001) log "  (auto-picked 5001 on macOS to avoid AirPlay Receiver on :5000)" ;;
+esac
+
+# 1. Backend services (Docker)
+preflight_check_port "$SERVER_PORT" "superdesk server" || true
+
+if server_reachable "$SERVER_URL"; then
+    log "server already reachable; skipping docker bring-up"
+else
+    log "bringing up backend services via docker compose"
+    if [ "$REBUILD_SERVER" = true ]; then
+        (cd "$REPO_ROOT" && docker compose -f "$COMPOSE_FILE" build superdesk-server)
+    fi
+    (cd "$REPO_ROOT" && docker compose -f "$COMPOSE_FILE" up -d)
+    wait_until_reachable "$SERVER_URL" "server" server_reachable 240 \
+        "docker compose -f docker-compose.dev.yml logs superdesk-server"
+fi
+
+# 2. Client dev server (grunt, background)
+preflight_check_port 9000 "client dev server" || true
+
+if reachable "$CLIENT_URL"; then
+    log "client already reachable; skipping grunt server start"
+else
+    if [ -f "$GRUNT_PIDFILE" ] && kill -0 "$(cat "$GRUNT_PIDFILE")" 2>/dev/null; then
+        log "grunt pidfile is live but $CLIENT_URL isn't responding yet; waiting"
+    else
+        log "starting grunt server in the background (logs: $GRUNT_LOGFILE)"
+        log "  client will point at backend: $SUPERDESK_URL"
+        # nohup so the process survives this shell exiting; the pidfile
+        # makes it findable for down.sh regardless of who started it.
+        # SUPERDESK_URL is set explicitly here as well as exported — the
+        # explicit prefix documents the contract and guards against any
+        # weird env-inheritance edge case.
+        (cd "$CLIENT_DIR" && SUPERDESK_URL="$SUPERDESK_URL" nohup npm run start > "$GRUNT_LOGFILE" 2>&1 & echo $! > "$GRUNT_PIDFILE")
+    fi
+    # Grunt cold-build is the slow step (~60-120s). Long timeout, error
+    # points at the grunt log specifically.
+    wait_until_reachable "$CLIENT_URL" "client" reachable 300 "$GRUNT_LOGFILE"
+
+    # The PID stored above was the npm-wrapper subshell, which exits as
+    # soon as it forks grunt. Replace it with the actual listener PID so
+    # down.sh can find the right process.
+    if command -v lsof > /dev/null; then
+        if listener_pid=$(lsof -ti:9000 -sTCP:LISTEN 2>/dev/null | head -1); then
+            echo "$listener_pid" > "$GRUNT_PIDFILE"
+        fi
+    fi
+fi
+
+log "ready"
+log "  server: $SERVER_URL"
+log "  client: $CLIENT_URL  (login admin / admin)"
+log "  grunt log: $GRUNT_LOGFILE"
+log ""
+log "Edit files in your sibling checkouts (superdesk-client-core, superdesk-planning)"
+log "and grunt's watch will rebuild automatically. To stop: ./scripts/dev/down.sh"

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -64,7 +64,7 @@ botocore==1.37.3
     #   s3transfer
 cachetools==6.2.2
     # via flask-oidc-ex
-celery[redis]==5.5.3
+celery[redis]==5.6.2
     # via
     #   celery-redbeat
     #   superdesk-core
@@ -188,7 +188,7 @@ jwcrypto==1.5.6
     # via
     #   flask-oidc-ex
     #   python-jwt
-kombu[redis]==5.5.4
+kombu[redis]==5.6.2
     # via
     #   celery
     #   superdesk-core


### PR DESCRIPTION
### Purpose

Setting up Superdesk locally for client and extension work is currently a multi-step, error-prone process. You have to clone the right sibling repos in the right place, install dependencies across multiple `package.json`s, start the Docker stack, initialise the database, create an admin user, link the local checkouts into the host, and only then start the client dev server. Each step has its own failure modes (wrong Node version, port conflicts, stale `node_modules`, etc.).

New contributors lose time on this every time. Even experienced developers trip up when something drifts. This PR collapses the whole flow into a single command, and adds optional Claude Code integration so non-CLI users can just say "set up Superdesk" and have an agent drive it.

### What has changed

**Four scripts under `scripts/dev/`** that wrap the lifecycle:

- `setup.sh` — first-time install. Validates prerequisites (Docker running, Volta installed, sibling repos in place), links the local checkouts of `superdesk-client-core` and `superdesk-planning`, brings up the backend, creates the admin user. Re-runs are idempotent and fast.
- `up.sh` — start the stack day-to-day. Backend in Docker, client running natively on the host with grunt watch so edits to sibling checkouts auto-reload the browser.
- `down.sh` — stop everything. Data persists between sessions; a `--volumes` flag is provided for full reset.
- `extension.sh` — list, enable, or disable in-tree extensions (helloWorld, datetimeField, etc.) without manual edits to `client/index.ts`.

**`docker-compose.dev.yml`** — a new compose file alongside the existing one. Runs only the backend services (Python server, MongoDB, Redis, Elasticsearch); the client runs natively on the host for fast iteration. The existing fully-containerised `docker-compose.yml` is unchanged and remains the right choice if you just want to see Superdesk running without editing it.

**Claude Code integration** (`.claude/`):

- Slash commands (`/superdesk-setup`, `/superdesk-up`, `/superdesk-down`, `/superdesk-ext`) for explicit invocation.
- A natural-language skill that catches plain-language phrasings like "start Superdesk" or "enable the helloWorld extension" and confirms intent before running anything destructive.
- A narrow allowlist of pre-approved commands so users aren't prompted to approve each Bash call one by one.

**Documentation**: `DEVSETUP.md` rewritten with a Prerequisites section, a first-run validation checklist, and a troubleshooting section. `README.md` gains a "Local development" section pointing at either the slash commands or the scripts directly.

### How it works

After cloning the required sibling repos next to this one (`superdesk-client-core` and `superdesk-planning` are mandatory; analytics and publisher are optional), the user runs `./scripts/dev/setup.sh` once. The script handles installation, linking, Docker bring-up, and first-run database init. From then on, `up.sh` and `down.sh` start and stop the stack as needed. The app is at `http://localhost:9000`, login `admin` / `admin`.

The backend host port defaults to 5000, with automatic fallback to 5001 on macOS where port 5000 is reserved for AirPlay Receiver. Both can be overridden with `SUPERDESK_PORT=<port>`.

For Claude Code users, the same flow is accessible through `/superdesk-setup`, `/superdesk-up`, `/superdesk-down`, `/superdesk-ext list|enable|disable`, or plain language ("start the dev environment", "enable helloWorld"). The agent confirms intent before any destructive operation.

### Steps to test

1. Clone `superdesk-client-core` and `superdesk-planning` next to this repo (same parent directory).
2. Have Docker Desktop running and Volta installed.
3. Open Claude Code in this repo and run `/superdesk-setup` (or just ask Claude in plain language: "set up the dev environment"). First run is slow — image pulls, `npm install`, DB init — re-runs are fast.
4. Open `http://localhost:9000` and log in with `admin` / `admin`. The monitoring view should load.
5. Make a visible change in a file under `superdesk-client-core/scripts/...`. The browser should reload within a few seconds and reflect the change.
6. Run `/superdesk-ext list` to see what's available, then `/superdesk-ext enable helloWorld`. After grunt picks up the change, the extension's UI should appear.
7. Run `/superdesk-down`. The agent should remind you to quit Docker Desktop manually.
8. Run `/superdesk-up`. Your data and admin user should still be there.

**Without Claude Code:** every step above maps 1:1 to a shell script — `./scripts/dev/setup.sh`, `./scripts/dev/up.sh`, `./scripts/dev/down.sh`, `./scripts/dev/extension.sh list|enable|disable`. Invoke them directly and the behaviour is identical. The Claude integration is a thin convenience layer; the scripts are the source of truth.

Resolves: [SDESK-7925]

[SDESK-7925]: https://sofab.atlassian.net/browse/SDESK-7925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ