### PR TITLE
Bump superdesk-core to pick up sass-loader 16 migration

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -950,17 +950,16 @@
             }
         },
         "node_modules/@parcel/watcher": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
-            "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.6.0.tgz",
+            "integrity": "sha512-7FNeNl8NCE7aINx7WXiKQrPYZWC/hvrTsmk6zmxbI7LTXE7hVek/n8AfVgpe2y82zl3w0HvCHN0bVKMBoJcC0w==",
             "hasInstallScript": true,
-            "license": "MIT",
             "optional": true,
             "dependencies": {
                 "detect-libc": "^2.0.3",
                 "is-glob": "^4.0.3",
                 "node-addon-api": "^7.0.0",
-                "picomatch": "^4.0.3"
+                "picomatch": "^4.0.4"
             },
             "engines": {
                 "node": ">= 10.0.0"
@@ -970,29 +969,27 @@
                 "url": "https://opencollective.com/parcel"
             },
             "optionalDependencies": {
-                "@parcel/watcher-android-arm64": "2.5.6",
-                "@parcel/watcher-darwin-arm64": "2.5.6",
-                "@parcel/watcher-darwin-x64": "2.5.6",
-                "@parcel/watcher-freebsd-x64": "2.5.6",
-                "@parcel/watcher-linux-arm-glibc": "2.5.6",
-                "@parcel/watcher-linux-arm-musl": "2.5.6",
-                "@parcel/watcher-linux-arm64-glibc": "2.5.6",
-                "@parcel/watcher-linux-arm64-musl": "2.5.6",
-                "@parcel/watcher-linux-x64-glibc": "2.5.6",
-                "@parcel/watcher-linux-x64-musl": "2.5.6",
-                "@parcel/watcher-win32-arm64": "2.5.6",
-                "@parcel/watcher-win32-ia32": "2.5.6",
-                "@parcel/watcher-win32-x64": "2.5.6"
+                "@parcel/watcher-android-arm64": "2.6.0",
+                "@parcel/watcher-darwin-arm64": "2.6.0",
+                "@parcel/watcher-darwin-x64": "2.6.0",
+                "@parcel/watcher-freebsd-x64": "2.6.0",
+                "@parcel/watcher-linux-arm-glibc": "2.6.0",
+                "@parcel/watcher-linux-arm-musl": "2.6.0",
+                "@parcel/watcher-linux-arm64-glibc": "2.6.0",
+                "@parcel/watcher-linux-arm64-musl": "2.6.0",
+                "@parcel/watcher-linux-x64-glibc": "2.6.0",
+                "@parcel/watcher-linux-x64-musl": "2.6.0",
+                "@parcel/watcher-win32-arm64": "2.6.0",
+                "@parcel/watcher-win32-x64": "2.6.0"
             }
         },
         "node_modules/@parcel/watcher-android-arm64": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
-            "integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.6.0.tgz",
+            "integrity": "sha512-trgpLSCKRC/huFjXX/Smh+0sWe4+YtKfktIToiMl59ghz7z+qkH6kMvNnUbLyRs9N11t8l4svSCs1+5B3rOAhA==",
             "cpu": [
                 "arm64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "android"
@@ -1006,13 +1003,12 @@
             }
         },
         "node_modules/@parcel/watcher-darwin-arm64": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
-            "integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.6.0.tgz",
+            "integrity": "sha512-Y3QV0gl7Q1zbfueunkWIERICbEojQFCgpyG7YqOGNFLsckXyI1xu9mAIUpKY9QBYzBtSkN8dBPwd3yiAO9ovMw==",
             "cpu": [
                 "arm64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
@@ -1026,13 +1022,12 @@
             }
         },
         "node_modules/@parcel/watcher-darwin-x64": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
-            "integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.6.0.tgz",
+            "integrity": "sha512-Ohv6OpzhUfKYD7Beb8kDvG0jbIxORCYY1JRdZnaBtnjjkJxgD7ZVL0nw2sCYd0yTMKTvz3nnTnOF3cDifK+kvw==",
             "cpu": [
                 "x64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
@@ -1046,13 +1041,12 @@
             }
         },
         "node_modules/@parcel/watcher-freebsd-x64": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
-            "integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.6.0.tgz",
+            "integrity": "sha512-5HmXvDgs8VK+74jF9y9/2FE3/OnlcKmc56tjmSrEuZjpSZOGL+fvAu+HKJBdPs9uwoP2hE6TlSUpXZ/C5jUFmQ==",
             "cpu": [
                 "x64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "freebsd"
@@ -1066,13 +1060,12 @@
             }
         },
         "node_modules/@parcel/watcher-linux-arm-glibc": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
-            "integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.6.0.tgz",
+            "integrity": "sha512-Ps/hui3A+vMbjdqlqAowK2ZL8+BO8dBjxeWXj6npTBs3jx4wWmbPpaLuqwrQrSqIVMCnpWo238bJ1U37GhQOYg==",
             "cpu": [
                 "arm"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -1086,13 +1079,12 @@
             }
         },
         "node_modules/@parcel/watcher-linux-arm-musl": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
-            "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.6.0.tgz",
+            "integrity": "sha512-9c6AUHgHoG+IY88MRIHupztQiQnrbqHYQjkM2btA+Bf/wQnQMuiD0Wfk1EVv3TlNT3x41uU71rn6E4xh/+zvkw==",
             "cpu": [
                 "arm"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -1106,13 +1098,12 @@
             }
         },
         "node_modules/@parcel/watcher-linux-arm64-glibc": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
-            "integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.6.0.tgz",
+            "integrity": "sha512-yHRqS2owEXe6Hic9z6Mh1ECsCd+ODVOGvZDyciqRd21+v+o+DnXMOrw50DSpIG2sb8GPEaPPmfeCAWKPJdq46g==",
             "cpu": [
                 "arm64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -1126,13 +1117,12 @@
             }
         },
         "node_modules/@parcel/watcher-linux-arm64-musl": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
-            "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.6.0.tgz",
+            "integrity": "sha512-WhB2e/V7rqdHHWZusBSPuy5Ei8S6lSz6FE5TKKQz5h3a0O+C+mhY7vxU9b/stqvMb8beLnPY82ZrFTLKs+SrKA==",
             "cpu": [
                 "arm64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -1146,13 +1136,12 @@
             }
         },
         "node_modules/@parcel/watcher-linux-x64-glibc": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
-            "integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.6.0.tgz",
+            "integrity": "sha512-ulGE6x6Oz6iAwg75T8YQSoguBWasniIbX+QWpaYPcCnDOpdWX3k+4xbEYPZVLxOuoJI+svJJPD3sEj8G7lrQ3A==",
             "cpu": [
                 "x64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -1166,13 +1155,12 @@
             }
         },
         "node_modules/@parcel/watcher-linux-x64-musl": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
-            "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.6.0.tgz",
+            "integrity": "sha512-tkBYKt7YQrjIJWYDnto2YgO8MRkjlMTSNoRHzsXinBqbLdeOM3L32wPZJvIZxqaLMfSlS/4sUjH/6STVP/XDLw==",
             "cpu": [
                 "x64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -1186,33 +1174,12 @@
             }
         },
         "node_modules/@parcel/watcher-win32-arm64": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
-            "integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.6.0.tgz",
+            "integrity": "sha512-gIZAP23jaHjGWasY/TY6yL7NHFClf0Ga7FN+iINvk+KN94rhm94lYZhFsbYFNcA04/onvGD9kKmiJLJB2HbNwQ==",
             "cpu": [
                 "arm64"
             ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">= 10.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/@parcel/watcher-win32-ia32": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
-            "integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
-            "cpu": [
-                "ia32"
-            ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
@@ -1226,13 +1193,12 @@
             }
         },
         "node_modules/@parcel/watcher-win32-x64": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
-            "integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.6.0.tgz",
+            "integrity": "sha512-cA+/pXV2YkfxlIcXOQ5fSWqAzzPyD78/x5qbK/I0vUkrlYHA8TIz+MXjAbGouguKVSI4bOmkTSJ1/poVSsgt+A==",
             "cpu": [
                 "x64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
@@ -1246,10 +1212,9 @@
             }
         },
         "node_modules/@parcel/watcher/node_modules/picomatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-            "license": "MIT",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
             "optional": true,
             "engines": {
                 "node": ">=12"
@@ -3684,15 +3649,14 @@
             }
         },
         "node_modules/chokidar": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-            "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-            "license": "MIT",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+            "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
             "dependencies": {
-                "readdirp": "^4.0.1"
+                "readdirp": "^5.0.0"
             },
             "engines": {
-                "node": ">= 14.16.0"
+                "node": ">= 20.19.0"
             },
             "funding": {
                 "url": "https://paulmillr.com/funding/"
@@ -4573,7 +4537,6 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
             "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-            "license": "Apache-2.0",
             "optional": true,
             "engines": {
                 "node": ">=8"
@@ -8704,15 +8667,6 @@
                 "graceful-fs": "^4.1.11"
             }
         },
-        "node_modules/klona": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.6.tgz",
-            "integrity": "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 8"
-            }
-        },
         "node_modules/launch-editor": {
             "version": "2.14.1",
             "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.14.1.tgz",
@@ -9453,7 +9407,6 @@
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
             "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-            "license": "MIT",
             "optional": true
         },
         "node_modules/node-exports-info": {
@@ -11307,12 +11260,11 @@
             }
         },
         "node_modules/readdirp": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-            "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-            "license": "MIT",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+            "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
             "engines": {
-                "node": ">= 14.18.0"
+                "node": ">= 20.19.0"
             },
             "funding": {
                 "type": "individual",
@@ -11851,67 +11803,28 @@
             "license": "MIT"
         },
         "node_modules/sass": {
-            "version": "1.97.3",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.97.3.tgz",
-            "integrity": "sha512-fDz1zJpd5GycprAbu4Q2PV/RprsRtKC/0z82z0JLgdytmcq0+ujJbJ/09bPGDxCLkKY3Np5cRAOcWiVkLXJURg==",
-            "license": "MIT",
+            "version": "1.101.7",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.101.7.tgz",
+            "integrity": "sha512-cDeUYU0dhwKVbpYg/ppsjyuoddxYhWlJOkRoI7+/iZsaSp7iowWDfm+tL2HcUafedWBDvbf/+hx0QRgKG4JSHA==",
             "dependencies": {
-                "chokidar": "^4.0.0",
-                "immutable": "^5.0.2",
+                "chokidar": "^5.0.0",
+                "immutable": "^5.1.5",
                 "source-map-js": ">=0.6.2 <2.0.0"
             },
             "bin": {
                 "sass": "sass.js"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=20.19.0"
             },
             "optionalDependencies": {
                 "@parcel/watcher": "^2.4.1"
             }
         },
-        "node_modules/sass-loader": {
-            "version": "10.5.2",
-            "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-10.5.2.tgz",
-            "integrity": "sha512-vMUoSNOUKJILHpcNCCyD23X34gve1TS7Rjd9uXHeKqhvBG39x6XbswFDtpbTElj6XdMFezoWhkh5vtKudf2cgQ==",
-            "license": "MIT",
-            "dependencies": {
-                "klona": "^2.0.4",
-                "loader-utils": "^2.0.0",
-                "neo-async": "^2.6.2",
-                "schema-utils": "^3.0.0",
-                "semver": "^7.3.2"
-            },
-            "engines": {
-                "node": ">= 10.13.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            },
-            "peerDependencies": {
-                "fibers": ">= 3.1.0",
-                "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
-                "sass": "^1.3.0",
-                "webpack": "^4.36.0 || ^5.0.0"
-            },
-            "peerDependenciesMeta": {
-                "fibers": {
-                    "optional": true
-                },
-                "node-sass": {
-                    "optional": true
-                },
-                "sass": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/sass/node_modules/immutable": {
-            "version": "5.1.4",
-            "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.4.tgz",
-            "integrity": "sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==",
-            "license": "MIT"
+            "version": "5.1.9",
+            "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+            "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg=="
         },
         "node_modules/scheduler": {
             "version": "0.19.1",
@@ -12690,8 +12603,7 @@
         },
         "node_modules/superdesk-core": {
             "version": "3.5.0-dev",
-            "resolved": "git+ssh://git@github.com/superdesk/superdesk-client-core.git#1f277ab62e07d0fa10a82a47196fa2e167da6b0b",
-            "integrity": "sha512-+y3q/i3IryjTCjF1TmftUifOK4xsSPUXDEsnnqPrNaXdE8t4LNYM260d7w/MENWpzohsdNOrl7kA2uJNrAacJg==",
+            "resolved": "git+ssh://git@github.com/superdesk/superdesk-client-core.git#dd5a44fa397824d01a78ddba402f562159031aab",
             "hasInstallScript": true,
             "license": "AGPL-3.0",
             "dependencies": {
@@ -12789,7 +12701,7 @@
                 "redux-logger": "^3.0.6",
                 "redux-thunk": "^2.3.0",
                 "sass": "^1.97.2",
-                "sass-loader": "^10.5.2",
+                "sass-loader": "^16.0.8",
                 "shallow-equal": "^3.1.0",
                 "shortid": "2.2.8",
                 "superdesk-ui-framework": "7.0.0-dev1",
@@ -12872,6 +12784,45 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/rangy/-/rangy-1.3.0.tgz",
             "integrity": "sha512-hcN1Oo5xO7UDLU81aCnO9BEv4Dss6JmxPyrQSFQ16fVL1opbfTRtVpC6GVcGyk1CNvMYoZkrD4g92DGaScABzw=="
+        },
+        "node_modules/superdesk-core/node_modules/sass-loader": {
+            "version": "16.0.8",
+            "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-16.0.8.tgz",
+            "integrity": "sha512-hcov4ZwZJIGbEuyNr9EmiTmZueyrxSToE6GOzoZnq5JM7ecRO7ttyvilPn+VmRsqiP16+VYZzVnGZj/hzZgKBA==",
+            "dependencies": {
+                "neo-async": "^2.6.2"
+            },
+            "engines": {
+                "node": ">= 18.12.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            },
+            "peerDependencies": {
+                "@rspack/core": "0.x || ^1.0.0 || ^2.0.0-0",
+                "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
+                "sass": "^1.3.0",
+                "sass-embedded": "*",
+                "webpack": "^5.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@rspack/core": {
+                    "optional": true
+                },
+                "node-sass": {
+                    "optional": true
+                },
+                "sass": {
+                    "optional": true
+                },
+                "sass-embedded": {
+                    "optional": true
+                },
+                "webpack": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/superdesk-core/node_modules/typescript": {
             "version": "4.9.5",


### PR DESCRIPTION
Regenerates `client/package-lock.json` against the latest `superdesk-client-core` `develop`, which includes the sass-loader 16 migration (superdesk/superdesk-client-core#5260) and the nested-install fix (superdesk/superdesk-client-core#5265). Supersedes dependabot #4232.