### PR TITLE
[SDESK-8005] Bump superdesk-core and superdesk-planning to current develop in /client

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -14622,7 +14622,8 @@
         },
         "node_modules/superdesk-core": {
             "version": "3.5.0-dev",
-            "resolved": "git+ssh://git@github.com/superdesk/superdesk-client-core.git#7b3c1e13e60e2a535661c2d4921b0ab9896b58d3",
+            "resolved": "git+ssh://git@github.com/superdesk/superdesk-client-core.git#173928f1977ec1566dbe4141d71f2a644938fd8a",
+            "integrity": "sha512-M9U5FhRKlrjH4qpfWHkcGUoXiXkNqlr6bRvd7ld5NYtAuEcPICszPJ5wznrOZ1W+FYky3Quj8NcO51H1eJQYjA==",
             "hasInstallScript": true,
             "license": "AGPL-3.0",
             "dependencies": {
@@ -14926,7 +14927,8 @@
         },
         "node_modules/superdesk-planning": {
             "version": "3.5.0-dev",
-            "resolved": "git+ssh://git@github.com/superdesk/superdesk-planning.git#d5890a6a7e2b9ab6d479e4dcd826fdf5842cb4dc",
+            "resolved": "git+ssh://git@github.com/superdesk/superdesk-planning.git#03c54fc363885b591a57da8153fa2b773434be91",
+            "integrity": "sha512-0xZ8iLRBsRa4QqfxcujdbeuZM4hlCodzOaSANuOwc6fFCbmIle+L/ZsqNcCm6hTU3Uv7MIha21LLsS2Ov3HyFg==",
             "license": "AGPL-3.0",
             "dependencies": {
                 "@sourcefabric/common": "0.0.69",


### PR DESCRIPTION
- Bumps `superdesk-core` to `173928f` and `superdesk-planning` to `03c54fc` (current develop heads) in `client/package-lock.json`.
- Manual bump instead of Dependabot: Dependabot's regenerated lock drops the nested `@swc/helpers` peer entry (needed since the swc-loader change in SDESK-8005) and `npm ci` then fails the `client / install` job. This supersedes #4251 and #4252.
- Lock regenerated locally with a targeted `npm install --package-lock-only --ignore-scripts`; `npm ci --dry-run` passes against it.