### PR TITLE
Bump superdesk-analytics and superdesk-planning in the client lockfile

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -14116,7 +14116,7 @@
         },
         "node_modules/superdesk-analytics": {
             "version": "3.2.0-dev.0",
-            "resolved": "git+ssh://git@github.com/superdesk/superdesk-analytics.git#526f5cd71f59cc47f676b545e29563a08b9d902c",
+            "resolved": "git+ssh://git@github.com/superdesk/superdesk-analytics.git#901934a2a6eeb3c28766055fcbd15b8a67ca8dee",
             "license": "AGPL-3.0",
             "dependencies": {
                 "highcharts": "^6.2.0",
@@ -14335,9 +14335,8 @@
             }
         },
         "node_modules/superdesk-planning": {
-            "version": "3.3.0",
-            "resolved": "git+ssh://git@github.com/superdesk/superdesk-planning.git#6852316e8f0c2b6b82b565d523d32a017be88cc0",
-            "integrity": "sha512-Iotl3gk7qCEDgRMPHQXB/x9nZje0ltQGVFtHvR2IEMd0WpKlbA6o3GkQTuNjNFfpS0j0iObaeqP3vp5eIR9MXw==",
+            "version": "3.5.0-dev",
+            "resolved": "git+ssh://git@github.com/superdesk/superdesk-planning.git#cd838fa826d92735e8101016c24b1013f0ad03aa",
             "license": "AGPL-3.0",
             "dependencies": {
                 "@sourcefabric/common": "0.0.69",


### PR DESCRIPTION
## Problem

The `sd-cl-ext` build fails in `webpack-build`:

```
ERROR in ./node_modules/superdesk-analytics/client/styles/analytics.scss
Module build failed (from ./node_modules/sass-loader/dist/cjs.js):
Can't find stylesheet to import.
  ╷
4 │ @import '~mixins.scss';
  │         ^^^^^^^^^^^^^^
```

`superdesk-client-core`'s SDESK-8005 moved the build to `sass-loader` 16 with `api: 'modern-compiler'` and `sass-embedded`. That combination no longer resolves the webpack-specific `~` import prefix — imports resolve through `sassOptions.loadPaths` instead. Core stripped `~` from its own stylesheets in that change (131 import lines across 67 files), and both satellite apps did the same on `develop`.

The lockfile still pinned commits from before those fixes:

| Package | Pinned | Contains the fix? |
|---|---|---|
| superdesk-analytics | `526f5cd` (2026-01-20) | no — fixed in `ea53b1b`, 2026-06-25 |
| superdesk-planning | `6852316` | no — ~50 `~` imports across 25 stylesheets |

Analytics is the one that fails first; planning would have failed immediately after.

## Change

Re-resolves both to `develop`:

- `superdesk-analytics` → `901934a`
- `superdesk-planning` → `cd838fa`

Lockfile only, no `package.json` change — both were already specified as `#develop`, so this just moves the pins to what that spec resolves to today.

## Note

`superdesk-planning` moves `3.3.0` → `3.5.0-dev`, which is a larger jump than the stylesheet fix alone requires. It is unavoidable here, since only `develop` carries the `~` strip, but it is the most likely source of any new breakage in this build.

## Testing

Not built end to end. The lockfile was regenerated with `npm install --package-lock-only` and the resulting pins verified to contain the `~`-strip commits.